### PR TITLE
rclcpp 0.4.0 changes

### DIFF
--- a/ros_controllers/include/ros_controllers/joint_trajectory_controller.hpp
+++ b/ros_controllers/include/ros_controllers/joint_trajectory_controller.hpp
@@ -84,7 +84,7 @@ private:
 
   // TODO(karsten1987): eventually activate and deactive subscriber directly when its supported
   bool subscriber_is_active_ = false;
-  rclcpp::subscription::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr
+  rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr
     joint_command_subscriber_ = nullptr;
 
   TrajectoryPointConstIter prev_traj_point_ptr_;

--- a/ros_controllers/include/ros_controllers/trajectory.hpp
+++ b/ros_controllers/include/ros_controllers/trajectory.hpp
@@ -28,9 +28,9 @@ namespace ros_controllers
 {
 
 using TrajectoryPointIter =
-    std::vector<trajectory_msgs::msg::JointTrajectoryPoint>::iterator;
+  std::vector<trajectory_msgs::msg::JointTrajectoryPoint>::iterator;
 using TrajectoryPointConstIter =
-    std::vector<trajectory_msgs::msg::JointTrajectoryPoint>::const_iterator;
+  std::vector<trajectory_msgs::msg::JointTrajectoryPoint>::const_iterator;
 
 class Trajectory
 {

--- a/ros_controllers/src/joint_state_controller.cpp
+++ b/ros_controllers/src/joint_state_controller.cpp
@@ -72,7 +72,7 @@ JointStateController::update()
     return hardware_interface::HW_RET_ERROR;
   }
 
-  joint_state_msg_->header.stamp = rclcpp::Time::now();
+  joint_state_msg_->header.stamp = rclcpp::Clock().now();
   size_t i = 0;
   for (auto joint_state_handle : registered_joint_handles_) {
     joint_state_msg_->position[i] = joint_state_handle->get_position();
@@ -88,7 +88,7 @@ JointStateController::update()
 
 }  // namespace ros_controllers
 
-#include "class_loader/class_loader_register_macro.h"
+#include "class_loader/register_macro.hpp"
 
 CLASS_LOADER_REGISTER_CLASS(
   ros_controllers::JointStateController, controller_interface::ControllerInterface)

--- a/ros_controllers/src/joint_trajectory_controller.cpp
+++ b/ros_controllers/src/joint_trajectory_controller.cpp
@@ -199,7 +199,7 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
   // subscriber call back
   // non realtime
   // TODO(karsten): check if traj msg and point time are valid
-  auto callback = [this](const typename trajectory_msgs::msg::JointTrajectory::SharedPtr msg)
+  auto callback = [this](const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> msg)
     -> void
     {
       if (registered_joint_cmd_handles_.size() != msg->joint_names.size()) {
@@ -330,7 +330,7 @@ JointTrajectoryController::update()
   }
 
   // find next new point for current timestamp
-  auto traj_point_ptr = (*traj_point_active_ptr_)->sample(rclcpp::Time::now());
+  auto traj_point_ptr = (*traj_point_active_ptr_)->sample(rclcpp::Clock().now());
   // find next new point for current timestamp
   // set cmd only if a point is found
   if (traj_point_ptr == (*traj_point_active_ptr_)->end()) {
@@ -374,7 +374,7 @@ JointTrajectoryController::halt()
 
 }  // namespace ros_controllers
 
-#include "class_loader/class_loader_register_macro.h"
+#include "class_loader/register_macro.hpp"
 
 CLASS_LOADER_REGISTER_CLASS(
   ros_controllers::JointTrajectoryController, controller_interface::ControllerInterface)

--- a/ros_controllers/src/joint_trajectory_controller.cpp
+++ b/ros_controllers/src/joint_trajectory_controller.cpp
@@ -40,7 +40,7 @@ namespace
 
 rcl_lifecycle_transition_key_t
 fetch_parameters_from_parameter_server(
-  std::shared_ptr<rclcpp::parameter_client::AsyncParametersClient> parameters_client,
+  std::shared_ptr<rclcpp::AsyncParametersClient> parameters_client,
   const std::string parameter_key,
   std::vector<std::string> & parameters)
 {

--- a/ros_controllers/src/trajectory.cpp
+++ b/ros_controllers/src/trajectory.cpp
@@ -19,6 +19,8 @@
 #include "hardware_interface/macros.hpp"
 #include "hardware_interface/utils/time_utils.hpp"
 
+#include "rclcpp/clock.hpp"
+
 namespace ros_controllers
 {
 
@@ -35,7 +37,7 @@ Trajectory::Trajectory()
 Trajectory::Trajectory(std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory)
 : trajectory_msg_(joint_trajectory),
   trajectory_start_time_(time_is_zero(joint_trajectory->header.stamp) ?
-    rclcpp::Time::now() :
+    rclcpp::Clock().now() :
     static_cast<rclcpp::Time>(joint_trajectory->header.stamp))
 {}
 
@@ -44,7 +46,7 @@ Trajectory::update(std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_
 {
   trajectory_msg_ = joint_trajectory;
   trajectory_start_time_ = (time_is_zero(joint_trajectory->header.stamp) ?
-    rclcpp::Time::now() :
+    rclcpp::Clock().now() :
     static_cast<rclcpp::Time>(joint_trajectory->header.stamp));
 }
 

--- a/ros_controllers/test/test_trajectory.cpp
+++ b/ros_controllers/test/test_trajectory.cpp
@@ -19,6 +19,8 @@
 
 #include "gtest/gtest.h"
 
+#include "rclcpp/clock.hpp"
+
 #include "ros_controllers/trajectory.hpp"
 
 using namespace std::chrono_literals;
@@ -38,18 +40,18 @@ TEST_F(TestTrajectory, initialize_trajectory) {
     empty_msg->header.stamp.nanosec = 2;
     rclcpp::Time empty_time = empty_msg->header.stamp;
     auto traj = ros_controllers::Trajectory(empty_msg);
-    EXPECT_EQ(traj.end(), traj.sample(rclcpp::Time::now()));
+    EXPECT_EQ(traj.end(), traj.sample(rclcpp::Clock().now()));
     EXPECT_EQ(empty_time, traj.time_from_start());
   }
   {
     auto empty_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
     empty_msg->header.stamp.sec = 0;
     empty_msg->header.stamp.nanosec = 0;
-    auto now = rclcpp::Time::now();
+    auto now = rclcpp::Clock().now();
     auto traj = ros_controllers::Trajectory(empty_msg);
     auto traj_starttime = traj.time_from_start();
-    EXPECT_EQ(traj.end(), traj.sample(rclcpp::Time::now()));
-    auto allowed_delta = 10000ull;
+    EXPECT_EQ(traj.end(), traj.sample(rclcpp::Clock().now()));
+    auto allowed_delta = 10000ll;
     EXPECT_TRUE(traj.time_from_start().nanoseconds() - now.nanoseconds() < allowed_delta);
   }
 }
@@ -86,46 +88,46 @@ TEST_F(TestTrajectory, sample_trajectory) {
 
   auto traj = ros_controllers::Trajectory(full_msg);
 
-  auto sample_p1 = traj.sample(rclcpp::Time::now());
+  auto sample_p1 = traj.sample(rclcpp::Clock().now());
   ASSERT_NE(traj.end(), sample_p1);
   EXPECT_EQ(1.0f, sample_p1->positions[0]);
 
-  auto sample_p11 = traj.sample(rclcpp::Time::now());
+  auto sample_p11 = traj.sample(rclcpp::Clock().now());
   ASSERT_NE(traj.end(), sample_p11);
   EXPECT_EQ(1.0f, sample_p11->positions[0]);
 
   std::this_thread::sleep_for(1s);
 
-  auto sample_p2 = traj.sample(rclcpp::Time::now());
+  auto sample_p2 = traj.sample(rclcpp::Clock().now());
   ASSERT_NE(traj.end(), sample_p1);
   EXPECT_EQ(2.0f, sample_p2->positions[0]);
 
-  auto sample_p22 = traj.sample(rclcpp::Time::now());
+  auto sample_p22 = traj.sample(rclcpp::Clock().now());
   ASSERT_NE(traj.end(), sample_p22);
   EXPECT_EQ(2.0f, sample_p22->positions[0]);
 
   std::this_thread::sleep_for(1s);
 
-  auto sample_p3 = traj.sample(rclcpp::Time::now());
+  auto sample_p3 = traj.sample(rclcpp::Clock().now());
   ASSERT_NE(traj.end(), sample_p1);
   EXPECT_EQ(3.0f, sample_p3->positions[0]);
 
-  auto sample_p33 = traj.sample(rclcpp::Time::now());
+  auto sample_p33 = traj.sample(rclcpp::Clock().now());
   ASSERT_NE(traj.end(), sample_p33);
   EXPECT_EQ(3.0f, sample_p33->positions[0]);
 
   std::this_thread::sleep_for(1s);
 
-  auto sample_end = traj.sample(rclcpp::Time::now());
+  auto sample_end = traj.sample(rclcpp::Clock().now());
   EXPECT_EQ(traj.end(), sample_end);
 
-  auto sample_end_end = traj.sample(rclcpp::Time::now());
+  auto sample_end_end = traj.sample(rclcpp::Clock().now());
   EXPECT_EQ(traj.end(), sample_end_end);
 }
 
 TEST_F(TestTrajectory, future_sample_trajectory) {
   auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
-  full_msg->header.stamp = rclcpp::Time::now();
+  full_msg->header.stamp = rclcpp::Clock().now();
   full_msg->header.stamp.sec += 2;  // extra padding
 
   trajectory_msgs::msg::JointTrajectoryPoint p1;
@@ -156,6 +158,6 @@ TEST_F(TestTrajectory, future_sample_trajectory) {
   auto traj = ros_controllers::Trajectory(full_msg);
 
   // sample for future point
-  auto sample_p0 = traj.sample(rclcpp::Time::now());
+  auto sample_p0 = traj.sample(rclcpp::Clock().now());
   ASSERT_EQ(traj.end(), sample_p0);
 }

--- a/ros_controllers/test/test_trajectory_controller.cpp
+++ b/ros_controllers/test/test_trajectory_controller.cpp
@@ -59,7 +59,7 @@ protected:
     joint_names = {{test_robot->joint_name1, test_robot->joint_name2, test_robot->joint_name3}};
     op_mode = {{test_robot->write_op_handle_name1}};
 
-    pub_node = std::make_shared<rclcpp::node::Node>("trajectory_publisher");
+    pub_node = std::make_shared<rclcpp::Node>("trajectory_publisher");
     trajectory_publisher = pub_node->create_publisher<trajectory_msgs::msg::JointTrajectory>(
       controller_name + "/joint_trajectory");
   }
@@ -127,7 +127,7 @@ protected:
   std::vector<std::string> joint_names;
   std::vector<std::string> op_mode;
 
-  rclcpp::node::Node::SharedPtr pub_node;
+  rclcpp::Node::SharedPtr pub_node;
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr trajectory_publisher;
 };
 


### PR DESCRIPTION
Complementary PR with: [ros2_control PR](https://github.com/ros-controls/ros2_control/pull/8)

Maybe we should create branch `ardent` to have `ros2_control` versions trackable with `rclcpp` versions.
@Karsten1987
Current build error -
```
ros2_ws/src/ros2/ros2_controllers/ros_controllers/src/trajectory.cpp:38:5: error: 
‘now’ is not a member of ‘rclcpp::Time’
     rclcpp::Time::now() :
```