### PR TITLE
Remove usages of register_controller macro

### DIFF
--- a/ros_controllers/CMakeLists.txt
+++ b/ros_controllers/CMakeLists.txt
@@ -41,11 +41,6 @@ ament_target_dependencies(
   "sensor_msgs"
   "trajectory_msgs"
 )
-controller_manager_register_controller(
-  default_controllers
-  "ros_controllers::JointStateController"
-  "ros_controllers::JointTrajectoryController"
-)
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(default_controllers PRIVATE "ROS_CONTROLLERS_BUILDING_DLL")

--- a/ros_controllers/test/test_trajectory_controller.cpp
+++ b/ros_controllers/test/test_trajectory_controller.cpp
@@ -107,10 +107,12 @@ protected:
 
     size_t index = 0;
     for (; index < points.size(); ++index) {
+      using SecT = decltype(traj_msg.points[index].time_from_start.sec);
+      using NSecT = decltype(traj_msg.points[index].time_from_start.nanosec);
       traj_msg.points[index].time_from_start.sec =
-        duration_total.nanoseconds() / 1e9;
+        static_cast<SecT>(duration_total.nanoseconds() / 1e9);
       traj_msg.points[index].time_from_start.nanosec =
-        duration_total.nanoseconds();
+        static_cast<NSecT>(duration_total.nanoseconds());
       traj_msg.points[index].positions.resize(3);
       traj_msg.points[index].positions[0] = points[index][0];
       traj_msg.points[index].positions[1] = points[index][1];


### PR DESCRIPTION
https://github.com/ros-controls/ros2_control/pull/41 breaks `ros2_controllers` master branch. This PR should be merged after https://github.com/ros-controls/ros2_control/pull/41 is accepted. 