### PR TITLE
[Review Ready] Action server for JointTrajectoryController

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(angles REQUIRED)
 find_package(controller_interface REQUIRED)
 find_package(control_msgs REQUIRED)
 find_package(hardware_interface REQUIRED)
@@ -27,6 +28,7 @@ add_library(joint_trajectory_controller SHARED
 )
 target_include_directories(joint_trajectory_controller PRIVATE include)
 ament_target_dependencies(joint_trajectory_controller
+  angles
   builtin_interfaces
   controller_interface
   control_msgs

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -42,7 +42,8 @@ ament_target_dependencies(joint_trajectory_controller
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(joint_trajectory_controller PRIVATE "JOINT_TRAJECTORY_CONTROLLER_BUILDING_DLL")
+target_compile_definitions(joint_trajectory_controller PRIVATE
+  "JOINT_TRAJECTORY_CONTROLLER_BUILDING_DLL" "_USE_MATH_DEFINES")
 
 pluginlib_export_plugin_description_file(controller_interface joint_trajectory_plugin.xml)
 

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -105,15 +105,15 @@ if(BUILD_TESTING)
     joint_trajectory_controller
   )
   ament_target_dependencies(test_trajectory_actions
-    "controller_parameter_server"
-    "control_msgs"
-    "hardware_interface"
-    "rclcpp"
-    "rclcpp_lifecycle"
-    "rcutils"
-    "test_robot_hardware"
-    "trajectory_msgs"
-    "realtime_tools"
+    controller_parameter_server
+    control_msgs
+    hardware_interface
+    rclcpp
+    rclcpp_lifecycle
+    rcutils
+    test_robot_hardware
+    trajectory_msgs
+    realtime_tools
   )
 endif()
 

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -95,6 +95,26 @@ if(BUILD_TESTING)
     controller_manager
     test_robot_hardware
   )
+
+  ament_add_gtest(
+    test_trajectory_actions
+    test/test_trajectory_actions.cpp
+  )
+  target_include_directories(test_trajectory_actions PRIVATE include)
+  target_link_libraries(test_trajectory_actions
+    joint_trajectory_controller
+  )
+  ament_target_dependencies(test_trajectory_actions
+    "controller_parameter_server"
+    "control_msgs"
+    "hardware_interface"
+    "rclcpp"
+    "rclcpp_lifecycle"
+    "rcutils"
+    "test_robot_hardware"
+    "trajectory_msgs"
+    "realtime_tools"
+  )
 endif()
 
 ament_export_dependencies(

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -154,7 +154,9 @@ private:
   void set_op_mode(const hardware_interface::OperationMode & mode);
   void halt();
 
-  void publish_state();
+  using JointTrajectoryPoint = trajectory_msgs::msg::JointTrajectoryPoint;
+  void publish_state(const JointTrajectoryPoint& desired_state,
+    const JointTrajectoryPoint& current_state, const JointTrajectoryPoint& state_error);
 };
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -110,7 +110,6 @@ private:
   rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr
     joint_command_subscriber_ = nullptr;
 
-  TrajectoryPointConstIter prev_traj_point_ptr_;
   std::shared_ptr<Trajectory> * traj_point_active_ptr_ = nullptr;
   std::shared_ptr<Trajectory> traj_external_point_ptr_ = nullptr;
   std::shared_ptr<Trajectory> traj_home_point_ptr_ = nullptr;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -95,8 +95,6 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_shutdown(const rclcpp_lifecycle::State & previous_state) override;
 
-  rclcpp::Duration get_action_monitor_period() {return action_monitor_period_;}
-
 private:
   std::vector<std::string> joint_names_;
   std::vector<std::string> write_op_names_;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -126,15 +126,15 @@ private:
   rclcpp::Duration state_publisher_period_ = rclcpp::Duration(RCUTILS_MS_TO_NS(20));
   rclcpp::Time last_state_publish_time_;
 
-  typedef control_msgs::action::FollowJointTrajectory FollowJTrajAction;
-  typedef realtime_tools::RealtimeServerGoalHandle<FollowJTrajAction> RealtimeGoalHandle;
-  typedef std::shared_ptr<RealtimeGoalHandle> RealtimeGoalHandlePtr;
+  using FollowJTrajAction = control_msgs::action::FollowJointTrajectory;
+  using RealtimeGoalHandle = realtime_tools::RealtimeServerGoalHandle<FollowJTrajAction>;
+  using RealtimeGoalHandlePtr = std::shared_ptr<RealtimeGoalHandle>;
 
   rclcpp_action::Server<FollowJTrajAction>::SharedPtr action_server_;
   bool allow_partial_joints_goal_;
   RealtimeGoalHandlePtr rt_active_goal_;     ///< Currently active action goal, if any.
   rclcpp::TimerBase::SharedPtr goal_handle_timer_;
-  rclcpp::Duration action_monitor_period_ = rclcpp::Duration(1.0 / 50.0);
+  rclcpp::Duration action_monitor_period_ = rclcpp::Duration(RCUTILS_MS_TO_NS(50));
   std::mutex trajectory_mtx_;
 
   // callbacks for action_server_

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -110,7 +110,6 @@ private:
   rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr
     joint_command_subscriber_ = nullptr;
 
-  TrajectoryPointConstIter prev_traj_point_ptr_;
   std::shared_ptr<Trajectory> * traj_point_active_ptr_ = nullptr;
   std::shared_ptr<Trajectory> traj_external_point_ptr_ = nullptr;
   std::shared_ptr<Trajectory> traj_home_point_ptr_ = nullptr;
@@ -132,23 +131,24 @@ private:
   typedef std::shared_ptr<RealtimeGoalHandle> RealtimeGoalHandlePtr;
 
   rclcpp_action::Server<FollowJTrajAction>::SharedPtr action_server_;
-  bool allow_partial_joints_goal_ = false;
+  bool allow_partial_joints_goal_;
   RealtimeGoalHandlePtr rt_active_goal_;     ///< Currently active action goal, if any.
   rclcpp::TimerBase::SharedPtr goal_handle_timer_;
-  rclcpp::Duration action_monitor_period_ = rclcpp::Duration(1.0 / 20.0);
+  rclcpp::Duration action_monitor_period_ = rclcpp::Duration(1.0 / 50.0);
+  std::mutex trajectory_mtx_;
 
   // callbacks for action_server_
-  rclcpp_action::GoalResponse goalCB(
+  rclcpp_action::GoalResponse goal_callback(
     const rclcpp_action::GoalUUID& uuid,
     std::shared_ptr<const FollowJTrajAction::Goal> goal);
-  rclcpp_action::CancelResponse cancelCB(
+  rclcpp_action::CancelResponse cancel_callback(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
-  void feedbackSetupCB(
+  void feedback_setup_callback(
     std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
 
   SegmentTolerances default_tolerances_;
 
-  void preemptActiveGoal();
+  void preempt_active_goal();
 
   bool reset();
   void set_op_mode(const hardware_interface::OperationMode & mode);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -30,6 +30,7 @@
 #include "hardware_interface/robot_hardware.hpp"
 
 #include "joint_trajectory_controller/trajectory.hpp"
+#include "joint_trajectory_controller/tolerances.hpp"
 #include "joint_trajectory_controller/visibility_control.h"
 
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -144,6 +145,8 @@ private:
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
   void feedbackSetupCB(
     std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
+
+  SegmentTolerances default_tolerances_;
 
   void preemptActiveGoal();
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -158,7 +158,8 @@ private:
   using JointTrajectoryPoint = trajectory_msgs::msg::JointTrajectoryPoint;
   void publish_state(
     const JointTrajectoryPoint & desired_state,
-    const JointTrajectoryPoint & current_state, const JointTrajectoryPoint & state_error);
+    const JointTrajectoryPoint & current_state,
+    const JointTrajectoryPoint & state_error);
 };
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -132,12 +132,13 @@ private:
 
   rclcpp_action::Server<FollowJTrajAction>::SharedPtr action_server_;
   bool allow_partial_joints_goal_ = false;
-  RealtimeGoalHandlePtr     rt_active_goal_;     ///< Currently active action goal, if any.
+  RealtimeGoalHandlePtr rt_active_goal_;     ///< Currently active action goal, if any.
   rclcpp::TimerBase::SharedPtr goal_handle_timer_;
   rclcpp::Duration action_monitor_period_ = rclcpp::Duration(1.0 / 20.0);
 
   // callbacks for action_server_
-  rclcpp_action::GoalResponse goalCB(const rclcpp_action::GoalUUID& uuid,
+  rclcpp_action::GoalResponse goalCB(
+    const rclcpp_action::GoalUUID& uuid,
     std::shared_ptr<const FollowJTrajAction::Goal> goal);
   rclcpp_action::CancelResponse cancelCB(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -139,7 +139,7 @@ private:
 
   // callbacks for action_server_
   rclcpp_action::GoalResponse goal_callback(
-    const rclcpp_action::GoalUUID& uuid,
+    const rclcpp_action::GoalUUID & uuid,
     std::shared_ptr<const FollowJTrajAction::Goal> goal);
   rclcpp_action::CancelResponse cancel_callback(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
@@ -156,8 +156,9 @@ private:
   void halt();
 
   using JointTrajectoryPoint = trajectory_msgs::msg::JointTrajectoryPoint;
-  void publish_state(const JointTrajectoryPoint& desired_state,
-    const JointTrajectoryPoint& current_state, const JointTrajectoryPoint& state_error);
+  void publish_state(
+    const JointTrajectoryPoint & desired_state,
+    const JointTrajectoryPoint & current_state, const JointTrajectoryPoint & state_error);
 };
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -110,6 +110,7 @@ private:
   rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr
     joint_command_subscriber_ = nullptr;
 
+  TrajectoryPointConstIter prev_traj_point_ptr_;
   std::shared_ptr<Trajectory> * traj_point_active_ptr_ = nullptr;
   std::shared_ptr<Trajectory> traj_external_point_ptr_ = nullptr;
   std::shared_ptr<Trajectory> traj_home_point_ptr_ = nullptr;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -149,6 +149,7 @@ private:
   SegmentTolerances default_tolerances_;
 
   void preempt_active_goal();
+  void set_hold_position();
 
   bool reset();
   void set_op_mode(const hardware_interface::OperationMode & mode);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright 2013 PAL Robotics S.L.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -99,7 +99,7 @@ SegmentTolerances get_segment_tolerances(
   const rclcpp_lifecycle::LifecycleNode::SharedPtr & node,
   const std::vector<std::string> & joint_names)
 {
-  const unsigned int n_joints = joint_names.size();
+  auto n_joints = joint_names.size();
   SegmentTolerances tolerances;
 
   // State and goal state tolerances
@@ -110,7 +110,7 @@ SegmentTolerances get_segment_tolerances(
 
   tolerances.state_tolerance.resize(n_joints);
   tolerances.goal_state_tolerance.resize(n_joints);
-  for (auto i = 0u; i < n_joints; ++i) {
+  for (auto i = 0ul; i < n_joints; ++i) {
     std::string prefix = "constraints." + joint_names[i];
 
     node->get_parameter_or<double>(

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -114,7 +114,8 @@ SegmentTolerances getSegmentTolerances(
 
   // State and goal state tolerances
   double stopped_velocity_tolerance;
-  node->get_parameter_or<double>("constraints.stopped_velocity_tolerance",
+  node->get_parameter_or<double>(
+    "constraints.stopped_velocity_tolerance",
     stopped_velocity_tolerance, 0.01);
 
   tolerances.state_tolerance.resize(n_joints);
@@ -122,13 +123,17 @@ SegmentTolerances getSegmentTolerances(
   for (auto i = 0u; i < n_joints; ++i) {
     std::string prefix = "constraints." + joint_names[i];
 
-    node->get_parameter_or<double>(prefix + ".trajectory", tolerances.state_tolerance[i].position,
+    node->get_parameter_or<double>(
+      prefix + ".trajectory", tolerances.state_tolerance[i].position,
       0.0);
-    node->get_parameter_or<double>(prefix + ".goal", tolerances.goal_state_tolerance[i].position,
+    node->get_parameter_or<double>(
+      prefix + ".goal", tolerances.goal_state_tolerance[i].position,
       0.0);
-    RCLCPP_DEBUG(rclcpp::get_logger("tolerance"), "%s %f",
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("tolerance"), "%s %f",
       (prefix + ".trajectory").c_str(), tolerances.state_tolerance[i].position);
-    RCLCPP_DEBUG(rclcpp::get_logger("tolerance"), "%s %f",
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("tolerance"), "%s %f",
       (prefix + ".goal").c_str(), tolerances.goal_state_tolerance[i].position);
 
     tolerances.goal_state_tolerance[i].velocity = stopped_velocity_tolerance;
@@ -169,18 +174,21 @@ inline bool checkStateTolerancePerJoint(
       RCLCPP_ERROR_STREAM(logger, "Path state tolerances failed:");
 
       if (state_tolerance.position > 0.0 && abs(error_position) > state_tolerance.position) {
-        RCLCPP_ERROR_STREAM(logger, "Position Error: " << error_position <<
-          " Position Tolerance: " << state_tolerance.position);
+        RCLCPP_ERROR_STREAM(
+          logger, "Position Error: " << error_position <<
+            " Position Tolerance: " << state_tolerance.position);
       }
       if (state_tolerance.velocity > 0.0 && abs(error_velocity) > state_tolerance.velocity) {
-        RCLCPP_ERROR_STREAM(logger, "Velocity Error: " << error_velocity <<
-          " Velocity Tolerance: " << state_tolerance.velocity);
+        RCLCPP_ERROR_STREAM(
+          logger, "Velocity Error: " << error_velocity <<
+            " Velocity Tolerance: " << state_tolerance.velocity);
       }
       if (state_tolerance.acceleration > 0.0 &&
         abs(error_acceleration) > state_tolerance.acceleration)
       {
-        RCLCPP_ERROR_STREAM(logger, "Acceleration Error: " << error_acceleration <<
-          " Acceleration Tolerance: " << state_tolerance.acceleration);
+        RCLCPP_ERROR_STREAM(
+          logger, "Acceleration Error: " << error_acceleration <<
+            " Acceleration Tolerance: " << state_tolerance.acceleration);
       }
     }
     return false;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Open Source Robotics Foundation, Inc.
+// Copyright (C) 2013, PAL Robotics S.L.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -1,16 +1,29 @@
 // Copyright 2013 PAL Robotics S.L.
+// All rights reserved.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Software License Agreement (BSD License 2.0)
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -35,9 +35,9 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/node.hpp"
-
 #include "control_msgs/action/follow_joint_trajectory.hpp"
+
+#include "rclcpp/node.hpp"
 
 namespace joint_trajectory_controller
 {
@@ -103,10 +103,10 @@ SegmentTolerances get_segment_tolerances(
   SegmentTolerances tolerances;
 
   // State and goal state tolerances
-  double stopped_velocity_tolerance;
+  double stopped_velocity_tolerance = 0.01;
   node->get_parameter_or<double>(
     "constraints.stopped_velocity_tolerance",
-    stopped_velocity_tolerance, 0.01);
+    stopped_velocity_tolerance, stopped_velocity_tolerance);
 
   tolerances.state_tolerance.resize(n_joints);
   tolerances.goal_state_tolerance.resize(n_joints);
@@ -119,11 +119,13 @@ SegmentTolerances get_segment_tolerances(
     node->get_parameter_or<double>(
       prefix + ".goal", tolerances.goal_state_tolerance[i].position,
       0.0);
+
+    auto logger = rclcpp::get_logger("tolerance");
     RCLCPP_DEBUG(
-      rclcpp::get_logger("tolerance"), "%s %f",
+      logger, "%s %f",
       (prefix + ".trajectory").c_str(), tolerances.state_tolerance[i].position);
     RCLCPP_DEBUG(
-      rclcpp::get_logger("tolerance"), "%s %f",
+      logger, "%s %f",
       (prefix + ".goal").c_str(), tolerances.goal_state_tolerance[i].position);
 
     tolerances.goal_state_tolerance[i].velocity = stopped_velocity_tolerance;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -1,29 +1,16 @@
-///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright 2020 Open Source Robotics Foundation, Inc.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//   * Redistributions of source code must retain the above copyright notice,
-//     this list of conditions and the following disclaimer.
-//   * Redistributions in binary form must reproduce the above copyright
-//     notice, this list of conditions and the following disclaimer in the
-//     documentation and/or other materials provided with the distribution.
-//   * Neither the name of PAL Robotics S.L. nor the names of its
-//     contributors may be used to endorse or promote products derived from
-//     this software without specific prior written permission.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-//////////////////////////////////////////////////////////////////////////////
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -17,16 +17,13 @@
 #ifndef JOINT_TRAJECTORY_CONTROLLER__TOLERANCES_HPP_
 #define JOINT_TRAJECTORY_CONTROLLER__TOLERANCES_HPP_
 
-// C++ standard
 #include <cassert>
 #include <cmath>
 #include <string>
 #include <vector>
 
-// ROS
 #include "rclcpp/node.hpp"
 
-// ROS messages
 #include "control_msgs/action/follow_joint_trajectory.hpp"
 
 namespace joint_trajectory_controller
@@ -72,9 +69,9 @@ void declareSegmentTolerances(const rclcpp_lifecycle::LifecycleNode::SharedPtr &
 }
 
 /**
- * \brief Populate trajectory segment tolerances from data in the ROS parameter server.
+ * \brief Populate trajectory segment tolerances using data from the ROS node.
  *
- * It is assumed that the following parameter structure is followed on the provided NodeHandle. Unspecified parameters
+ * It is assumed that the following parameter structure is followed on the provided LifecycleNode. Unspecified parameters
  * will take the defaults shown in the comments:
  *
  * \code
@@ -88,11 +85,11 @@ void declareSegmentTolerances(const rclcpp_lifecycle::LifecycleNode::SharedPtr &
  *    goal: 0.01
  * \endcode
  *
- * \param nh NodeHandle where the tolerances are specified.
+ * \param node LifecycleNode where the tolerances are specified.
  * \param joint_names Names of joints to look for in the parameter server for a tolerance specification.
  * \return Trajectory segment tolerances.
  */
-SegmentTolerances getSegmentTolerances(
+SegmentTolerances get_segment_tolerances(
   const rclcpp_lifecycle::LifecycleNode::SharedPtr & node,
   const std::vector<std::string> & joint_names)
 {
@@ -139,7 +136,7 @@ SegmentTolerances getSegmentTolerances(
  * \param show_errors If the joint that violate its tolerance should be output to console. NOT REALTIME if true
  * \return True if \p state_error fulfills \p state_tolerance.
  */
-inline bool checkStateTolerancePerJoint(
+inline bool check_state_tolerance_per_joint(
   const trajectory_msgs::msg::JointTrajectoryPoint & state_error,
   int joint_idx,
   const StateTolerances & state_tolerance,
@@ -155,32 +152,33 @@ inline bool checkStateTolerancePerJoint(
     !(state_tolerance.velocity > 0.0 && abs(error_velocity) > state_tolerance.velocity) &&
     !(state_tolerance.acceleration > 0.0 && abs(error_acceleration) > state_tolerance.acceleration);
 
-  if (!is_valid) {
-    if (show_errors) {
-      auto logger = rclcpp::get_logger("tolerances");
-      RCLCPP_ERROR_STREAM(logger, "Path state tolerances failed:");
-
-      if (state_tolerance.position > 0.0 && abs(error_position) > state_tolerance.position) {
-        RCLCPP_ERROR_STREAM(
-          logger, "Position Error: " << error_position <<
-            " Position Tolerance: " << state_tolerance.position);
-      }
-      if (state_tolerance.velocity > 0.0 && abs(error_velocity) > state_tolerance.velocity) {
-        RCLCPP_ERROR_STREAM(
-          logger, "Velocity Error: " << error_velocity <<
-            " Velocity Tolerance: " << state_tolerance.velocity);
-      }
-      if (state_tolerance.acceleration > 0.0 &&
-        abs(error_acceleration) > state_tolerance.acceleration)
-      {
-        RCLCPP_ERROR_STREAM(
-          logger, "Acceleration Error: " << error_acceleration <<
-            " Acceleration Tolerance: " << state_tolerance.acceleration);
-      }
-    }
-    return false;
+  if (is_valid) {
+    return true;
   }
-  return true;
+
+  if (show_errors) {
+    auto logger = rclcpp::get_logger("tolerances");
+    RCLCPP_ERROR_STREAM(logger, "Path state tolerances failed:");
+
+    if (state_tolerance.position > 0.0 && abs(error_position) > state_tolerance.position) {
+      RCLCPP_ERROR_STREAM(
+        logger, "Position Error: " << error_position <<
+          " Position Tolerance: " << state_tolerance.position);
+    }
+    if (state_tolerance.velocity > 0.0 && abs(error_velocity) > state_tolerance.velocity) {
+      RCLCPP_ERROR_STREAM(
+        logger, "Velocity Error: " << error_velocity <<
+          " Velocity Tolerance: " << state_tolerance.velocity);
+    }
+    if (state_tolerance.acceleration > 0.0 &&
+      abs(error_acceleration) > state_tolerance.acceleration)
+    {
+      RCLCPP_ERROR_STREAM(
+        logger, "Acceleration Error: " << error_acceleration <<
+          " Acceleration Tolerance: " << state_tolerance.acceleration);
+    }
+  }
+  return false;
 }
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -61,13 +61,6 @@ struct SegmentTolerances
   double goal_time_tolerance = 0.0;
 };
 
-void declareSegmentTolerances(const rclcpp_lifecycle::LifecycleNode::SharedPtr & node)
-{
-  node->declare_parameter<double>("constraints.stopped_velocity_tolerance", 0.01);
-  node->declare_parameter<double>("constraints.goal_time", 0.0);
-  // not possible to declare per-joint tolerances since we need to obtain joint_names
-}
-
 /**
  * \brief Populate trajectory segment tolerances using data from the ROS node.
  *

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -1,0 +1,320 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Adolfo Rodriguez Tsouroukdissian
+
+#ifndef JOINT_TRAJECTORY_CONTROLLER_TOLERANCES_H
+#define JOINT_TRAJECTORY_CONTROLLER_TOLERANCES_H
+
+// C++ standard
+#include <cassert>
+#include <cmath>
+#include <string>
+#include <vector>
+
+// ROS
+#include <rclcpp/rclcpp.hpp>
+
+// ROS messages
+#include "control_msgs/action/follow_joint_trajectory.hpp"
+
+namespace joint_trajectory_controller
+{
+
+/**
+ * \brief Trajectory state tolerances for position, velocity and acceleration variables.
+ *
+ * A tolerance value of zero means that no tolerance will be applied for that variable.
+ */
+struct StateTolerances
+{
+  StateTolerances(double position_tolerance     = 0.0,
+                  double velocity_tolerance     = 0.0,
+                  double acceleration_tolerance = 0.0)
+    : position(position_tolerance),
+      velocity(velocity_tolerance),
+      acceleration(acceleration_tolerance)
+  {}
+
+  double position;
+  double velocity;
+  double acceleration;
+};
+
+/**
+ * \brief Trajectory segment tolerances.
+ */
+struct SegmentTolerances
+{
+  SegmentTolerances(const typename std::vector<StateTolerances>::size_type& size = 0)
+    : state_tolerance(size, 0.0),
+      goal_state_tolerance(size, 0.0),
+      goal_time_tolerance(0.0)
+  {}
+
+  /** State tolerances that appply during segment execution. */
+  std::vector<StateTolerances> state_tolerance;
+
+  /** State tolerances that apply for the goal state only.*/
+  std::vector<StateTolerances> goal_state_tolerance;
+
+  /** Extra time after the segment end time allowed to reach the goal state tolerances. */
+  double goal_time_tolerance;
+};
+
+/**
+ * \brief Trajectory segment tolerances per Joint
+ */
+struct SegmentTolerancesPerJoint
+{
+  SegmentTolerancesPerJoint()
+    : state_tolerance(0.0),
+      goal_state_tolerance(0.0),
+      goal_time_tolerance(0.0)
+  {}
+
+  /** State tolerances that appply during segment execution. */
+  StateTolerances state_tolerance;
+
+  /** State tolerances that apply for the goal state only.*/
+  StateTolerances goal_state_tolerance;
+
+  /** Extra time after the segment end time allowed to reach the goal state tolerances. */
+  double goal_time_tolerance;
+};
+
+/**
+ * \param state_error State error to check.
+ * \param state_tolerance State tolerances to check \p state_error against.
+ * \param show_errors If the joints that violate their tolerances should be output to console. NOT REALTIME if true
+ * \return True if \p state_error fulfills \p state_tolerance.
+ */
+template <class State>
+inline bool checkStateTolerance(const State&                     state_error,
+                                const std::vector<StateTolerances>& state_tolerance,
+                                bool show_errors = false)
+{
+  const unsigned int n_joints = state_tolerance.size();
+
+  // Preconditions
+  assert(n_joints == state_error.position.size());
+  assert(n_joints == state_error.velocity.size());
+  assert(n_joints == state_error.acceleration.size());
+
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    using std::abs;
+    const StateTolerances& tol = state_tolerance[i]; // Alias for brevity
+    const bool is_valid = !(tol.position     > 0.0 && abs(state_error.position[i])     > tol.position) &&
+                          !(tol.velocity     > 0.0 && abs(state_error.velocity[i])     > tol.velocity) &&
+                          !(tol.acceleration > 0.0 && abs(state_error.acceleration[i]) > tol.acceleration);
+
+    if (!is_valid)
+    {
+      if( show_errors )
+      {
+        auto logger = rclcpp::get_logger("tolerances");
+        RCLCPP_ERROR_STREAM(logger, "Path state tolerances failed on joint " << i);
+
+        if (tol.position     > 0.0 && abs(state_error.position[i])     > tol.position)
+          RCLCPP_ERROR_STREAM(logger, "Position Error: " << state_error.position[i] <<
+            " Position Tolerance: " << tol.position);
+        if (tol.velocity     > 0.0 && abs(state_error.velocity[i])     > tol.velocity)
+          RCLCPP_ERROR_STREAM(logger, "Velocity Error: " << state_error.velocity[i] <<
+            " Velocity Tolerance: " << tol.velocity);
+        if (tol.acceleration > 0.0 && abs(state_error.acceleration[i]) > tol.acceleration)
+          RCLCPP_ERROR_STREAM(logger, "Acceleration Error: " << state_error.acceleration[i] <<
+            " Acceleration Tolerance: " << tol.acceleration);
+      }
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * \param state_error State error to check.
+ * \param state_tolerance State tolerances to check \p state_error against.
+ * \param show_errors If the joint that violate its tolerance should be output to console. NOT REALTIME if true
+ * \return True if \p state_error fulfills \p state_tolerance.
+ */
+template <class State>
+inline bool checkStateTolerancePerJoint(const State&                                   state_error,
+                                        const StateTolerances& state_tolerance,
+                                        bool show_errors = false)
+{
+
+  using std::abs;
+
+  const bool is_valid = !(state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position) &&
+                        !(state_tolerance.velocity     > 0.0 && abs(state_error.velocity[0])     > state_tolerance.velocity) &&
+                        !(state_tolerance.acceleration > 0.0 && abs(state_error.acceleration[0]) > state_tolerance.acceleration);
+
+  if (!is_valid)
+  {
+    if( show_errors )
+    {
+      auto logger = rclcpp::get_logger("tolerances");
+      RCLCPP_ERROR_STREAM(logger, "Path state tolerances failed:");
+
+      if (state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position)
+        RCLCPP_ERROR_STREAM(logger, "Position Error: " << state_error.position[0] <<
+          " Position Tolerance: " << state_tolerance.position);
+      if (state_tolerance.velocity     > 0.0 && abs(state_error.velocity[0])     > state_tolerance.velocity)
+        RCLCPP_ERROR_STREAM(logger, "Velocity Error: " << state_error.velocity[0] <<
+          " Velocity Tolerance: " << state_tolerance.velocity);
+      if (state_tolerance.acceleration > 0.0 && abs(state_error.acceleration[0]) > state_tolerance.acceleration)
+        RCLCPP_ERROR_STREAM(logger, "Acceleration Error: " << state_error.acceleration[0] <<
+          " Acceleration Tolerance: " << state_tolerance.acceleration);
+    }
+    return false;
+  }
+  return true;
+}
+
+/**
+ * \brief Update data in \p tols from data in \p msg_tol.
+ *
+ * - If a value in \p tol_msg is positive, the corresponding values in \p tols will be overritten.
+ * - If a value in \p tol_msg is negative, the corresponding values in \p tols will be reset.
+ * - If a value in \p tol_msg is zero, the corresponding values in \p tols is unchanged.
+ *
+ * \param[in] tol_msg Message containing tolerance values \p tols will be updated with.
+ * \param[out] tols Tolerances values to update.
+ *
+ **/
+void updateStateTolerances(const control_msgs::msg::JointTolerance& tol_msg, StateTolerances& tols)
+{
+  if      (tol_msg.position     > 0.0) {tols.position     = static_cast<double>(tol_msg.position);}
+  else if (tol_msg.position     < 0.0) {tols.position     = 0.0;}
+
+  if      (tol_msg.velocity     > 0.0) {tols.velocity     = static_cast<double>(tol_msg.velocity);}
+  else if (tol_msg.velocity     < 0.0) {tols.velocity     = 0.0;}
+
+  if      (tol_msg.acceleration > 0.0) {tols.acceleration = static_cast<double>(tol_msg.acceleration);}
+  else if (tol_msg.acceleration < 0.0) {tols.acceleration = 0.0;}
+}
+
+/**
+ * \brief Update data in \p tols from data in \p goal.
+ *
+ * \param[in] goal Action goal data containing tolerance values \p tols will be updated with.
+ * \param[in] joint_names Names of joints in \p tols, with the same ordering.
+ * \param[out] tols Tolerances values to update.
+ */
+void updateSegmentTolerances(const control_msgs::action::FollowJointTrajectory::Goal& goal,
+                             const std::vector<std::string>& joint_names,
+                             SegmentTolerances& tols
+)
+{
+  // Preconditions
+  assert(joint_names.size() == tols.state_tolerance.size());
+  assert(joint_names.size() == tols.goal_state_tolerance.size());
+
+  typedef typename std::vector<std::string>::const_iterator                  StringConstIterator;
+  typedef typename std::vector<control_msgs::msg::JointTolerance>::const_iterator TolMsgConstIterator;
+
+  for (StringConstIterator names_it = joint_names.begin(); names_it != joint_names.end(); ++names_it)
+  {
+    const typename std::vector<std::string>::size_type id = std::distance(joint_names.begin(), names_it);
+
+    // Update path tolerances
+    const std::vector<control_msgs::msg::JointTolerance>& state_tol = goal.path_tolerance;
+    for(TolMsgConstIterator state_tol_it = state_tol.begin(); state_tol_it != state_tol.end(); ++state_tol_it)
+    {
+      if (*names_it == state_tol_it->name) {updateStateTolerances(*state_tol_it, tols.state_tolerance[id]);}
+    }
+
+    // Update goal state tolerances
+    const std::vector<control_msgs::msg::JointTolerance>& g_state_tol = goal.goal_tolerance;
+    for(TolMsgConstIterator g_state_tol_it = g_state_tol.begin(); g_state_tol_it != g_state_tol.end(); ++g_state_tol_it)
+    {
+      if (*names_it == g_state_tol_it->name) {updateStateTolerances(*g_state_tol_it, tols.goal_state_tolerance[id]);}
+    }
+  }
+
+  // Update goal time tolerance
+  const rclcpp::Duration& goal_time_tolerance = goal.goal_time_tolerance;
+  if      (goal_time_tolerance < rclcpp::Duration(0.0)) {tols.goal_time_tolerance = 0.0;}
+  else if (goal_time_tolerance > rclcpp::Duration(0.0)) {tols.goal_time_tolerance = goal_time_tolerance.seconds();}
+}
+
+/**
+ * \brief Populate trajectory segment tolerances from data in the ROS parameter server.
+ *
+ * It is assumed that the following parameter structure is followed on the provided NodeHandle. Unspecified parameters
+ * will take the defaults shown in the comments:
+ *
+ * \code
+ * constraints:
+ *  goal_time: 1.0                   # Defaults to zero
+ *  stopped_velocity_tolerance: 0.02 # Defaults to 0.01
+ *  foo_joint:
+ *    trajectory: 0.05               # Defaults to zero (ie. the tolerance is not enforced)
+ *    goal:       0.03               # Defaults to zero (ie. the tolerance is not enforced)
+ *  bar_joint:
+ *    goal: 0.01
+ * \endcode
+ *
+ * \param nh NodeHandle where the tolerances are specified.
+ * \param joint_names Names of joints to look for in the parameter server for a tolerance specification.
+ * \return Trajectory segment tolerances.
+ */
+SegmentTolerances getSegmentTolerances(const rclcpp_lifecycle::LifecycleNode::SharedPtr& node,
+                                       const std::vector<std::string>& joint_names)
+{
+  const unsigned int n_joints = joint_names.size();
+  SegmentTolerances tolerances;
+  std::string tolerance_ns = "constraints";
+
+  // State and goal state tolerances
+  double stopped_velocity_tolerance;
+  node->declare_parameter(tolerance_ns + ".stopped_velocity_tolerance");
+  node->get_parameter_or<double>(tolerance_ns + ".stopped_velocity_tolerance", stopped_velocity_tolerance, 0.01);
+  
+  tolerances.state_tolerance.resize(n_joints);
+  tolerances.goal_state_tolerance.resize(n_joints);
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    std::string prefix = tolerance_ns + joint_names[i];
+    node->declare_parameter(prefix + ".trajectory");
+    node->declare_parameter(prefix + ".goal");
+    node->get_parameter_or<double>(prefix + ".trajectory", tolerances.state_tolerance[i].position, 0.0);
+    node->get_parameter_or<double>(prefix + ".goal", tolerances.goal_state_tolerance[i].position, 0.0);
+    tolerances.goal_state_tolerance[i].velocity = stopped_velocity_tolerance;
+  }
+
+  // Goal time tolerance
+  node->declare_parameter(tolerance_ns + ".goal_time");
+  node->get_parameter_or<double>(tolerance_ns + ".goal_time", tolerances.goal_time_tolerance, 0.0);
+
+  return tolerances;
+}
+
+} // namespace
+
+#endif // header guard

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -52,17 +52,9 @@ namespace joint_trajectory_controller
  */
 struct StateTolerances
 {
-  StateTolerances(double position_tolerance     = 0.0,
-                  double velocity_tolerance     = 0.0,
-                  double acceleration_tolerance = 0.0)
-    : position(position_tolerance),
-      velocity(velocity_tolerance),
-      acceleration(acceleration_tolerance)
-  {}
-
-  double position;
-  double velocity;
-  double acceleration;
+  double position = 0.0;
+  double velocity = 0.0;
+  double acceleration = 0.0;
 };
 
 /**
@@ -70,9 +62,9 @@ struct StateTolerances
  */
 struct SegmentTolerances
 {
-  SegmentTolerances(const typename std::vector<StateTolerances>::size_type& size = 0)
-    : state_tolerance(size, 0.0),
-      goal_state_tolerance(size, 0.0),
+  SegmentTolerances(size_t size = 0)
+    : state_tolerance(size),
+      goal_state_tolerance(size),
       goal_time_tolerance(0.0)
   {}
 
@@ -84,28 +76,68 @@ struct SegmentTolerances
 
   /** Extra time after the segment end time allowed to reach the goal state tolerances. */
   double goal_time_tolerance;
+
 };
+
+void declareSegmentTolerances(const rclcpp_lifecycle::LifecycleNode::SharedPtr& node)
+{
+  node->declare_parameter<double>("constraints.stopped_velocity_tolerance", 0.01);
+  node->declare_parameter<double>("constraints.goal_time", 0.0);
+}
 
 /**
- * \brief Trajectory segment tolerances per Joint
+ * \brief Populate trajectory segment tolerances from data in the ROS parameter server.
+ *
+ * It is assumed that the following parameter structure is followed on the provided NodeHandle. Unspecified parameters
+ * will take the defaults shown in the comments:
+ *
+ * \code
+ * constraints:
+ *  goal_time: 1.0                   # Defaults to zero
+ *  stopped_velocity_tolerance: 0.02 # Defaults to 0.01
+ *  foo_joint:
+ *    trajectory: 0.05               # Defaults to zero (ie. the tolerance is not enforced)
+ *    goal:       0.03               # Defaults to zero (ie. the tolerance is not enforced)
+ *  bar_joint:
+ *    goal: 0.01
+ * \endcode
+ *
+ * \param nh NodeHandle where the tolerances are specified.
+ * \param joint_names Names of joints to look for in the parameter server for a tolerance specification.
+ * \return Trajectory segment tolerances.
  */
-struct SegmentTolerancesPerJoint
+SegmentTolerances getSegmentTolerances(const rclcpp_lifecycle::LifecycleNode::SharedPtr& node,
+                                       const std::vector<std::string>& joint_names)
 {
-  SegmentTolerancesPerJoint()
-    : state_tolerance(0.0),
-      goal_state_tolerance(0.0),
-      goal_time_tolerance(0.0)
-  {}
+  const unsigned int n_joints = joint_names.size();
+  SegmentTolerances tolerances;
 
-  /** State tolerances that appply during segment execution. */
-  StateTolerances state_tolerance;
+  // State and goal state tolerances
+  double stopped_velocity_tolerance;
+  node->get_parameter_or<double>("constraints.stopped_velocity_tolerance", stopped_velocity_tolerance, 0.01);
+  
+  tolerances.state_tolerance.resize(n_joints);
+  tolerances.goal_state_tolerance.resize(n_joints);
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    std::string prefix = "constraints." + joint_names[i];
+    // not possible to declare in init function since we need joint_names to be set first
+    //node->declare_parameter<double>(prefix + ".trajectory", 0.0);
+    //node->declare_parameter<double>(prefix + ".goal", 0.0);
 
-  /** State tolerances that apply for the goal state only.*/
-  StateTolerances goal_state_tolerance;
+    node->get_parameter_or<double>(prefix + ".trajectory", tolerances.state_tolerance[i].position, 0.0);
+    node->get_parameter_or<double>(prefix + ".goal", tolerances.goal_state_tolerance[i].position, 0.0);
+    RCLCPP_INFO(rclcpp::get_logger("tolerance"), "%s %f", (prefix + ".trajectory").c_str(), tolerances.state_tolerance[i].position);
+    RCLCPP_INFO(rclcpp::get_logger("tolerance"), "%s %f", (prefix + ".goal").c_str(), tolerances.goal_state_tolerance[i].position);
+    
+    tolerances.goal_state_tolerance[i].velocity = stopped_velocity_tolerance;
+  }
 
-  /** Extra time after the segment end time allowed to reach the goal state tolerances. */
-  double goal_time_tolerance;
-};
+  // Goal time tolerance
+  node->get_parameter_or<double>("constraints.goal_time", tolerances.goal_time_tolerance, 0.0);
+
+  return tolerances;
+}
 
 /**
  * \param state_error State error to check.
@@ -162,17 +194,20 @@ inline bool checkStateTolerance(const State&                     state_error,
  * \param show_errors If the joint that violate its tolerance should be output to console. NOT REALTIME if true
  * \return True if \p state_error fulfills \p state_tolerance.
  */
-template <class State>
-inline bool checkStateTolerancePerJoint(const State&                                   state_error,
+inline bool checkStateTolerancePerJoint(const trajectory_msgs::msg::JointTrajectoryPoint& state_error,
+                                        int joint_idx,
                                         const StateTolerances& state_tolerance,
                                         bool show_errors = false)
 {
 
   using std::abs;
+  double error_position = state_error.positions[joint_idx];
+  double error_velocity = state_error.velocities[joint_idx];
+  double error_acceleration = state_error.accelerations[joint_idx];
 
-  const bool is_valid = !(state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position) &&
-                        !(state_tolerance.velocity     > 0.0 && abs(state_error.velocity[0])     > state_tolerance.velocity) &&
-                        !(state_tolerance.acceleration > 0.0 && abs(state_error.acceleration[0]) > state_tolerance.acceleration);
+  const bool is_valid = !(state_tolerance.position     > 0.0 && abs(error_position)     > state_tolerance.position) &&
+                        !(state_tolerance.velocity     > 0.0 && abs(error_velocity)     > state_tolerance.velocity) &&
+                        !(state_tolerance.acceleration > 0.0 && abs(error_acceleration) > state_tolerance.acceleration);
 
   if (!is_valid)
   {
@@ -181,14 +216,14 @@ inline bool checkStateTolerancePerJoint(const State&                            
       auto logger = rclcpp::get_logger("tolerances");
       RCLCPP_ERROR_STREAM(logger, "Path state tolerances failed:");
 
-      if (state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position)
-        RCLCPP_ERROR_STREAM(logger, "Position Error: " << state_error.position[0] <<
+      if (state_tolerance.position     > 0.0 && abs(error_position)     > state_tolerance.position)
+        RCLCPP_ERROR_STREAM(logger, "Position Error: " << error_position <<
           " Position Tolerance: " << state_tolerance.position);
-      if (state_tolerance.velocity     > 0.0 && abs(state_error.velocity[0])     > state_tolerance.velocity)
-        RCLCPP_ERROR_STREAM(logger, "Velocity Error: " << state_error.velocity[0] <<
+      if (state_tolerance.velocity     > 0.0 && abs(error_velocity)     > state_tolerance.velocity)
+        RCLCPP_ERROR_STREAM(logger, "Velocity Error: " << error_velocity <<
           " Velocity Tolerance: " << state_tolerance.velocity);
-      if (state_tolerance.acceleration > 0.0 && abs(state_error.acceleration[0]) > state_tolerance.acceleration)
-        RCLCPP_ERROR_STREAM(logger, "Acceleration Error: " << state_error.acceleration[0] <<
+      if (state_tolerance.acceleration > 0.0 && abs(error_acceleration) > state_tolerance.acceleration)
+        RCLCPP_ERROR_STREAM(logger, "Acceleration Error: " << error_acceleration <<
           " Acceleration Tolerance: " << state_tolerance.acceleration);
     }
     return false;
@@ -261,58 +296,6 @@ void updateSegmentTolerances(const control_msgs::action::FollowJointTrajectory::
   const rclcpp::Duration& goal_time_tolerance = goal.goal_time_tolerance;
   if      (goal_time_tolerance < rclcpp::Duration(0.0)) {tols.goal_time_tolerance = 0.0;}
   else if (goal_time_tolerance > rclcpp::Duration(0.0)) {tols.goal_time_tolerance = goal_time_tolerance.seconds();}
-}
-
-/**
- * \brief Populate trajectory segment tolerances from data in the ROS parameter server.
- *
- * It is assumed that the following parameter structure is followed on the provided NodeHandle. Unspecified parameters
- * will take the defaults shown in the comments:
- *
- * \code
- * constraints:
- *  goal_time: 1.0                   # Defaults to zero
- *  stopped_velocity_tolerance: 0.02 # Defaults to 0.01
- *  foo_joint:
- *    trajectory: 0.05               # Defaults to zero (ie. the tolerance is not enforced)
- *    goal:       0.03               # Defaults to zero (ie. the tolerance is not enforced)
- *  bar_joint:
- *    goal: 0.01
- * \endcode
- *
- * \param nh NodeHandle where the tolerances are specified.
- * \param joint_names Names of joints to look for in the parameter server for a tolerance specification.
- * \return Trajectory segment tolerances.
- */
-SegmentTolerances getSegmentTolerances(const rclcpp_lifecycle::LifecycleNode::SharedPtr& node,
-                                       const std::vector<std::string>& joint_names)
-{
-  const unsigned int n_joints = joint_names.size();
-  SegmentTolerances tolerances;
-  std::string tolerance_ns = "constraints";
-
-  // State and goal state tolerances
-  double stopped_velocity_tolerance;
-  node->declare_parameter(tolerance_ns + ".stopped_velocity_tolerance");
-  node->get_parameter_or<double>(tolerance_ns + ".stopped_velocity_tolerance", stopped_velocity_tolerance, 0.01);
-  
-  tolerances.state_tolerance.resize(n_joints);
-  tolerances.goal_state_tolerance.resize(n_joints);
-  for (unsigned int i = 0; i < n_joints; ++i)
-  {
-    std::string prefix = tolerance_ns + joint_names[i];
-    node->declare_parameter(prefix + ".trajectory");
-    node->declare_parameter(prefix + ".goal");
-    node->get_parameter_or<double>(prefix + ".trajectory", tolerances.state_tolerance[i].position, 0.0);
-    node->get_parameter_or<double>(prefix + ".goal", tolerances.goal_state_tolerance[i].position, 0.0);
-    tolerances.goal_state_tolerance[i].velocity = stopped_velocity_tolerance;
-  }
-
-  // Goal time tolerance
-  node->declare_parameter(tolerance_ns + ".goal_time");
-  node->get_parameter_or<double>(tolerance_ns + ".goal_time", tolerances.goal_time_tolerance, 0.0);
-
-  return tolerances;
 }
 
 } // namespace

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -76,6 +76,9 @@ public:
   bool
   is_empty() const;
 
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> get_trajectory_msg() const {
+    return trajectory_msg_;
+  }
 private:
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg_;
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -76,9 +76,11 @@ public:
   bool
   is_empty() const;
 
-  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> get_trajectory_msg() const {
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> get_trajectory_msg() const
+  {
     return trajectory_msg_;
   }
+
 private:
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg_;
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -48,10 +48,13 @@ public:
     const trajectory_msgs::msg::JointTrajectoryPoint & current_point,
     std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory);
 
-
+  /// Set the point before the trajectory message is replaced/appended
+  /// Example: if we receive a new trajectory message and it's first point is 0.5 seconds
+  /// from the current one, we call this function to log the current state, then
+  /// append/replace the current trajectory
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   void
-  set_point_before_traj(
+  set_point_before_trajectory_msg(
     const rclcpp::Time & current_time,
     const trajectory_msgs::msg::JointTrajectoryPoint & current_point);
 
@@ -96,7 +99,7 @@ public:
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   bool
-  has_traj_msg() const;
+  has_trajectory_msg() const;
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory>

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -72,10 +72,10 @@ public:
   * - Sampling after entire trajectory:
   *    start_segment_itr = --end(), end_segment_itr = end()
   * - Sampling empty msg:
-  *    start_segment_itr = end(), end_segment_itr = end()
+  *    return false
   */
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  void
+  bool
   sample(const rclcpp::Time & sample_time,
     trajectory_msgs::msg::JointTrajectoryPoint& expected_state,
     TrajectoryPointConstIter& start_segment_itr,
@@ -95,7 +95,7 @@ public:
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   bool
-  is_empty() const;
+  has_traj_msg() const;
 
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory> get_trajectory_msg() const
   {

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -45,7 +45,7 @@ public:
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   explicit Trajectory(
     const rclcpp::Time & current_time,
-    const trajectory_msgs::msg::JointTrajectoryPoint& current_point,
+    const trajectory_msgs::msg::JointTrajectoryPoint & current_point,
     std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory);
 
 
@@ -53,13 +53,13 @@ public:
   void
   set_point_before_traj(
     const rclcpp::Time & current_time,
-    const trajectory_msgs::msg::JointTrajectoryPoint& current_point);
+    const trajectory_msgs::msg::JointTrajectoryPoint & current_point);
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   void
   update(std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory);
 
-  /// Find the segment (made up of 2 points) and its expected state from the 
+  /// Find the segment (made up of 2 points) and its expected state from the
   /// containing trajectory.
   /**
   * Specific case returns for start_segment_itr and end_segment_itr:
@@ -76,10 +76,11 @@ public:
   */
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   bool
-  sample(const rclcpp::Time & sample_time,
-    trajectory_msgs::msg::JointTrajectoryPoint& expected_state,
-    TrajectoryPointConstIter& start_segment_itr,
-    TrajectoryPointConstIter& end_segment_itr);
+  sample(
+    const rclcpp::Time & sample_time,
+    trajectory_msgs::msg::JointTrajectoryPoint & expected_state,
+    TrajectoryPointConstIter & start_segment_itr,
+    TrajectoryPointConstIter & end_segment_itr);
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   TrajectoryPointConstIter
@@ -98,14 +99,15 @@ public:
   has_traj_msg() const;
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> 
-  get_trajectory_msg() const { return trajectory_msg_; }
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory>
+  get_trajectory_msg() const {return trajectory_msg_;}
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  rclcpp::Time get_trajectory_start_time() const { return trajectory_start_time_; }
+  rclcpp::Time get_trajectory_start_time() const {return trajectory_start_time_;}
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  bool is_sampled_already() const { return sampled_already_; }
+  bool is_sampled_already() const {return sampled_already_;}
+
 private:
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg_;
   rclcpp::Time trajectory_start_time_;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -97,10 +97,12 @@ public:
   bool
   has_traj_msg() const;
 
-  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> get_trajectory_msg() const
-  {
-    return trajectory_msg_;
-  }
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> 
+  get_trajectory_msg() const { return trajectory_msg_; }
+
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  rclcpp::Time get_trajectory_start_time() const { return trajectory_start_time_; }
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   bool is_sampled_already() const { return sampled_already_; }

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>angles</build_depend>
   <build_depend>controller_interface</build_depend>
   <build_depend>control_msgs</build_depend>
   <build_depend>hardware_interface</build_depend>

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -105,7 +105,7 @@ JointTrajectoryController::update()
         current.positions[index], desired.positions[index]);
 
       if (!desired.velocities.empty()) {
-        error.velocities[index] = current.velocities[index] - desired.velocities[index];
+        error.velocities[index] = desired.velocities[index] - current.velocities[index];
       } else {
         error.velocities[index] = 0.0;
       }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -295,7 +295,8 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
       action_monitor_rate = lifecycle_node_->get_parameter("action_monitor_rate")
         .get_value<int>();
     }
-    RCLCPP_INFO_STREAM(logger, "Action status changes will be monitored at " <<
+    RCLCPP_INFO_STREAM(
+      logger, "Action status changes will be monitored at " <<
       action_monitor_rate << "Hz.");
     action_monitor_period_ = rclcpp::Duration(1.0 / static_cast<double>(action_monitor_rate));
 
@@ -449,7 +450,8 @@ rclcpp_action::GoalResponse JointTrajectoryController::goalCB(
 
   // Precondition: Running controller
   if (is_halted) {
-    RCLCPP_ERROR(lifecycle_node_->get_logger(),
+    RCLCPP_ERROR(
+      lifecycle_node_->get_logger(),
       "Can't accept new action goals. Controller is not running.");
     return rclcpp_action::GoalResponse::REJECT;
   }
@@ -489,7 +491,8 @@ rclcpp_action::CancelResponse JointTrajectoryController::cancelCB(
     // Enter hold current position mode
     // setHoldPosition(uptime);
 
-    RCLCPP_DEBUG(lifecycle_node_->get_logger(),
+    RCLCPP_DEBUG(
+      lifecycle_node_->get_logger(),
       "Canceling active action goal because cancel callback recieved.");
 
     // Mark the current goal as canceled

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -143,7 +143,8 @@ JointTrajectoryController::update()
       start_segment_itr, end_segment_itr);
 
     if (valid_point) {
-      bool abort = false, outside_goal_tolerance = false;
+      bool abort = false;
+      bool outside_goal_tolerance = false;
       bool before_last_point = end_segment_itr != (*traj_point_active_ptr_)->end();
       for (auto index = 0ul; index < joint_num; ++index) {
         // set values for next hardware write()
@@ -348,7 +349,7 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
 
   publisher_ = lifecycle_node_->create_publisher<ControllerStateMsg>(
     "state", rclcpp::SystemDefaultsQoS());
-  state_publisher_.reset(new StatePublisher(publisher_));
+  state_publisher_ = std::make_unique<StatePublisher>(publisher_);
 
   auto n_joints = joint_names_.size();
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -297,7 +297,7 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
     }
     RCLCPP_INFO_STREAM(
       logger, "Action status changes will be monitored at " <<
-      action_monitor_rate << "Hz.");
+        action_monitor_rate << "Hz.");
     action_monitor_period_ = rclcpp::Duration(1.0 / static_cast<double>(action_monitor_rate));
 
     using namespace std::placeholders;
@@ -459,7 +459,8 @@ rclcpp_action::GoalResponse JointTrajectoryController::goalCB(
   // If partial joints goals are not allowed, goal should specify all controller joints
   if (!allow_partial_joints_goal_) {
     if (goal->trajectory.joint_names.size() != joint_names_.size()) {
-      RCLCPP_ERROR(lifecycle_node_->get_logger(),
+      RCLCPP_ERROR(
+        lifecycle_node_->get_logger(),
         "Joints on incoming goal don't match the controller joints.");
       return rclcpp_action::GoalResponse::REJECT;
     }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -128,10 +128,11 @@ JointTrajectoryController::update()
   std::lock_guard<std::mutex> guard(trajectory_mtx_);
 
   // currently carrying out a trajectory
-  if (traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_traj_msg() == false) {
+  if (traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_trajectory_msg() == false) {
     // if sampling the first time, set the point before you sample
     if (!(*traj_point_active_ptr_)->is_sampled_already()) {
-      (*traj_point_active_ptr_)->set_point_before_traj(lifecycle_node_->now(), state_current);
+      (*traj_point_active_ptr_)->set_point_before_trajectory_msg(
+        lifecycle_node_->now(), state_current);
     }
     resize_joint_trajectory_point(state_error, joint_num);
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -379,7 +379,7 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
   RCLCPP_INFO_STREAM(
     logger, "Action status changes will be monitored at " <<
       action_monitor_rate << "Hz.");
-  action_monitor_period_ = rclcpp::Duration(1.0 / action_monitor_rate);
+  action_monitor_period_ = rclcpp::Duration::from_seconds(1.0 / action_monitor_rate);
 
   using namespace std::placeholders;
   action_server_ = rclcpp_action::create_server<FollowJTrajAction>(

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -309,8 +309,6 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
   }
 
-  default_tolerances_ = getSegmentTolerances(lifecycle_node_, joint_names_);
-  
   // Store 'home' pose
   traj_msg_home_ptr_ = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
   traj_msg_home_ptr_->header.stamp.sec = 0;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -91,7 +91,7 @@ JointTrajectoryController::update()
   }
 
   auto resize_joint_trajectory_point =
-    [](trajectory_msgs::msg::JointTrajectoryPoint & point, int size)
+    [](trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size)
     {
       point.positions.resize(size);
       point.velocities.resize(size);
@@ -113,7 +113,7 @@ JointTrajectoryController::update()
     };
 
   JointTrajectoryPoint state_current, state_desired, state_error;
-  size_t joint_num = registered_joint_state_handles_.size();
+  auto joint_num = registered_joint_state_handles_.size();
   resize_joint_trajectory_point(state_current, joint_num);
 
   // current state update
@@ -343,7 +343,7 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
     state_publisher_period_ =
       rclcpp::Duration::from_seconds(1.0 / state_publish_rate);
   } else {
-    state_publisher_period_ = rclcpp::Duration(0.0);
+    state_publisher_period_ = rclcpp::Duration::from_seconds(0.0);
   }
 
   publisher_ = lifecycle_node_->create_publisher<ControllerStateMsg>(

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -359,38 +359,36 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
   // joint_command_subscriber_->on_activate();
 
   // State publisher
-  {
-    double state_publish_rate =
-      lifecycle_node_->get_parameter("state_publish_rate").get_value<double>();
-    RCLCPP_INFO_STREAM(
-      logger, "Controller state will be published at " <<
-        state_publish_rate << "Hz.");
-    if (state_publish_rate > 0.0) {
-      state_publisher_period_ =
-        rclcpp::Duration::from_seconds(1.0 / state_publish_rate);
-    } else {
-      state_publisher_period_ = rclcpp::Duration(0.0);
-    }
-
-    publisher_ = lifecycle_node_->create_publisher<ControllerStateMsg>(
-      "state", rclcpp::SystemDefaultsQoS());
-    state_publisher_.reset(new StatePublisher(publisher_));
-
-    int n_joints = joint_names_.size();
-
-    state_publisher_->lock();
-    state_publisher_->msg_.joint_names = joint_names_;
-    state_publisher_->msg_.desired.positions.resize(n_joints);
-    state_publisher_->msg_.desired.velocities.resize(n_joints);
-    state_publisher_->msg_.desired.accelerations.resize(n_joints);
-    state_publisher_->msg_.actual.positions.resize(n_joints);
-    state_publisher_->msg_.actual.velocities.resize(n_joints);
-    state_publisher_->msg_.error.positions.resize(n_joints);
-    state_publisher_->msg_.error.velocities.resize(n_joints);
-    state_publisher_->unlock();
-
-    last_state_publish_time_ = lifecycle_node_->now();
+  double state_publish_rate =
+    lifecycle_node_->get_parameter("state_publish_rate").get_value<double>();
+  RCLCPP_INFO_STREAM(
+    logger, "Controller state will be published at " <<
+      state_publish_rate << "Hz.");
+  if (state_publish_rate > 0.0) {
+    state_publisher_period_ =
+      rclcpp::Duration::from_seconds(1.0 / state_publish_rate);
+  } else {
+    state_publisher_period_ = rclcpp::Duration(0.0);
   }
+
+  publisher_ = lifecycle_node_->create_publisher<ControllerStateMsg>(
+    "state", rclcpp::SystemDefaultsQoS());
+  state_publisher_.reset(new StatePublisher(publisher_));
+
+  int n_joints = joint_names_.size();
+
+  state_publisher_->lock();
+  state_publisher_->msg_.joint_names = joint_names_;
+  state_publisher_->msg_.desired.positions.resize(n_joints);
+  state_publisher_->msg_.desired.velocities.resize(n_joints);
+  state_publisher_->msg_.desired.accelerations.resize(n_joints);
+  state_publisher_->msg_.actual.positions.resize(n_joints);
+  state_publisher_->msg_.actual.velocities.resize(n_joints);
+  state_publisher_->msg_.error.positions.resize(n_joints);
+  state_publisher_->msg_.error.velocities.resize(n_joints);
+  state_publisher_->unlock();
+
+  last_state_publish_time_ = lifecycle_node_->now();
 
   // action server configuration
   {

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -122,8 +122,9 @@ JointTrajectoryController::update()
 
     // find segment for current timestamp
     TrajectoryPointConstIter start_segment_itr, end_segment_itr;
-    bool valid_point = (*traj_point_active_ptr_)->sample(lifecycle_node_->now(), state_desired,
-        start_segment_itr, end_segment_itr);
+    bool valid_point = (*traj_point_active_ptr_)->sample(
+      lifecycle_node_->now(), state_desired,
+      start_segment_itr, end_segment_itr);
 
     auto compute_error_for_joint = [](JointTrajectoryPoint & error, int index,
         const JointTrajectoryPoint & current, const JointTrajectoryPoint & desired)
@@ -150,8 +151,9 @@ JointTrajectoryController::update()
 
         // check tolerances
         bool state_tolerance_ok =
-          checkStateTolerancePerJoint(state_error, index,
-            default_tolerances_.state_tolerance[index], false);
+          checkStateTolerancePerJoint(
+          state_error, index,
+          default_tolerances_.state_tolerance[index], false);
 
         if (!state_tolerance_ok) {
           abort = true;
@@ -186,8 +188,9 @@ JointTrajectoryController::update()
 
         compute_error_for_joint(state_error, index, state_current, state_desired);
 
-        if (!checkStateTolerancePerJoint(state_error, index,
-          default_tolerances_.goal_state_tolerance[index], false))
+        if (!checkStateTolerancePerJoint(
+            state_error, index,
+            default_tolerances_.goal_state_tolerance[index], false))
         {
           outside_goal_tolerance = true;
           break;
@@ -214,7 +217,8 @@ JointTrajectoryController::update()
             result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
             rt_active_goal_->setAborted(result);
             rt_active_goal_.reset();
-            RCLCPP_WARN(lifecycle_node_->get_logger(),
+            RCLCPP_WARN(
+              lifecycle_node_->get_logger(),
               "Aborted due goal_time_tolerance exceeding by %f seconds",
               difference);
           }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -310,8 +310,7 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
   }
 
   default_tolerances_ = getSegmentTolerances(lifecycle_node_, joint_names_);
-  RCLCPP_INFO(lifecycle_node_->get_logger(), "tol: %f", default_tolerances_.goal_time_tolerance);
-
+  
   // Store 'home' pose
   traj_msg_home_ptr_ = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
   traj_msg_home_ptr_->header.stamp.sec = 0;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -370,7 +370,7 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
   allow_partial_joints_goal_ = lifecycle_node_->get_parameter("allow_partial_joints_goal")
     .get_value<bool>();
   if (allow_partial_joints_goal_) {
-    // TODO(ddengster): implement partial joints, log an enabled partial joints goal message
+    // TODO(ddengster): implement partial joints, log an enabled partial joints goal message https://github.com/ros-controls/ros2_controllers/issues/37
     RCLCPP_WARN(logger, "Warning: Goals with partial set of joints not implemented yet.");
   }
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -14,14 +14,14 @@
 
 #include "joint_trajectory_controller/joint_trajectory_controller.hpp"
 
-#include <angles/angles.h>
-
 #include <cassert>
 #include <chrono>
 #include <iterator>
 #include <string>
 #include <memory>
 #include <vector>
+
+#include "angles/angles.h"
 
 #include "builtin_interfaces/msg/time.hpp"
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -73,7 +73,8 @@ JointTrajectoryController::init(
   lifecycle_node_->declare_parameter<double>("state_publish_rate", 50.0);
   lifecycle_node_->declare_parameter<double>("action_monitor_rate", 20.0);
   lifecycle_node_->declare_parameter<bool>("allow_partial_joints_goal", allow_partial_joints_goal_);
-  declareSegmentTolerances(lifecycle_node_);
+  lifecycle_node_->declare_parameter<double>("constraints.stopped_velocity_tolerance", 0.01);
+  lifecycle_node_->declare_parameter<double>("constraints.goal_time", 0.0);
 
   return CONTROLLER_INTERFACE_RET_SUCCESS;
 }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -309,6 +309,9 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
   }
 
+  default_tolerances_ = getSegmentTolerances(lifecycle_node_, joint_names_);
+  RCLCPP_INFO(lifecycle_node_->get_logger(), "tol: %f", default_tolerances_.goal_time_tolerance);
+
   // Store 'home' pose
   traj_msg_home_ptr_ = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
   traj_msg_home_ptr_->header.stamp.sec = 0;
@@ -342,7 +345,6 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State & previous
       // http://wiki.ros.org/joint_trajectory_controller/UnderstandingTrajectoryReplacement
       // always replace old msg with new one for now
       if (subscriber_is_active_) {
-        std::lock_guard<std::mutex> guard(trajectory_mtx_);
         traj_external_point_ptr_->update(msg);
       }
     };

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -17,61 +17,153 @@
 #include <memory>
 
 #include "hardware_interface/macros.hpp"
-#include "hardware_interface/utils/time_utils.hpp"
 
 #include "rclcpp/clock.hpp"
+#include "rclcpp/logging.hpp"
 
 namespace joint_trajectory_controller
 {
 
-// TODO(karsten1987): Fix to rclcpp time when API stable.
-using hardware_interface::utils::time_is_zero;
-using hardware_interface::utils::time_less_than_equal;
-using hardware_interface::utils::time_add;
-using hardware_interface::utils::time_less_than;
-
 Trajectory::Trajectory()
-: trajectory_start_time_(0)
+: trajectory_start_time_(0), time_before_traj_msg_(0)
 {}
 
-Trajectory::Trajectory(std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory)
+Trajectory::Trajectory(
+    std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory)
 : trajectory_msg_(joint_trajectory),
-  trajectory_start_time_(time_is_zero(joint_trajectory->header.stamp) ?
-    rclcpp::Clock().now() :
-    static_cast<rclcpp::Time>(joint_trajectory->header.stamp))
-{}
+  trajectory_start_time_(static_cast<rclcpp::Time>(joint_trajectory->header.stamp))
+{
+}
+
+Trajectory::Trajectory(
+  const rclcpp::Time & current_time,
+  const trajectory_msgs::msg::JointTrajectoryPoint& current_point,
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory)
+: trajectory_msg_(joint_trajectory),
+  trajectory_start_time_(static_cast<rclcpp::Time>(joint_trajectory->header.stamp))
+{
+  set_point_before_traj(current_time, current_point);
+}
+
+void
+Trajectory::set_point_before_traj(
+    const rclcpp::Time & current_time,
+    const trajectory_msgs::msg::JointTrajectoryPoint& current_point)
+{
+  time_before_traj_msg_ = current_time;
+  state_before_traj_msg_ = current_point;  
+}
 
 void
 Trajectory::update(std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory)
 {
   trajectory_msg_ = joint_trajectory;
-  trajectory_start_time_ = (time_is_zero(joint_trajectory->header.stamp) ?
-    rclcpp::Clock().now() :
-    static_cast<rclcpp::Time>(joint_trajectory->header.stamp));
+  trajectory_start_time_ = static_cast<rclcpp::Time>(joint_trajectory->header.stamp);
+  sampled_already_ = false;
 }
 
-TrajectoryPointConstIter
-Trajectory::sample(const rclcpp::Time & sample_time)
+void
+Trajectory::sample(const rclcpp::Time & sample_time,
+  trajectory_msgs::msg::JointTrajectoryPoint& expected_state,
+  TrajectoryPointConstIter& start_segment_itr, 
+  TrajectoryPointConstIter& end_segment_itr)
 {
   THROW_ON_NULLPTR(trajectory_msg_)
-
-  // skip if current time hasn't reached traj time of the first msg yet
-  if (sample_time < trajectory_start_time_) {
-    return end();
+  
+  if (trajectory_msg_->points.empty())
+  {
+    start_segment_itr = end();
+    end_segment_itr = end();
+    return;
   }
 
-  // time_from_start + trajectory time is the expected arrival time of trajectory
-  for (auto point = begin(); point != end(); ++point) {
-    rclcpp::Duration duration_from_start(point->time_from_start.sec, point->time_from_start.nanosec);
-    rclcpp::Time start_time = trajectory_start_time_ + duration_from_start;
-    if (sample_time < start_time) {
+  // first sampling of this trajectory
+  if (!sampled_already_)
+  {
+    if (trajectory_start_time_.seconds() == 0.0)
+      trajectory_start_time_ = sample_time;
 
-      // TODO(ddengster) : replace with interpolated point
-      return point;
+    sampled_already_ = true;
+  }
+
+  auto linear_interpolation = [&](
+    const rclcpp::Time& time_a, const trajectory_msgs::msg::JointTrajectoryPoint& state_a, 
+    const rclcpp::Time& time_b, const trajectory_msgs::msg::JointTrajectoryPoint& state_b, 
+    const rclcpp::Time& sample_time,
+    trajectory_msgs::msg::JointTrajectoryPoint& output)
+  {
+    rclcpp::Duration duration_so_far = sample_time - time_a;
+    rclcpp::Duration duration_btwn_points = time_b - time_a;
+    double percent = duration_so_far.seconds() / duration_btwn_points.seconds();
+    percent = percent > 1.0 ? 1.0 : percent;
+    percent = percent < 0.0 ? 0.0 : percent;
+    
+    output.positions.resize(state_a.positions.size());
+    for (uint i=0; i<state_a.positions.size(); ++i)
+    {
+      output.positions[i] =
+        state_a.positions[i] + percent * (state_b.positions[i] - state_a.positions[i]);
+    }
+
+    if (!state_a.velocities.empty() && !state_b.velocities.empty()) {
+      output.velocities.resize(state_b.velocities.size());
+      for (uint i=0; i<state_b.velocities.size(); ++i)
+      {
+        output.velocities[i] =
+          state_a.velocities[i] + percent * (state_b.velocities[i] - state_a.velocities[i]);
+      }
+    }
+
+    if (!state_a.accelerations.empty() && !state_b.accelerations.empty()) {
+      output.accelerations.resize(state_b.accelerations.size());
+      for (uint i=0; i<state_b.accelerations.size(); ++i)
+      {
+        output.accelerations[i] =
+          state_a.accelerations[i] + percent * (state_b.accelerations[i] - state_a.accelerations[i]);
+      }
+    }
+  };
+
+  // current time hasn't reached traj time of the first msg yet
+  const auto& first_point_in_msg = trajectory_msg_->points[0];
+  rclcpp::Duration offset(first_point_in_msg.time_from_start.sec, first_point_in_msg.time_from_start.nanosec);
+  rclcpp::Time first_point_timestamp = trajectory_start_time_ + offset;
+  if (sample_time < first_point_timestamp) {
+    rclcpp::Time t0 = time_before_traj_msg_;
+    
+    linear_interpolation(t0, state_before_traj_msg_, first_point_timestamp, first_point_in_msg, sample_time, expected_state);
+    start_segment_itr = begin(); //no segments before the first
+    end_segment_itr = begin();
+    return;
+  }
+  
+  // time_from_start + trajectory time is the expected arrival time of trajectory
+  uint last_idx = trajectory_msg_->points.size() - 1;
+  for (uint i=0; i<last_idx; ++i) {
+    auto& point = trajectory_msg_->points[i];
+    auto& next_point = trajectory_msg_->points[i + 1];
+
+    rclcpp::Duration t0_offset(point.time_from_start.sec, point.time_from_start.nanosec);
+    rclcpp::Duration t1_offset(next_point.time_from_start.sec, next_point.time_from_start.nanosec);
+    rclcpp::Time t0 = trajectory_start_time_ + t0_offset;
+    rclcpp::Time t1 = trajectory_start_time_ + t1_offset;
+
+    if (sample_time >= t0 && sample_time < t1) {
+      // TODO (ddengster): Find a way to add custom interpolation implementations. 
+      // Likely a lambda + parameters supplied from the controller would do
+      // do simple linear interpolation for now
+      // reference: https://github.com/ros-controls/ros_controllers/blob/melodic-devel/joint_trajectory_controller/include/trajectory_interface/quintic_spline_segment.h#L84
+      linear_interpolation(t0, point, t1, next_point, sample_time, expected_state);
+      start_segment_itr = begin() + i;
+      end_segment_itr = begin() + (i + 1);
+      return;
     }
   }
 
-  return end();
+  // whole animation has played out
+  start_segment_itr = --end();
+  end_segment_itr = end();
+  expected_state = (*start_segment_itr);
 }
 
 TrajectoryPointConstIter

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -130,7 +130,8 @@ Trajectory::sample(
   if (sample_time < first_point_timestamp) {
     rclcpp::Time t0 = time_before_traj_msg_;
 
-    linear_interpolation(t0, state_before_traj_msg_, first_point_timestamp, first_point_in_msg,
+    linear_interpolation(
+      t0, state_before_traj_msg_, first_point_timestamp, first_point_in_msg,
       sample_time, expected_state);
     start_segment_itr = begin();  // no segments before the first
     end_segment_itr = begin();

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -42,11 +42,11 @@ Trajectory::Trajectory(
 : trajectory_msg_(joint_trajectory),
   trajectory_start_time_(static_cast<rclcpp::Time>(joint_trajectory->header.stamp))
 {
-  set_point_before_traj(current_time, current_point);
+  set_point_before_trajectory_msg(current_time, current_point);
 }
 
 void
-Trajectory::set_point_before_traj(
+Trajectory::set_point_before_trajectory_msg(
   const rclcpp::Time & current_time,
   const trajectory_msgs::msg::JointTrajectoryPoint & current_point)
 {
@@ -190,7 +190,7 @@ Trajectory::time_from_start() const
 }
 
 bool
-Trajectory::has_traj_msg() const
+Trajectory::has_trajectory_msg() const
 {
   return !trajectory_msg_;
 }

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -29,7 +29,7 @@ Trajectory::Trajectory()
 {}
 
 Trajectory::Trajectory(
-    std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory)
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory)
 : trajectory_msg_(joint_trajectory),
   trajectory_start_time_(static_cast<rclcpp::Time>(joint_trajectory->header.stamp))
 {
@@ -37,7 +37,7 @@ Trajectory::Trajectory(
 
 Trajectory::Trajectory(
   const rclcpp::Time & current_time,
-  const trajectory_msgs::msg::JointTrajectoryPoint& current_point,
+  const trajectory_msgs::msg::JointTrajectoryPoint & current_point,
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_trajectory)
 : trajectory_msg_(joint_trajectory),
   trajectory_start_time_(static_cast<rclcpp::Time>(joint_trajectory->header.stamp))
@@ -47,11 +47,11 @@ Trajectory::Trajectory(
 
 void
 Trajectory::set_point_before_traj(
-    const rclcpp::Time & current_time,
-    const trajectory_msgs::msg::JointTrajectoryPoint& current_point)
+  const rclcpp::Time & current_time,
+  const trajectory_msgs::msg::JointTrajectoryPoint & current_point)
 {
   time_before_traj_msg_ = current_time;
-  state_before_traj_msg_ = current_point;  
+  state_before_traj_msg_ = current_point;
 }
 
 void
@@ -63,85 +63,85 @@ Trajectory::update(std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_
 }
 
 bool
-Trajectory::sample(const rclcpp::Time & sample_time,
-  trajectory_msgs::msg::JointTrajectoryPoint& expected_state,
-  TrajectoryPointConstIter& start_segment_itr, 
-  TrajectoryPointConstIter& end_segment_itr)
+Trajectory::sample(
+  const rclcpp::Time & sample_time,
+  trajectory_msgs::msg::JointTrajectoryPoint & expected_state,
+  TrajectoryPointConstIter & start_segment_itr,
+  TrajectoryPointConstIter & end_segment_itr)
 {
   THROW_ON_NULLPTR(trajectory_msg_)
-  
-  if (trajectory_msg_->points.empty())
-  {
+
+  if (trajectory_msg_->points.empty()) {
     start_segment_itr = end();
     end_segment_itr = end();
     return false;
   }
 
   // first sampling of this trajectory
-  if (!sampled_already_)
-  {
-    if (trajectory_start_time_.seconds() == 0.0)
+  if (!sampled_already_) {
+    if (trajectory_start_time_.seconds() == 0.0) {
       trajectory_start_time_ = sample_time;
+    }
 
     sampled_already_ = true;
   }
 
   auto linear_interpolation = [&](
-    const rclcpp::Time& time_a, const trajectory_msgs::msg::JointTrajectoryPoint& state_a, 
-    const rclcpp::Time& time_b, const trajectory_msgs::msg::JointTrajectoryPoint& state_b, 
-    const rclcpp::Time& sample_time,
-    trajectory_msgs::msg::JointTrajectoryPoint& output)
-  {
-    rclcpp::Duration duration_so_far = sample_time - time_a;
-    rclcpp::Duration duration_btwn_points = time_b - time_a;
-    double percent = duration_so_far.seconds() / duration_btwn_points.seconds();
-    percent = percent > 1.0 ? 1.0 : percent;
-    percent = percent < 0.0 ? 0.0 : percent;
-    
-    output.positions.resize(state_a.positions.size());
-    for (uint i=0; i<state_a.positions.size(); ++i)
+    const rclcpp::Time & time_a, const trajectory_msgs::msg::JointTrajectoryPoint & state_a,
+    const rclcpp::Time & time_b, const trajectory_msgs::msg::JointTrajectoryPoint & state_b,
+    const rclcpp::Time & sample_time,
+    trajectory_msgs::msg::JointTrajectoryPoint & output)
     {
-      output.positions[i] =
-        state_a.positions[i] + percent * (state_b.positions[i] - state_a.positions[i]);
-    }
+      rclcpp::Duration duration_so_far = sample_time - time_a;
+      rclcpp::Duration duration_btwn_points = time_b - time_a;
+      double percent = duration_so_far.seconds() / duration_btwn_points.seconds();
+      percent = percent > 1.0 ? 1.0 : percent;
+      percent = percent < 0.0 ? 0.0 : percent;
 
-    if (!state_a.velocities.empty() && !state_b.velocities.empty()) {
-      output.velocities.resize(state_b.velocities.size());
-      for (uint i=0; i<state_b.velocities.size(); ++i)
-      {
-        output.velocities[i] =
-          state_a.velocities[i] + percent * (state_b.velocities[i] - state_a.velocities[i]);
+      output.positions.resize(state_a.positions.size());
+      for (uint i = 0; i < state_a.positions.size(); ++i) {
+        output.positions[i] =
+          state_a.positions[i] + percent * (state_b.positions[i] - state_a.positions[i]);
       }
-    }
 
-    if (!state_a.accelerations.empty() && !state_b.accelerations.empty()) {
-      output.accelerations.resize(state_b.accelerations.size());
-      for (uint i=0; i<state_b.accelerations.size(); ++i)
-      {
-        output.accelerations[i] =
-          state_a.accelerations[i] + percent * (state_b.accelerations[i] - state_a.accelerations[i]);
+      if (!state_a.velocities.empty() && !state_b.velocities.empty()) {
+        output.velocities.resize(state_b.velocities.size());
+        for (uint i = 0; i < state_b.velocities.size(); ++i) {
+          output.velocities[i] =
+            state_a.velocities[i] + percent * (state_b.velocities[i] - state_a.velocities[i]);
+        }
       }
-    }
-  };
+
+      if (!state_a.accelerations.empty() && !state_b.accelerations.empty()) {
+        output.accelerations.resize(state_b.accelerations.size());
+        for (uint i = 0; i < state_b.accelerations.size(); ++i) {
+          output.accelerations[i] =
+            state_a.accelerations[i] + percent *
+            (state_b.accelerations[i] - state_a.accelerations[i]);
+        }
+      }
+    };
 
   // current time hasn't reached traj time of the first msg yet
-  const auto& first_point_in_msg = trajectory_msg_->points[0];
-  rclcpp::Duration offset(first_point_in_msg.time_from_start.sec, first_point_in_msg.time_from_start.nanosec);
+  const auto & first_point_in_msg = trajectory_msg_->points[0];
+  rclcpp::Duration offset(first_point_in_msg.time_from_start.sec,
+    first_point_in_msg.time_from_start.nanosec);
   rclcpp::Time first_point_timestamp = trajectory_start_time_ + offset;
   if (sample_time < first_point_timestamp) {
     rclcpp::Time t0 = time_before_traj_msg_;
-    
-    linear_interpolation(t0, state_before_traj_msg_, first_point_timestamp, first_point_in_msg, sample_time, expected_state);
-    start_segment_itr = begin(); //no segments before the first
+
+    linear_interpolation(t0, state_before_traj_msg_, first_point_timestamp, first_point_in_msg,
+      sample_time, expected_state);
+    start_segment_itr = begin();  // no segments before the first
     end_segment_itr = begin();
     return true;
   }
-  
+
   // time_from_start + trajectory time is the expected arrival time of trajectory
   uint last_idx = trajectory_msg_->points.size() - 1;
-  for (uint i=0; i<last_idx; ++i) {
-    auto& point = trajectory_msg_->points[i];
-    auto& next_point = trajectory_msg_->points[i + 1];
+  for (uint i = 0; i < last_idx; ++i) {
+    auto & point = trajectory_msg_->points[i];
+    auto & next_point = trajectory_msg_->points[i + 1];
 
     rclcpp::Duration t0_offset(point.time_from_start.sec, point.time_from_start.nanosec);
     rclcpp::Duration t1_offset(next_point.time_from_start.sec, next_point.time_from_start.nanosec);
@@ -149,7 +149,7 @@ Trajectory::sample(const rclcpp::Time & sample_time,
     rclcpp::Time t1 = trajectory_start_time_ + t1_offset;
 
     if (sample_time >= t0 && sample_time < t1) {
-      // TODO (ddengster): Find a way to add custom interpolation implementations. 
+      // TODO(ddengster): Find a way to add custom interpolation implementations.
       // Likely a lambda + parameters supplied from the controller would do
       // do simple linear interpolation for now
       // reference: https://github.com/ros-controls/ros_controllers/blob/melodic-devel/joint_trajectory_controller/include/trajectory_interface/quintic_spline_segment.h#L84

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -144,8 +144,8 @@ Trajectory::sample(
     auto & point = trajectory_msg_->points[i];
     auto & next_point = trajectory_msg_->points[i + 1];
 
-    rclcpp::Duration t0_offset(point.time_from_start.sec, point.time_from_start.nanosec);
-    rclcpp::Duration t1_offset(next_point.time_from_start.sec, next_point.time_from_start.nanosec);
+    rclcpp::Duration t0_offset = point.time_from_start;
+    rclcpp::Duration t1_offset = next_point.time_from_start;
     rclcpp::Time t0 = trajectory_start_time_ + t0_offset;
     rclcpp::Time t1 = trajectory_start_time_ + t1_offset;
 

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -99,14 +99,14 @@ Trajectory::sample(
       percent = percent < 0.0 ? 0.0 : percent;
 
       output.positions.resize(state_a.positions.size());
-      for (uint i = 0; i < state_a.positions.size(); ++i) {
+      for (auto i = 0ul; i < state_a.positions.size(); ++i) {
         output.positions[i] =
           state_a.positions[i] + percent * (state_b.positions[i] - state_a.positions[i]);
       }
 
       if (!state_a.velocities.empty() && !state_b.velocities.empty()) {
         output.velocities.resize(state_b.velocities.size());
-        for (uint i = 0; i < state_b.velocities.size(); ++i) {
+        for (auto i = 0ul; i < state_b.velocities.size(); ++i) {
           output.velocities[i] =
             state_a.velocities[i] + percent * (state_b.velocities[i] - state_a.velocities[i]);
         }
@@ -114,7 +114,7 @@ Trajectory::sample(
 
       if (!state_a.accelerations.empty() && !state_b.accelerations.empty()) {
         output.accelerations.resize(state_b.accelerations.size());
-        for (uint i = 0; i < state_b.accelerations.size(); ++i) {
+        for (auto i = 0ul; i < state_b.accelerations.size(); ++i) {
           output.accelerations[i] =
             state_a.accelerations[i] + percent *
             (state_b.accelerations[i] - state_a.accelerations[i]);
@@ -139,8 +139,8 @@ Trajectory::sample(
   }
 
   // time_from_start + trajectory time is the expected arrival time of trajectory
-  uint last_idx = trajectory_msg_->points.size() - 1;
-  for (uint i = 0; i < last_idx; ++i) {
+  auto last_idx = trajectory_msg_->points.size() - 1;
+  for (auto i = 0ul; i < last_idx; ++i) {
     auto & point = trajectory_msg_->points[i];
     auto & next_point = trajectory_msg_->points[i + 1];
 

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -56,14 +56,17 @@ Trajectory::sample(const rclcpp::Time & sample_time)
   THROW_ON_NULLPTR(trajectory_msg_)
 
   // skip if current time hasn't reached traj time of the first msg yet
-  if (time_less_than(sample_time, trajectory_start_time_)) {
+  if (sample_time < trajectory_start_time_) {
     return end();
   }
 
   // time_from_start + trajectory time is the expected arrival time of trajectory
   for (auto point = begin(); point != end(); ++point) {
-    auto start_time = time_add(trajectory_start_time_, point->time_from_start);
-    if (time_less_than(sample_time, start_time)) {
+    rclcpp::Duration duration_from_start(point->time_from_start.sec, point->time_from_start.nanosec);
+    rclcpp::Time start_time = trajectory_start_time_ + duration_from_start;
+    if (sample_time < start_time) {
+
+      // TODO(ddengster) : replace with interpolated point
       return point;
     }
   }

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -124,8 +124,7 @@ Trajectory::sample(
 
   // current time hasn't reached traj time of the first msg yet
   const auto & first_point_in_msg = trajectory_msg_->points[0];
-  rclcpp::Duration offset(first_point_in_msg.time_from_start.sec,
-    first_point_in_msg.time_from_start.nanosec);
+  rclcpp::Duration offset = first_point_in_msg.time_from_start;
   rclcpp::Time first_point_timestamp = trajectory_start_time_ + offset;
   if (sample_time < first_point_timestamp) {
     rclcpp::Time t0 = time_before_traj_msg_;

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -62,7 +62,7 @@ Trajectory::update(std::shared_ptr<trajectory_msgs::msg::JointTrajectory> joint_
   sampled_already_ = false;
 }
 
-void
+bool
 Trajectory::sample(const rclcpp::Time & sample_time,
   trajectory_msgs::msg::JointTrajectoryPoint& expected_state,
   TrajectoryPointConstIter& start_segment_itr, 
@@ -74,7 +74,7 @@ Trajectory::sample(const rclcpp::Time & sample_time,
   {
     start_segment_itr = end();
     end_segment_itr = end();
-    return;
+    return false;
   }
 
   // first sampling of this trajectory
@@ -134,7 +134,7 @@ Trajectory::sample(const rclcpp::Time & sample_time,
     linear_interpolation(t0, state_before_traj_msg_, first_point_timestamp, first_point_in_msg, sample_time, expected_state);
     start_segment_itr = begin(); //no segments before the first
     end_segment_itr = begin();
-    return;
+    return true;
   }
   
   // time_from_start + trajectory time is the expected arrival time of trajectory
@@ -156,7 +156,7 @@ Trajectory::sample(const rclcpp::Time & sample_time,
       linear_interpolation(t0, point, t1, next_point, sample_time, expected_state);
       start_segment_itr = begin() + i;
       end_segment_itr = begin() + (i + 1);
-      return;
+      return true;
     }
   }
 
@@ -164,6 +164,7 @@ Trajectory::sample(const rclcpp::Time & sample_time,
   start_segment_itr = --end();
   end_segment_itr = end();
   expected_state = (*start_segment_itr);
+  return true;
 }
 
 TrajectoryPointConstIter
@@ -189,7 +190,7 @@ Trajectory::time_from_start() const
 }
 
 bool
-Trajectory::is_empty() const
+Trajectory::has_traj_msg() const
 {
   return !trajectory_msg_;
 }

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -109,7 +109,7 @@ TEST_F(TestTrajectory, sample_trajectory) {
   current_point.accelerations.push_back(0.0);
 
   rclcpp::Time time_now = rclcpp::Clock().now();
-  traj.set_point_before_traj(time_now, current_point);
+  traj.set_point_before_trajectory_msg(time_now, current_point);
 
   trajectory_msgs::msg::JointTrajectoryPoint expected_state;
   joint_trajectory_controller::TrajectoryPointConstIter start, end;

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -40,7 +40,13 @@ TEST_F(TestTrajectory, initialize_trajectory) {
     empty_msg->header.stamp.nanosec = 2;
     rclcpp::Time empty_time = empty_msg->header.stamp;
     auto traj = joint_trajectory_controller::Trajectory(empty_msg);
-    EXPECT_EQ(traj.end(), traj.sample(rclcpp::Clock().now()));
+
+    trajectory_msgs::msg::JointTrajectoryPoint expected_point;
+    joint_trajectory_controller::TrajectoryPointConstIter start, end;
+    traj.sample(rclcpp::Clock().now(), expected_point, start, end);
+    
+    EXPECT_EQ(traj.end(), start);
+    EXPECT_EQ(traj.end(), end);
     EXPECT_EQ(empty_time, traj.time_from_start());
   }
   {
@@ -50,7 +56,13 @@ TEST_F(TestTrajectory, initialize_trajectory) {
     auto now = rclcpp::Clock().now();
     auto traj = joint_trajectory_controller::Trajectory(empty_msg);
     auto traj_starttime = traj.time_from_start();
-    EXPECT_EQ(traj.end(), traj.sample(rclcpp::Clock().now()));
+
+    trajectory_msgs::msg::JointTrajectoryPoint expected_point;
+    joint_trajectory_controller::TrajectoryPointConstIter start, end;
+    traj.sample(rclcpp::Clock().now(), expected_point, start, end);
+
+    EXPECT_EQ(traj.end(), start);
+    EXPECT_EQ(traj.end(), end);
     auto allowed_delta = 10000ll;
     EXPECT_LT(traj.time_from_start().nanoseconds() - now.nanoseconds(), allowed_delta);
   }
@@ -63,101 +75,80 @@ TEST_F(TestTrajectory, sample_trajectory) {
 
   trajectory_msgs::msg::JointTrajectoryPoint p1;
   p1.positions.push_back(1.0f);
-  builtin_interfaces::msg::Duration d1;
-  d1.sec = 1;
-  d1.nanosec = 0;
-  p1.time_from_start = d1;
+  p1.velocities.push_back(0.0f);
+  p1.accelerations.push_back(0.0f);
+  p1.time_from_start.sec = 1;
+  p1.time_from_start.nanosec = 0;
 
   trajectory_msgs::msg::JointTrajectoryPoint p2;
   p2.positions.push_back(2.0f);
-  builtin_interfaces::msg::Duration d2;
-  d2.sec = 2;
-  d2.nanosec = 0;
-  p2.time_from_start = d2;
+  p2.velocities.push_back(0.0f);
+  p2.accelerations.push_back(0.0f);
+  p2.time_from_start.sec = 2;
+  p2.time_from_start.nanosec = 0;
 
   trajectory_msgs::msg::JointTrajectoryPoint p3;
   p3.positions.push_back(3.0f);
-  builtin_interfaces::msg::Duration d3;
-  d3.sec = 3;
-  d3.nanosec = 0;
-  p3.time_from_start = d3;
+  p3.velocities.push_back(0.0f);
+  p3.accelerations.push_back(0.0f);
+  p3.time_from_start.sec = 3;
+  p3.time_from_start.nanosec = 0;
 
   full_msg->points.push_back(p1);
   full_msg->points.push_back(p2);
   full_msg->points.push_back(p3);
 
+  // set current state before trajectory msg was sent
   auto traj = joint_trajectory_controller::Trajectory(full_msg);
 
-  auto sample_p1 = traj.sample(rclcpp::Clock().now());
-  ASSERT_NE(traj.end(), sample_p1);
-  EXPECT_EQ(1.0f, sample_p1->positions[0]);
+  trajectory_msgs::msg::JointTrajectoryPoint current_point;
+  current_point.time_from_start.sec = 0;
+  current_point.time_from_start.nanosec = 0;
+  current_point.positions.push_back(0.0);
+  current_point.velocities.push_back(0.0);
+  current_point.accelerations.push_back(0.0);
 
-  auto sample_p11 = traj.sample(rclcpp::Clock().now());
-  ASSERT_NE(traj.end(), sample_p11);
-  EXPECT_EQ(1.0f, sample_p11->positions[0]);
+  rclcpp::Time time_now = rclcpp::Clock().now();
+  traj.set_point_before_traj(time_now, current_point);
 
-  std::this_thread::sleep_for(1s);
+  trajectory_msgs::msg::JointTrajectoryPoint expected_state;
+  joint_trajectory_controller::TrajectoryPointConstIter start, end;
+  traj.sample(time_now, expected_state, start, end);
 
-  auto sample_p2 = traj.sample(rclcpp::Clock().now());
-  ASSERT_NE(traj.end(), sample_p1);
-  EXPECT_EQ(2.0f, sample_p2->positions[0]);
+  ASSERT_EQ(traj.begin(), start);
+  ASSERT_EQ(traj.begin(), end);
+  EXPECT_EQ(0.0f, expected_state.positions[0]);
 
-  auto sample_p22 = traj.sample(rclcpp::Clock().now());
-  ASSERT_NE(traj.end(), sample_p22);
-  EXPECT_EQ(2.0f, sample_p22->positions[0]);
+  //sample before trajectory starts
+  traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
+  ASSERT_EQ(traj.begin(), start);
+  ASSERT_EQ(traj.begin(), end);
+  EXPECT_EQ(0.0f, expected_state.positions[0]);
 
-  std::this_thread::sleep_for(1s);
+  traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
+  ASSERT_EQ(traj.begin(), start);
+  ASSERT_EQ(traj.begin(), end);
+  EXPECT_EQ(0.5f, expected_state.positions[0]);
 
-  auto sample_p3 = traj.sample(rclcpp::Clock().now());
-  ASSERT_NE(traj.end(), sample_p1);
-  EXPECT_EQ(3.0f, sample_p3->positions[0]);
+  traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
+  ASSERT_EQ(traj.begin(), start);
+  ASSERT_EQ((++traj.begin()), end);
+  EXPECT_EQ(1.0f, expected_state.positions[0]);
 
-  auto sample_p33 = traj.sample(rclcpp::Clock().now());
-  ASSERT_NE(traj.end(), sample_p33);
-  EXPECT_EQ(3.0f, sample_p33->positions[0]);
+  traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), expected_state, start, end);
+  ASSERT_EQ(traj.begin(), start);
+  ASSERT_EQ((++traj.begin()), end);
+  EXPECT_EQ(1.5f, expected_state.positions[0]);
 
-  std::this_thread::sleep_for(1s);
+  traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), expected_state, start, end);
+  EXPECT_EQ(2.5f, expected_state.positions[0]);
 
-  auto sample_end = traj.sample(rclcpp::Clock().now());
-  EXPECT_EQ(traj.end(), sample_end);
+  traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), expected_state, start, end);
+  EXPECT_EQ(3.0f, expected_state.positions[0]);
 
-  auto sample_end_end = traj.sample(rclcpp::Clock().now());
-  EXPECT_EQ(traj.end(), sample_end_end);
-}
-
-TEST_F(TestTrajectory, future_sample_trajectory) {
-  auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
-  full_msg->header.stamp = rclcpp::Clock().now();
-  full_msg->header.stamp.sec += 2;  // extra padding
-
-  trajectory_msgs::msg::JointTrajectoryPoint p1;
-  p1.positions.push_back(1.0f);
-  builtin_interfaces::msg::Duration d1;
-  d1.sec = 1;
-  d1.nanosec = 0;
-  p1.time_from_start = d1;
-
-  trajectory_msgs::msg::JointTrajectoryPoint p2;
-  p2.positions.push_back(2.0f);
-  builtin_interfaces::msg::Duration d2;
-  d2.sec = 2;
-  d2.nanosec = 0;
-  p2.time_from_start = d2;
-
-  trajectory_msgs::msg::JointTrajectoryPoint p3;
-  p3.positions.push_back(3.0f);
-  builtin_interfaces::msg::Duration d3;
-  d3.sec = 3;
-  d3.nanosec = 0;
-  p3.time_from_start = d3;
-
-  full_msg->points.push_back(p1);
-  full_msg->points.push_back(p2);
-  full_msg->points.push_back(p3);
-
-  auto traj = joint_trajectory_controller::Trajectory(full_msg);
-
-  // sample for future point
-  auto sample_p0 = traj.sample(rclcpp::Clock().now());
-  ASSERT_EQ(traj.end(), sample_p0);
+  // sample past given points
+  traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), expected_state, start, end);
+  ASSERT_EQ((--traj.end()), start);
+  ASSERT_EQ(traj.end(), end);
+  EXPECT_EQ(3.0f, expected_state.positions[0]);
 }

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -74,23 +74,23 @@ TEST_F(TestTrajectory, sample_trajectory) {
   full_msg->header.stamp.nanosec = 0;
 
   trajectory_msgs::msg::JointTrajectoryPoint p1;
-  p1.positions.push_back(1.0f);
-  p1.velocities.push_back(0.0f);
-  p1.accelerations.push_back(0.0f);
+  p1.positions.push_back(1.0);
+  p1.velocities.push_back(0.0);
+  p1.accelerations.push_back(0.0);
   p1.time_from_start.sec = 1;
   p1.time_from_start.nanosec = 0;
 
   trajectory_msgs::msg::JointTrajectoryPoint p2;
-  p2.positions.push_back(2.0f);
-  p2.velocities.push_back(0.0f);
-  p2.accelerations.push_back(0.0f);
+  p2.positions.push_back(2.0);
+  p2.velocities.push_back(0.0);
+  p2.accelerations.push_back(0.0);
   p2.time_from_start.sec = 2;
   p2.time_from_start.nanosec = 0;
 
   trajectory_msgs::msg::JointTrajectoryPoint p3;
-  p3.positions.push_back(3.0f);
-  p3.velocities.push_back(0.0f);
-  p3.accelerations.push_back(0.0f);
+  p3.positions.push_back(3.0);
+  p3.velocities.push_back(0.0);
+  p3.accelerations.push_back(0.0);
   p3.time_from_start.sec = 3;
   p3.time_from_start.nanosec = 0;
 
@@ -117,38 +117,38 @@ TEST_F(TestTrajectory, sample_trajectory) {
 
   ASSERT_EQ(traj.begin(), start);
   ASSERT_EQ(traj.begin(), end);
-  EXPECT_EQ(0.0f, expected_state.positions[0]);
+  EXPECT_EQ(0.0, expected_state.positions[0]);
 
   // sample before trajectory starts
   traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
   ASSERT_EQ(traj.begin(), start);
   ASSERT_EQ(traj.begin(), end);
-  EXPECT_EQ(0.0f, expected_state.positions[0]);
+  EXPECT_EQ(0.0, expected_state.positions[0]);
 
   traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
   ASSERT_EQ(traj.begin(), start);
   ASSERT_EQ(traj.begin(), end);
-  EXPECT_EQ(0.5f, expected_state.positions[0]);
+  EXPECT_EQ(0.5, expected_state.positions[0]);
 
   traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
   ASSERT_EQ(traj.begin(), start);
   ASSERT_EQ((++traj.begin()), end);
-  EXPECT_EQ(1.0f, expected_state.positions[0]);
+  EXPECT_EQ(1.0, expected_state.positions[0]);
 
   traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), expected_state, start, end);
   ASSERT_EQ(traj.begin(), start);
   ASSERT_EQ((++traj.begin()), end);
-  EXPECT_EQ(1.5f, expected_state.positions[0]);
+  EXPECT_EQ(1.5, expected_state.positions[0]);
 
   traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), expected_state, start, end);
-  EXPECT_EQ(2.5f, expected_state.positions[0]);
+  EXPECT_EQ(2.5, expected_state.positions[0]);
 
   traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), expected_state, start, end);
-  EXPECT_EQ(3.0f, expected_state.positions[0]);
+  EXPECT_EQ(3.0, expected_state.positions[0]);
 
   // sample past given points
   traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), expected_state, start, end);
   ASSERT_EQ((--traj.end()), start);
   ASSERT_EQ(traj.end(), end);
-  EXPECT_EQ(3.0f, expected_state.positions[0]);
+  EXPECT_EQ(3.0, expected_state.positions[0]);
 }

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -44,7 +44,7 @@ TEST_F(TestTrajectory, initialize_trajectory) {
     trajectory_msgs::msg::JointTrajectoryPoint expected_point;
     joint_trajectory_controller::TrajectoryPointConstIter start, end;
     traj.sample(rclcpp::Clock().now(), expected_point, start, end);
-    
+
     EXPECT_EQ(traj.end(), start);
     EXPECT_EQ(traj.end(), end);
     EXPECT_EQ(empty_time, traj.time_from_start());
@@ -119,7 +119,7 @@ TEST_F(TestTrajectory, sample_trajectory) {
   ASSERT_EQ(traj.begin(), end);
   EXPECT_EQ(0.0f, expected_state.positions[0]);
 
-  //sample before trajectory starts
+  // sample before trajectory starts
   traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
   ASSERT_EQ(traj.begin(), start);
   ASSERT_EQ(traj.begin(), end);

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -214,8 +214,6 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
     point.positions[1] = 2.0;
     point.positions[2] = 3.0;
 
-    point.velocities = std::vector<double>(joint_names.size(), 0.0);
-    point.accelerations = std::vector<double>(joint_names.size(), 0.0);
     points.push_back(point);
     
     sendActionGoal(points, 1, opt);
@@ -242,18 +240,6 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
     {
       (void)feedback;
       feedback_recv = true;
-      /*feedback->actual;
-      RCLCPP_INFO(node->get_logger(), "feedback recv time: %f", rclcpp::Clock().now().seconds());
-      RCLCPP_INFO(node->get_logger(), "actual time offset: %d %d", 
-        feedback->actual.time_from_start.sec, feedback->actual.time_from_start.nanosec);
-
-      RCLCPP_INFO(node->get_logger(), "desired offset: %d %d", 
-        feedback->desired.time_from_start.sec, feedback->desired.time_from_start.nanosec);
-      
-      for (uint i=0; i<feedback->joint_names.size(); ++i)
-        RCLCPP_INFO(node->get_logger(), "%d: actualposition: %f", i, feedback->actual.positions[i]);
-      for (uint i=0; i<feedback->joint_names.size(); ++i)
-        RCLCPP_INFO(node->get_logger(), "%d: desiredposition: %f", i, feedback->desired.positions[i]);*/
     };
 
   // send goal with multiple points
@@ -267,9 +253,6 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
     point1.positions[0] = 4.0;
     point1.positions[1] = 5.0;
     point1.positions[2] = 6.0;
-
-    point1.velocities = std::vector<double>(joint_names.size(), 0.0);
-    point1.accelerations = std::vector<double>(joint_names.size(), 0.0);
     points.push_back(point1);
 
     JointTrajectoryPoint point2;
@@ -280,9 +263,6 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
     point2.positions[0] = 7.0;
     point2.positions[1] = 8.0;
     point2.positions[2] = 9.0;
-
-    point2.velocities = std::vector<double>(joint_names.size(), 0.0);
-    point2.accelerations = std::vector<double>(joint_names.size(), 0.0);
     points.push_back(point2);
 
     sendActionGoal(points, 1, opt);
@@ -371,9 +351,6 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
     point.positions[0] = 1.0;
     point.positions[1] = 2.0;
     point.positions[2] = 3.0;
-
-    point.velocities = std::vector<double>(joint_names.size(), 0.0);
-    point.accelerations = std::vector<double>(joint_names.size(), 0.0);
     points.push_back(point);
     
     sendActionGoal(points, 1, opt);
@@ -415,9 +392,6 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
     point1.positions[0] = 4.0;
     point1.positions[1] = 5.0;
     point1.positions[2] = 6.0;
-
-    point1.velocities = std::vector<double>(joint_names.size(), 0.0);
-    point1.accelerations = std::vector<double>(joint_names.size(), 0.0);
     points.push_back(point1);
 
     JointTrajectoryPoint point2;
@@ -428,9 +402,6 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
     point2.positions[0] = 7.0;
     point2.positions[1] = 8.0;
     point2.positions[2] = 9.0;
-
-    point2.velocities = std::vector<double>(joint_names.size(), 0.0);
-    point2.accelerations = std::vector<double>(joint_names.size(), 0.0);
     points.push_back(point2);
 
     sendActionGoal(points, 1, opt);
@@ -522,9 +493,6 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail) {
     point.positions[0] = 4.0;
     point.positions[1] = 5.0;
     point.positions[2] = 6.0;
-
-    point.velocities = std::vector<double>(joint_names.size(), 0.0);
-    point.accelerations = std::vector<double>(joint_names.size(), 0.0);
     points.push_back(point);
     
     sendActionGoal(points, 1, opt);
@@ -599,9 +567,6 @@ TEST_F(TestTrajectoryActions, test_cancel_hold_position) {
     point.positions[0] = 4.0;
     point.positions[1] = 5.0;
     point.positions[2] = 6.0;
-
-    point.velocities = std::vector<double>(joint_names.size(), 0.0);
-    point.accelerations = std::vector<double>(joint_names.size(), 0.0);
     points.push_back(point);
     
     control_msgs::action::FollowJointTrajectory_Goal goal_msg;

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -103,6 +103,7 @@ protected:
   rclcpp_action::ResultCode common_resultcode = rclcpp_action::ResultCode::UNKNOWN;
   bool common_goal_accepted = false;
   int common_action_result_code = control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL;
+  double common_threshold = 0.001;
 
 public:
   void common_goal_response(std::shared_future<GoalHandle::SharedPtr> future)
@@ -264,10 +265,9 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
   EXPECT_EQ(true, common_goal_accepted);
   EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode);
 
-  double threshold = 0.001;
-  EXPECT_NEAR(7.0, test_robot->pos1, threshold);
-  EXPECT_NEAR(8.0, test_robot->pos2, threshold);
-  EXPECT_NEAR(9.0, test_robot->pos3, threshold);
+  EXPECT_NEAR(7.0, test_robot->pos1, common_threshold);
+  EXPECT_NEAR(8.0, test_robot->pos2, common_threshold);
+  EXPECT_NEAR(9.0, test_robot->pos3, common_threshold);
 
   executor.cancel();
 }
@@ -353,9 +353,9 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
     control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL,
     common_action_result_code);
 
-  EXPECT_EQ(1.0, test_robot->pos1);
-  EXPECT_EQ(2.0, test_robot->pos2);
-  EXPECT_EQ(3.0, test_robot->pos3);
+  EXPECT_NEAR(1.0, test_robot->pos1, common_threshold);
+  EXPECT_NEAR(2.0, test_robot->pos2, common_threshold);
+  EXPECT_NEAR(3.0, test_robot->pos3, common_threshold);
 
   // start again
   common_goal_accepted = false;
@@ -406,10 +406,9 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
     control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL,
     common_action_result_code);
 
-  double threshold = 0.001;
-  EXPECT_NEAR(7.0, test_robot->pos1, threshold);
-  EXPECT_NEAR(8.0, test_robot->pos2, threshold);
-  EXPECT_NEAR(9.0, test_robot->pos3, threshold);
+  EXPECT_NEAR(7.0, test_robot->pos1, common_threshold);
+  EXPECT_NEAR(8.0, test_robot->pos2, common_threshold);
+  EXPECT_NEAR(9.0, test_robot->pos3, common_threshold);
 
   executor.cancel();
 }

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -51,6 +51,19 @@ protected:
     op_mode = {{test_robot->write_op_handle_name1}};
 
     node = std::make_shared<rclcpp::Node>("trajectory_test_node");
+
+    traj_controller = std::make_shared<joint_trajectory_controller::JointTrajectoryController>();
+    auto ret = traj_controller->init(test_robot, controller_name);
+    if (ret != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+      FAIL();
+    }
+
+    traj_lifecycle_node = traj_controller->get_lifecycle_node();
+    rclcpp::Parameter joint_parameters("joints", joint_names);
+    traj_lifecycle_node->set_parameter(joint_parameters);
+
+    rclcpp::Parameter operation_mode_parameters("write_op_modes", op_mode);
+    traj_lifecycle_node->set_parameter(operation_mode_parameters);
   }
 
   void SetUpActionClient()
@@ -98,6 +111,8 @@ protected:
   std::vector<std::string> op_mode;
 
   rclcpp::Node::SharedPtr node;
+  std::shared_ptr<joint_trajectory_controller::JointTrajectoryController> traj_controller;
+  rclcpp_lifecycle::LifecycleNode::SharedPtr traj_lifecycle_node;
 
   rclcpp_action::Client<FollowJointTrajectoryMsg>::SharedPtr action_client;
   rclcpp_action::ResultCode common_resultcode = rclcpp_action::ResultCode::UNKNOWN;
@@ -145,19 +160,6 @@ public:
 };
 
 TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
-  auto traj_controller = std::make_shared<joint_trajectory_controller::JointTrajectoryController>();
-  auto ret = traj_controller->init(test_robot, controller_name);
-  if (ret != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
-    FAIL();
-  }
-
-  auto traj_lifecycle_node = traj_controller->get_lifecycle_node();
-  rclcpp::Parameter joint_parameters("joints", joint_names);
-  traj_lifecycle_node->set_parameter(joint_parameters);
-
-  rclcpp::Parameter operation_mode_parameters("write_op_modes", op_mode);
-  traj_lifecycle_node->set_parameter(operation_mode_parameters);
-
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(traj_lifecycle_node->get_node_base_interface());
 
@@ -271,19 +273,6 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
 }
 
 TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
-  auto traj_controller = std::make_shared<joint_trajectory_controller::JointTrajectoryController>();
-  auto ret = traj_controller->init(test_robot, controller_name);
-  if (ret != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
-    FAIL();
-  }
-
-  auto traj_lifecycle_node = traj_controller->get_lifecycle_node();
-  rclcpp::Parameter joint_parameters("joints", joint_names);
-  traj_lifecycle_node->set_parameter(joint_parameters);
-
-  rclcpp::Parameter operation_mode_parameters("write_op_modes", op_mode);
-  traj_lifecycle_node->set_parameter(operation_mode_parameters);
-
   // set tolerance parameters
   traj_lifecycle_node->declare_parameter("constraints.joint1.goal", 0.0);
   traj_lifecycle_node->declare_parameter("constraints.joint2.goal", 0.0);
@@ -410,19 +399,6 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
 }
 
 TEST_F(TestTrajectoryActions, test_state_tolerances_fail) {
-  auto traj_controller = std::make_shared<joint_trajectory_controller::JointTrajectoryController>();
-  auto ret = traj_controller->init(test_robot, controller_name);
-  if (ret != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
-    FAIL();
-  }
-
-  auto traj_lifecycle_node = traj_controller->get_lifecycle_node();
-  rclcpp::Parameter joint_parameters("joints", joint_names);
-  traj_lifecycle_node->set_parameter(joint_parameters);
-
-  rclcpp::Parameter operation_mode_parameters("write_op_modes", op_mode);
-  traj_lifecycle_node->set_parameter(operation_mode_parameters);
-
   // set joint tolerance parameters
   double state_tol = 0.0001;
   traj_lifecycle_node->declare_parameter("constraints.joint1.trajectory", 0.0);
@@ -495,19 +471,6 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail) {
 }
 
 TEST_F(TestTrajectoryActions, test_cancel_hold_position) {
-  auto traj_controller = std::make_shared<joint_trajectory_controller::JointTrajectoryController>();
-  auto ret = traj_controller->init(test_robot, controller_name);
-  if (ret != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
-    FAIL();
-  }
-
-  auto traj_lifecycle_node = traj_controller->get_lifecycle_node();
-  rclcpp::Parameter joint_parameters("joints", joint_names);
-  traj_lifecycle_node->set_parameter(joint_parameters);
-
-  rclcpp::Parameter operation_mode_parameters("write_op_modes", op_mode);
-  traj_lifecycle_node->set_parameter(operation_mode_parameters);
-
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(traj_lifecycle_node->get_node_base_interface());
 

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -192,7 +192,6 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
   };
   std::thread controller_hw_thread(thread_func, nullptr);
 
-  // TODO (ddengster): find a way to wait for action server proper?
   // common_goal_response and common_result_response 
   // sometimes doesnt receive calls when we dont sleep
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -536,10 +535,6 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail) {
   EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, common_resultcode);
   EXPECT_EQ(control_msgs::action::FollowJointTrajectory_Result::PATH_TOLERANCE_VIOLATED, 
     common_action_result_code);
-
-  // EXPECT_EQ(1.0, test_robot->pos1);
-  // EXPECT_EQ(2.0, test_robot->pos2);
-  // EXPECT_EQ(3.0, test_robot->pos3);
 
   executor.cancel();
 }

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -79,11 +79,11 @@ protected:
 
   bool sendActionGoal(
     const std::vector<JointTrajectoryPoint> & points,
-    int timeout,
+    double timeout,
     const GoalOptions & opt)
   {
     control_msgs::action::FollowJointTrajectory_Goal goal_msg;
-    goal_msg.goal_time_tolerance = rclcpp::Duration(timeout);
+    goal_msg.goal_time_tolerance = rclcpp::Duration::from_seconds(timeout);
     goal_msg.trajectory.joint_names = joint_names;
     goal_msg.trajectory.points = points;
 
@@ -199,7 +199,7 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
   {
     std::vector<JointTrajectoryPoint> points;
     JointTrajectoryPoint point;
-    point.time_from_start.set__sec(0);  // start asap
+    point.time_from_start = rclcpp::Duration::from_seconds(0.0);  // start asap
     point.positions.resize(joint_names.size());
 
     point.positions[0] = 1.0;
@@ -208,7 +208,7 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
 
     points.push_back(point);
 
-    sendActionGoal(points, 1, opt);
+    sendActionGoal(points, 1.0, opt);
   }
   controller_hw_thread.join();
 
@@ -238,8 +238,7 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
   {
     std::vector<JointTrajectoryPoint> points;
     JointTrajectoryPoint point1;
-    point1.time_from_start.set__sec(0);
-    point1.time_from_start.set__nanosec(200000000);  // 0.2 seconds
+    point1.time_from_start = rclcpp::Duration::from_seconds(0.2);
     point1.positions.resize(joint_names.size());
 
     point1.positions[0] = 4.0;
@@ -248,8 +247,7 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
     points.push_back(point1);
 
     JointTrajectoryPoint point2;
-    point2.time_from_start.set__sec(0);
-    point2.time_from_start.set__nanosec(300000000);  // 0.3 seconds
+    point2.time_from_start = rclcpp::Duration::from_seconds(0.3);
     point2.positions.resize(joint_names.size());
 
     point2.positions[0] = 7.0;
@@ -257,7 +255,7 @@ TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
     point2.positions[2] = 9.0;
     points.push_back(point2);
 
-    sendActionGoal(points, 1, opt);
+    sendActionGoal(points, 1.0, opt);
   }
   controller_hw_thread.join();
 
@@ -335,7 +333,7 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
   {
     std::vector<JointTrajectoryPoint> points;
     JointTrajectoryPoint point;
-    point.time_from_start.set__sec(0);  // start asap
+    point.time_from_start = rclcpp::Duration::from_seconds(0.0);  // start asap
     point.positions.resize(joint_names.size());
 
     point.positions[0] = 1.0;
@@ -343,7 +341,7 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
     point.positions[2] = 3.0;
     points.push_back(point);
 
-    sendActionGoal(points, 1, opt);
+    sendActionGoal(points, 1.0, opt);
   }
   controller_hw_thread.join();
 
@@ -376,8 +374,7 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
   {
     std::vector<JointTrajectoryPoint> points;
     JointTrajectoryPoint point1;
-    point1.time_from_start.set__sec(0);
-    point1.time_from_start.set__nanosec(200000000);  // 0.2 seconds
+    point1.time_from_start = rclcpp::Duration::from_seconds(0.2);
     point1.positions.resize(joint_names.size());
 
     point1.positions[0] = 4.0;
@@ -386,8 +383,7 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
     points.push_back(point1);
 
     JointTrajectoryPoint point2;
-    point2.time_from_start.set__sec(0);
-    point2.time_from_start.set__nanosec(300000000);  // 0.3 seconds
+    point2.time_from_start = rclcpp::Duration::from_seconds(0.3);
     point2.positions.resize(joint_names.size());
 
     point2.positions[0] = 7.0;
@@ -395,7 +391,7 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
     point2.positions[2] = 9.0;
     points.push_back(point2);
 
-    sendActionGoal(points, 1, opt);
+    sendActionGoal(points, 1.0, opt);
   }
   controller_hw_thread.join();
 
@@ -477,7 +473,7 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail) {
   {
     std::vector<JointTrajectoryPoint> points;
     JointTrajectoryPoint point;
-    point.time_from_start.set__sec(1);
+    point.time_from_start = rclcpp::Duration::from_seconds(1.0);
     point.positions.resize(joint_names.size());
 
     point.positions[0] = 4.0;
@@ -485,7 +481,7 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail) {
     point.positions[2] = 6.0;
     points.push_back(point);
 
-    sendActionGoal(points, 1, opt);
+    sendActionGoal(points, 1.0, opt);
   }
   controller_hw_thread.join();
 
@@ -527,7 +523,7 @@ TEST_F(TestTrajectoryActions, test_cancel_hold_position) {
 
   auto thread_func = [&]() {
       auto start_time = rclcpp::Clock().now();
-      rclcpp::Duration wait = rclcpp::Duration::from_seconds(2);
+      rclcpp::Duration wait = rclcpp::Duration::from_seconds(2.0);
       auto end_time = start_time + wait;
       while (rclcpp::Clock().now() < end_time) {
         test_robot->read();
@@ -551,7 +547,7 @@ TEST_F(TestTrajectoryActions, test_cancel_hold_position) {
   {
     std::vector<JointTrajectoryPoint> points;
     JointTrajectoryPoint point;
-    point.time_from_start.set__sec(1);
+    point.time_from_start = rclcpp::Duration::from_seconds(1.0);
     point.positions.resize(joint_names.size());
 
     point.positions[0] = 4.0;
@@ -560,7 +556,7 @@ TEST_F(TestTrajectoryActions, test_cancel_hold_position) {
     points.push_back(point);
 
     control_msgs::action::FollowJointTrajectory_Goal goal_msg;
-    goal_msg.goal_time_tolerance = rclcpp::Duration(2);
+    goal_msg.goal_time_tolerance = rclcpp::Duration::from_seconds(2.0);
     goal_msg.trajectory.joint_names = joint_names;
     goal_msg.trajectory.points = points;
 

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -1,0 +1,553 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <array>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "controller_parameter_server/parameter_server.hpp"
+
+#include "hardware_interface/robot_hardware.hpp"
+
+#include "joint_trajectory_controller/joint_trajectory_controller.hpp"
+
+#include "lifecycle_msgs/msg/state.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "rcutils/get_env.h"
+
+#include "test_robot_hardware/test_robot_hardware.hpp"
+
+#include "rclcpp_action/rclcpp_action.hpp"
+
+using lifecycle_msgs::msg::State;
+using trajectory_msgs::msg::JointTrajectoryPoint;
+using std::placeholders::_1;
+using std::placeholders::_2;
+
+void
+spin(rclcpp::executors::MultiThreadedExecutor * exe)
+{
+  exe->spin();
+}
+
+class TestTrajectoryActions : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    test_robot = std::make_shared<test_robot_hardware::TestRobotHardware>();
+    test_robot->init();
+    joint_names = {{test_robot->joint_name1, test_robot->joint_name2, test_robot->joint_name3}};
+    op_mode = {{test_robot->write_op_handle_name1}};
+
+    node = std::make_shared<rclcpp::Node>("trajectory_test_node");
+  }
+
+  void SetUpActionClient()
+  {
+    action_client = rclcpp_action::create_client<control_msgs::action::FollowJointTrajectory>(
+      node->get_node_base_interface(),
+      node->get_node_graph_interface(),
+      node->get_node_logging_interface(),
+      node->get_node_waitables_interface(),
+      controller_name + "/follow_joint_trajectory");
+    
+    bool response = 
+      action_client->wait_for_action_server(std::chrono::seconds(1));
+    if (!response)
+      throw std::runtime_error("could not get action server");
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+  using FollowJointTrajectoryMsg = control_msgs::action::FollowJointTrajectory ;
+  using GoalHandle = rclcpp_action::ClientGoalHandle<FollowJointTrajectoryMsg>;
+  using GoalOptions = rclcpp_action::Client<FollowJointTrajectoryMsg>::SendGoalOptions;
+
+  bool sendActionGoal(
+    const std::vector<JointTrajectoryPoint>& points,
+    int timeout, 
+    const GoalOptions& opt)
+  {
+    control_msgs::action::FollowJointTrajectory_Goal goal_msg;
+    goal_msg.goal_time_tolerance = rclcpp::Duration(timeout);
+    goal_msg.trajectory.joint_names = joint_names;
+    goal_msg.trajectory.points = points;
+    
+    auto goal_handle_future = action_client->async_send_goal(goal_msg, opt);
+    return true;
+  }
+
+  std::string controller_name = "test_joint_trajectory_actions";
+
+  std::shared_ptr<test_robot_hardware::TestRobotHardware> test_robot;
+  std::vector<std::string> joint_names;
+  std::vector<std::string> op_mode;
+
+  rclcpp::Node::SharedPtr node;
+
+  rclcpp_action::Client<FollowJointTrajectoryMsg>::SharedPtr action_client;
+  rclcpp_action::ResultCode common_resultcode = rclcpp_action::ResultCode::UNKNOWN;
+  bool common_goal_accepted = false;
+  int common_action_result_code = control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL;
+
+public:
+  void common_goal_response(std::shared_future<GoalHandle::SharedPtr> future) 
+  {
+    RCLCPP_DEBUG(node->get_logger(), "common_goal_response time: %f", rclcpp::Clock().now().seconds());
+    auto goal_handle = future.get();
+    if (!goal_handle) {
+      common_goal_accepted = false;
+      RCLCPP_DEBUG(node->get_logger(), "Goal rejected");
+    }
+    else {
+      common_goal_accepted = true;
+      RCLCPP_DEBUG(node->get_logger(), "Goal accepted");
+    }
+  }
+
+  void common_result_response(const GoalHandle::WrappedResult& result)
+  {
+    RCLCPP_DEBUG(node->get_logger(), "common_result_response time: %f", rclcpp::Clock().now().seconds());
+    common_resultcode = result.code;
+    common_action_result_code = result.result->error_code;
+    switch (result.code) {
+      case rclcpp_action::ResultCode::SUCCEEDED:
+        break;
+      case rclcpp_action::ResultCode::ABORTED:
+        RCLCPP_DEBUG(node->get_logger(), "Goal was aborted");
+        return;
+      case rclcpp_action::ResultCode::CANCELED:
+        RCLCPP_DEBUG(node->get_logger(), "Goal was canceled");
+        return;
+      default:
+        RCLCPP_DEBUG(node->get_logger(), "Unknown result code");
+        return;
+    }
+  }
+};
+
+TEST_F(TestTrajectoryActions, test_success_multi_point_sendgoal) {
+  auto traj_controller = std::make_shared<joint_trajectory_controller::JointTrajectoryController>();
+  auto ret = traj_controller->init(test_robot, controller_name);
+  if (ret != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+    FAIL();
+  }
+
+  auto traj_lifecycle_node = traj_controller->get_lifecycle_node();
+  rclcpp::Parameter joint_parameters("joints", joint_names);
+  traj_lifecycle_node->set_parameter(joint_parameters);
+
+  rclcpp::Parameter operation_mode_parameters("write_op_modes", op_mode);
+  traj_lifecycle_node->set_parameter(operation_mode_parameters);
+  
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(traj_lifecycle_node->get_node_base_interface());
+
+  traj_controller->on_configure(traj_lifecycle_node->get_current_state());
+  traj_controller->on_activate(traj_lifecycle_node->get_current_state());
+  SetUpActionClient();
+  executor.add_node(node->get_node_base_interface());
+  
+  auto future_handle = std::async(
+    std::launch::async, [&executor]() -> void {
+      executor.spin();
+    });
+
+  auto thread_func = [&](void*)
+  {
+    // controller hardware cycle update loop
+    auto start_time = rclcpp::Clock().now();
+    rclcpp::Duration wait = rclcpp::Duration::from_seconds(2.0);
+    auto end_time = start_time + wait;
+    while (rclcpp::Clock().now() < end_time) {
+      test_robot->read();
+      traj_controller->update();
+      test_robot->write();
+    }
+  };
+  std::thread controller_hw_thread(thread_func, nullptr);
+
+  // TODO (ddengster): find a way to wait for action server proper?
+  // common_goal_response and common_result_response 
+  // sometimes doesnt receive calls when we dont sleep
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  GoalOptions opt;
+  opt.goal_response_callback = 
+    std::bind(&TestTrajectoryActions::common_goal_response, this, _1);
+  opt.result_callback = 
+    std::bind(&TestTrajectoryActions::common_result_response, this, _1);
+  opt.feedback_callback = nullptr;
+  
+  // send goal
+  {
+    std::vector<JointTrajectoryPoint> points;
+    JointTrajectoryPoint point;
+    point.time_from_start.set__sec(0); // start asap
+    point.positions.resize(joint_names.size());
+    
+    point.positions[0] = 1.0;
+    point.positions[1] = 2.0;
+    point.positions[2] = 3.0;
+
+    point.velocities = std::vector<double>(joint_names.size(), 0.0);
+    point.accelerations = std::vector<double>(joint_names.size(), 0.0);
+    points.push_back(point);
+    
+    sendActionGoal(points, 1, opt);
+  }
+  controller_hw_thread.join();
+
+  EXPECT_EQ(true, common_goal_accepted);
+  EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode);
+
+  EXPECT_EQ(1.0, test_robot->pos1);
+  EXPECT_EQ(2.0, test_robot->pos2);
+  EXPECT_EQ(3.0, test_robot->pos3);
+
+  //start again
+  common_goal_accepted = false;
+  common_resultcode = rclcpp_action::ResultCode::UNKNOWN;
+  controller_hw_thread = std::thread(thread_func, nullptr);
+
+  // add feedback 
+  bool feedback_recv = false;
+  opt.feedback_callback = [&](
+    rclcpp_action::ClientGoalHandle<FollowJointTrajectoryMsg>::SharedPtr,
+    const std::shared_ptr<const FollowJointTrajectoryMsg::Feedback> feedback)
+    {
+      feedback_recv = true;
+      feedback->actual;
+      RCLCPP_INFO(node->get_logger(), "feedback recv time: %f", rclcpp::Clock().now().seconds());
+      RCLCPP_INFO(node->get_logger(), "actual time offset: %d %d", 
+        feedback->actual.time_from_start.sec, feedback->actual.time_from_start.nanosec);
+
+      RCLCPP_INFO(node->get_logger(), "desired offset: %d %d", 
+        feedback->desired.time_from_start.sec, feedback->desired.time_from_start.nanosec);
+      
+      for (uint i=0; i<feedback->joint_names.size(); ++i)
+        RCLCPP_INFO(node->get_logger(), "%d: actualposition: %f", i, feedback->actual.positions[i]);
+      for (uint i=0; i<feedback->joint_names.size(); ++i)
+        RCLCPP_INFO(node->get_logger(), "%d: desiredposition: %f", i, feedback->desired.positions[i]);
+    };
+
+  // send goal with multiple points
+  {
+    std::vector<JointTrajectoryPoint> points;
+    JointTrajectoryPoint point1;
+    point1.time_from_start.set__sec(0);
+    point1.time_from_start.set__nanosec(200000000); // 0.2 seconds
+    point1.positions.resize(joint_names.size());
+    
+    point1.positions[0] = 4.0;
+    point1.positions[1] = 5.0;
+    point1.positions[2] = 6.0;
+
+    point1.velocities = std::vector<double>(joint_names.size(), 0.0);
+    point1.accelerations = std::vector<double>(joint_names.size(), 0.0);
+    points.push_back(point1);
+
+    JointTrajectoryPoint point2;
+    point2.time_from_start.set__sec(0);
+    point2.time_from_start.set__nanosec(300000000); // 0.3 seconds
+    point2.positions.resize(joint_names.size());
+    
+    point2.positions[0] = 7.0;
+    point2.positions[1] = 8.0;
+    point2.positions[2] = 9.0;
+
+    point2.velocities = std::vector<double>(joint_names.size(), 0.0);
+    point2.accelerations = std::vector<double>(joint_names.size(), 0.0);
+    points.push_back(point2);
+
+    sendActionGoal(points, 1, opt);
+  }
+  controller_hw_thread.join();
+
+  EXPECT_EQ(true, feedback_recv);
+  EXPECT_EQ(true, common_goal_accepted);
+  EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode);
+
+  EXPECT_EQ(7.0, test_robot->pos1);
+  EXPECT_EQ(8.0, test_robot->pos2);
+  EXPECT_EQ(9.0, test_robot->pos3);
+
+  executor.cancel();
+}
+
+TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
+  auto traj_controller = std::make_shared<joint_trajectory_controller::JointTrajectoryController>();
+  auto ret = traj_controller->init(test_robot, controller_name);
+  if (ret != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+    FAIL();
+  }
+
+  auto traj_lifecycle_node = traj_controller->get_lifecycle_node();
+  rclcpp::Parameter joint_parameters("joints", joint_names);
+  traj_lifecycle_node->set_parameter(joint_parameters);
+
+  rclcpp::Parameter operation_mode_parameters("write_op_modes", op_mode);
+  traj_lifecycle_node->set_parameter(operation_mode_parameters);
+
+  //set tolerance parameters
+  traj_lifecycle_node->declare_parameter("constraints.joint1.goal", 0.0);
+  traj_lifecycle_node->declare_parameter("constraints.joint2.goal", 0.0);
+  traj_lifecycle_node->declare_parameter("constraints.joint3.goal", 0.0);
+  traj_lifecycle_node->set_parameter(rclcpp::Parameter("constraints.joint1.goal", 0.1));
+  traj_lifecycle_node->set_parameter(rclcpp::Parameter("constraints.joint2.goal", 0.1));
+  traj_lifecycle_node->set_parameter(rclcpp::Parameter("constraints.joint3.goal", 0.1));
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(traj_lifecycle_node->get_node_base_interface());
+
+  traj_controller->on_configure(traj_lifecycle_node->get_current_state());
+  traj_controller->on_activate(traj_lifecycle_node->get_current_state());
+  SetUpActionClient();
+  executor.add_node(node->get_node_base_interface());
+  
+  auto future_handle = std::async(
+    std::launch::async, [&executor]() -> void {
+      executor.spin();
+    });
+
+  auto thread_func = [&](void*)
+  {
+    // controller hardware cycle update loop
+    auto start_time = rclcpp::Clock().now();
+    rclcpp::Duration wait = rclcpp::Duration::from_seconds(2.0);
+    auto end_time = start_time + wait;
+    while (rclcpp::Clock().now() < end_time) {
+      test_robot->read();
+      traj_controller->update();
+      test_robot->write();
+    }
+  };
+  std::thread controller_hw_thread(thread_func, nullptr);
+
+  // common_goal_response and common_result_response 
+  // sometimes doesnt receive calls when we dont sleep
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  GoalOptions opt;
+  opt.goal_response_callback = 
+    std::bind(&TestTrajectoryActions::common_goal_response, this, _1);
+  opt.result_callback = 
+    std::bind(&TestTrajectoryActions::common_result_response, this, _1);
+  opt.feedback_callback = nullptr;
+  
+  // send goal
+  {
+    std::vector<JointTrajectoryPoint> points;
+    JointTrajectoryPoint point;
+    point.time_from_start.set__sec(0); // start asap
+    point.positions.resize(joint_names.size());
+    
+    point.positions[0] = 1.0;
+    point.positions[1] = 2.0;
+    point.positions[2] = 3.0;
+
+    point.velocities = std::vector<double>(joint_names.size(), 0.0);
+    point.accelerations = std::vector<double>(joint_names.size(), 0.0);
+    points.push_back(point);
+    
+    sendActionGoal(points, 1, opt);
+  }
+  controller_hw_thread.join();
+
+  EXPECT_EQ(true, common_goal_accepted);
+  EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode);
+  EXPECT_EQ(control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL, 
+    common_action_result_code);
+
+  EXPECT_EQ(1.0, test_robot->pos1);
+  EXPECT_EQ(2.0, test_robot->pos2);
+  EXPECT_EQ(3.0, test_robot->pos3);
+
+  //start again
+  common_goal_accepted = false;
+  common_resultcode = rclcpp_action::ResultCode::UNKNOWN;
+  controller_hw_thread = std::thread(thread_func, nullptr);
+
+  // add feedback 
+  bool feedback_recv = false;
+  opt.feedback_callback = [&](
+    rclcpp_action::ClientGoalHandle<FollowJointTrajectoryMsg>::SharedPtr,
+    const std::shared_ptr<const FollowJointTrajectoryMsg::Feedback> feedback)
+    {
+      feedback_recv = true;
+      feedback->actual;
+      RCLCPP_INFO(node->get_logger(), "feedback recv time: %f", rclcpp::Clock().now().seconds());
+      /*RCLCPP_INFO(node->get_logger(), "actual time offset: %d %d", 
+        feedback->actual.time_from_start.sec, feedback->actual.time_from_start.nanosec);
+
+      RCLCPP_INFO(node->get_logger(), "desired offset: %d %d", 
+        feedback->desired.time_from_start.sec, feedback->desired.time_from_start.nanosec);
+      
+      for (uint i=0; i<feedback->joint_names.size(); ++i)
+        RCLCPP_INFO(node->get_logger(), "%d: actualposition: %f", i, feedback->actual.positions[i]);
+      for (uint i=0; i<feedback->joint_names.size(); ++i)
+        RCLCPP_INFO(node->get_logger(), "%d: desiredposition: %f", i, feedback->desired.positions[i]);*/
+    };
+
+  // send goal with multiple points
+  {
+    std::vector<JointTrajectoryPoint> points;
+    JointTrajectoryPoint point1;
+    point1.time_from_start.set__sec(0);
+    point1.time_from_start.set__nanosec(200000000); // 0.2 seconds
+    point1.positions.resize(joint_names.size());
+    
+    point1.positions[0] = 4.0;
+    point1.positions[1] = 5.0;
+    point1.positions[2] = 6.0;
+
+    point1.velocities = std::vector<double>(joint_names.size(), 0.0);
+    point1.accelerations = std::vector<double>(joint_names.size(), 0.0);
+    points.push_back(point1);
+
+    JointTrajectoryPoint point2;
+    point2.time_from_start.set__sec(0);
+    point2.time_from_start.set__nanosec(300000000); // 0.3 seconds
+    point2.positions.resize(joint_names.size());
+    
+    point2.positions[0] = 7.0;
+    point2.positions[1] = 8.0;
+    point2.positions[2] = 9.0;
+
+    point2.velocities = std::vector<double>(joint_names.size(), 0.0);
+    point2.accelerations = std::vector<double>(joint_names.size(), 0.0);
+    points.push_back(point2);
+
+    sendActionGoal(points, 1, opt);
+  }
+  controller_hw_thread.join();
+
+  EXPECT_EQ(true, feedback_recv);
+  EXPECT_EQ(true, common_goal_accepted);
+  EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode);
+  EXPECT_EQ(control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL, 
+    common_action_result_code);
+
+  EXPECT_EQ(7.0, test_robot->pos1);
+  EXPECT_EQ(8.0, test_robot->pos2);
+  EXPECT_EQ(9.0, test_robot->pos3);
+
+  executor.cancel();
+}
+
+TEST_F(TestTrajectoryActions, test_state_tolerances_fail) {
+  auto traj_controller = std::make_shared<joint_trajectory_controller::JointTrajectoryController>();
+  auto ret = traj_controller->init(test_robot, controller_name);
+  if (ret != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+    FAIL();
+  }
+
+  auto traj_lifecycle_node = traj_controller->get_lifecycle_node();
+  rclcpp::Parameter joint_parameters("joints", joint_names);
+  traj_lifecycle_node->set_parameter(joint_parameters);
+
+  rclcpp::Parameter operation_mode_parameters("write_op_modes", op_mode);
+  traj_lifecycle_node->set_parameter(operation_mode_parameters);
+
+  //set joint tolerance parameters
+  double state_tol = 0.0001;
+  traj_lifecycle_node->declare_parameter("constraints.joint1.trajectory", 0.0);
+  traj_lifecycle_node->declare_parameter("constraints.joint2.trajectory", 0.0);
+  traj_lifecycle_node->declare_parameter("constraints.joint3.trajectory", 0.0);
+  traj_lifecycle_node->set_parameter(rclcpp::Parameter("constraints.joint1.trajectory", state_tol));
+  traj_lifecycle_node->set_parameter(rclcpp::Parameter("constraints.joint2.trajectory", state_tol));
+  traj_lifecycle_node->set_parameter(rclcpp::Parameter("constraints.joint3.trajectory", state_tol));
+  
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(traj_lifecycle_node->get_node_base_interface());
+
+  traj_controller->on_configure(traj_lifecycle_node->get_current_state());
+  traj_controller->on_activate(traj_lifecycle_node->get_current_state());
+  SetUpActionClient();
+  executor.add_node(node->get_node_base_interface());
+  
+  auto future_handle = std::async(
+    std::launch::async, [&executor]() -> void {
+      executor.spin();
+    });
+
+  auto thread_func = [&](void*)
+  {
+    // controller hardware cycle update loop
+    auto start_time = rclcpp::Clock().now();
+    rclcpp::Duration wait = rclcpp::Duration::from_seconds(2.0);
+    auto end_time = start_time + wait;
+    while (rclcpp::Clock().now() < end_time) {
+      test_robot->read();
+      traj_controller->update();
+      test_robot->write();
+    }
+  };
+  std::thread controller_hw_thread(thread_func, nullptr);
+
+  // common_goal_response and common_result_response 
+  // sometimes doesnt receive calls when we dont sleep
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  GoalOptions opt;
+  opt.goal_response_callback = 
+    std::bind(&TestTrajectoryActions::common_goal_response, this, _1);
+  opt.result_callback = 
+    std::bind(&TestTrajectoryActions::common_result_response, this, _1);
+  opt.feedback_callback = nullptr;
+  
+  // send goal
+  {
+    std::vector<JointTrajectoryPoint> points;
+    JointTrajectoryPoint point;
+    point.time_from_start.set__sec(1);
+    point.positions.resize(joint_names.size());
+    
+    point.positions[0] = 4.0;
+    point.positions[1] = 5.0;
+    point.positions[2] = 6.0;
+
+    point.velocities = std::vector<double>(joint_names.size(), 0.0);
+    point.accelerations = std::vector<double>(joint_names.size(), 0.0);
+    points.push_back(point);
+    
+    sendActionGoal(points, 1, opt);
+  }
+  controller_hw_thread.join();
+
+  EXPECT_EQ(true, common_goal_accepted);
+  EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, common_resultcode);
+  EXPECT_EQ(control_msgs::action::FollowJointTrajectory_Result::PATH_TOLERANCE_VIOLATED, 
+    common_action_result_code);
+
+  // EXPECT_EQ(1.0, test_robot->pos1);
+  // EXPECT_EQ(2.0, test_robot->pos2);
+  // EXPECT_EQ(3.0, test_robot->pos3);
+
+  executor.cancel();
+}

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -107,7 +107,8 @@ protected:
 public:
   void common_goal_response(std::shared_future<GoalHandle::SharedPtr> future)
   {
-    RCLCPP_DEBUG(node->get_logger(), "common_goal_response time: %f",
+    RCLCPP_DEBUG(
+      node->get_logger(), "common_goal_response time: %f",
       rclcpp::Clock().now().seconds());
     auto goal_handle = future.get();
     if (!goal_handle) {
@@ -121,7 +122,8 @@ public:
 
   void common_result_response(const GoalHandle::WrappedResult & result)
   {
-    RCLCPP_DEBUG(node->get_logger(), "common_result_response time: %f",
+    RCLCPP_DEBUG(
+      node->get_logger(), "common_result_response time: %f",
       rclcpp::Clock().now().seconds());
     common_resultcode = result.code;
     common_action_result_code = result.result->error_code;
@@ -347,7 +349,8 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
 
   EXPECT_EQ(true, common_goal_accepted);
   EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode);
-  EXPECT_EQ(control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL,
+  EXPECT_EQ(
+    control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL,
     common_action_result_code);
 
   EXPECT_EQ(1.0, test_robot->pos1);
@@ -399,7 +402,8 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_success) {
   EXPECT_EQ(true, feedback_recv);
   EXPECT_EQ(true, common_goal_accepted);
   EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode);
-  EXPECT_EQ(control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL,
+  EXPECT_EQ(
+    control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL,
     common_action_result_code);
 
   double threshold = 0.001;
@@ -488,7 +492,8 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail) {
 
   EXPECT_EQ(true, common_goal_accepted);
   EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, common_resultcode);
-  EXPECT_EQ(control_msgs::action::FollowJointTrajectory_Result::PATH_TOLERANCE_VIOLATED,
+  EXPECT_EQ(
+    control_msgs::action::FollowJointTrajectory_Result::PATH_TOLERANCE_VIOLATED,
     common_action_result_code);
 
   executor.cancel();
@@ -571,7 +576,8 @@ TEST_F(TestTrajectoryActions, test_cancel_hold_position) {
 
   EXPECT_EQ(true, common_goal_accepted);
   EXPECT_EQ(rclcpp_action::ResultCode::CANCELED, common_resultcode);
-  EXPECT_EQ(control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL,
+  EXPECT_EQ(
+    control_msgs::action::FollowJointTrajectory_Result::SUCCESSFUL,
     common_action_result_code);
 
   double prev_pos1 = test_robot->pos1;

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -103,8 +103,7 @@ protected:
     rclcpp::Duration duration(duration_msg);
     rclcpp::Duration duration_total(duration_msg);
 
-    size_t index = 0;
-    for (; index < points.size(); ++index) {
+    for (size_t index = 0; index < points.size(); ++index) {
       traj_msg.points[index].time_from_start = duration_total;
 
       traj_msg.points[index].positions.resize(3);

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -421,8 +421,7 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   state = traj_lifecycle_node->deactivate();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 
-  // no change in hw position
-  auto allowed_delta = 0.001;
+  auto allowed_delta = 0.01;
   EXPECT_NEAR(3.3, test_robot->pos1, allowed_delta);
   EXPECT_NEAR(4.4, test_robot->pos2, allowed_delta);
   EXPECT_NEAR(5.5, test_robot->pos3, allowed_delta);

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -349,9 +349,10 @@ TEST_F(TestTrajectoryController, cleanup) {
   test_robot->write();
 
   // shouild be home pose again
-  EXPECT_EQ(1.1, test_robot->pos1);
-  EXPECT_EQ(2.2, test_robot->pos2);
-  EXPECT_EQ(3.3, test_robot->pos3);
+  double threshold = 0.001;
+  EXPECT_NEAR(1.1, test_robot->pos1, threshold);
+  EXPECT_NEAR(2.2, test_robot->pos2, threshold);
+  EXPECT_NEAR(3.3, test_robot->pos3, threshold);
 
   executor.cancel();
 }

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -69,11 +69,11 @@ protected:
 
   /// Publish trajectory msgs with multiple points
   /**
-   *  time_from_start - delay between each points
+   *  delay - delay between each points
    *  points - vector of trajectories. Each trajectory consists of 3 joints
    */
   void publish(
-    const builtin_interfaces::msg::Duration & time_from_start,
+    const builtin_interfaces::msg::Duration & delay_btwn_points,
     const std::vector<std::array<double, 3>> & points)
   {
     int wait_count = 0;
@@ -98,19 +98,15 @@ protected:
     traj_msg.points.resize(points.size());
 
     builtin_interfaces::msg::Duration duration_msg;
-    duration_msg.sec = time_from_start.sec;
-    duration_msg.nanosec = time_from_start.nanosec;
+    duration_msg.sec = delay_btwn_points.sec;
+    duration_msg.nanosec = delay_btwn_points.nanosec;
     rclcpp::Duration duration(duration_msg);
     rclcpp::Duration duration_total(duration_msg);
 
     size_t index = 0;
     for (; index < points.size(); ++index) {
-      using SecT = decltype(traj_msg.points[index].time_from_start.sec);
-      using NSecT = decltype(traj_msg.points[index].time_from_start.nanosec);
-      traj_msg.points[index].time_from_start.sec =
-        static_cast<SecT>(duration_total.nanoseconds() / 1e9);
-      traj_msg.points[index].time_from_start.nanosec =
-        static_cast<NSecT>(duration_total.nanoseconds());
+      traj_msg.points[index].time_from_start = duration_total;
+
       traj_msg.points[index].positions.resize(3);
       traj_msg.points[index].positions[0] = points[index][0];
       traj_msg.points[index].positions[1] = points[index][1];
@@ -410,32 +406,43 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   // *INDENT-ON*
   publish(time_from_start, points);
   // wait for msg is be published to the system
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
+  // first update
+  traj_controller->update();
+  test_robot->write();
+  
+  // wait so controller process the second point when deactivated
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   traj_controller->update();
   test_robot->write();
 
   // deactivated
-  // wait so controller process the second point when deactivated
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
   state = traj_lifecycle_node->deactivate();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-  traj_controller->update();
-  test_robot->write();
 
   // no change in hw position
-  EXPECT_EQ(3.3, test_robot->pos1);
-  EXPECT_EQ(4.4, test_robot->pos2);
-  EXPECT_EQ(5.5, test_robot->pos3);
+  auto allowed_delta = 0.001;
+  EXPECT_NEAR(3.3, test_robot->pos1, allowed_delta);
+  EXPECT_NEAR(4.4, test_robot->pos2, allowed_delta);
+  EXPECT_NEAR(5.5, test_robot->pos3, allowed_delta);
 
   // cleanup
   state = traj_lifecycle_node->cleanup();
+
+  // update loop receives a new msg and updates accordingly
+  traj_controller->update();
+  test_robot->write();
+
+  // check the traj_msg_home_ptr_ initialization code for the standard wait timing
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
   traj_controller->update();
   test_robot->write();
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
-  EXPECT_EQ(1.1, test_robot->pos1);
-  EXPECT_EQ(2.2, test_robot->pos2);
-  EXPECT_EQ(3.3, test_robot->pos3);
+  
+  EXPECT_NEAR(1.1, test_robot->pos1, allowed_delta);
+  EXPECT_NEAR(2.2, test_robot->pos2, allowed_delta);
+  EXPECT_NEAR(3.3, test_robot->pos3, allowed_delta);
 
   state = traj_lifecycle_node->configure();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -69,7 +69,7 @@ protected:
 
   /// Publish trajectory msgs with multiple points
   /**
-   *  delay - delay between each points
+   *  delay_btwn_points - delay between each points
    *  points - vector of trajectories. Each trajectory consists of 3 joints
    */
   void publish(
@@ -406,7 +406,7 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   // *INDENT-ON*
   publish(time_from_start, points);
   // wait for msg is be published to the system
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   // first update
   traj_controller->update();

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -421,7 +421,7 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   state = traj_lifecycle_node->deactivate();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 
-  auto allowed_delta = 0.01;
+  auto allowed_delta = 0.05;
   EXPECT_NEAR(3.3, test_robot->pos1, allowed_delta);
   EXPECT_NEAR(4.4, test_robot->pos2, allowed_delta);
   EXPECT_NEAR(5.5, test_robot->pos3, allowed_delta);

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -411,7 +411,7 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   // first update
   traj_controller->update();
   test_robot->write();
-  
+
   // wait so controller process the second point when deactivated
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   traj_controller->update();
@@ -439,7 +439,7 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   traj_controller->update();
   test_robot->write();
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
-  
+
   EXPECT_NEAR(1.1, test_robot->pos1, allowed_delta);
   EXPECT_NEAR(2.2, test_robot->pos2, allowed_delta);
   EXPECT_NEAR(3.3, test_robot->pos3, allowed_delta);

--- a/travis/workspace.repos
+++ b/travis/workspace.repos
@@ -10,7 +10,7 @@ repositories:
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
-    version: dashing-devel
+    version: ros2_devel
   angles:
     type: git
     url: https://github.com/ros/angles.git

--- a/travis/workspace.repos
+++ b/travis/workspace.repos
@@ -11,3 +11,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
     version: dashing-devel
+  angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2


### PR DESCRIPTION
Issue [ #12](https://github.com/ros-controls/ros2_controllers/issues/12)

- Includes functionality to cancel actions. Robot holds position if we cancel.
- Feedback only posts data during action execution.
- Checks for goals and path violations, sending the success responses when the goal is achieved, else abort responses if something is violated.
- Append current, desired and error Pos/Vel/Acc data to publish_state() messages
- Hold position if we receive a cancel action 
- Success if joints arrive at the desired goal position within the specified goal_time_tolerance (if parameter set to non-zero)

**PR Dependencies**
- ~~Depends on PR #25  (state_publish_rate)~~ merged
- ~~Depends on PR [realtime tools server goal handle fixes](https://github.com/ros-controls/realtime_tools/pull/57)~~ merged

**Tolerance checking**
- To get goal and tolerance checks working, the Trajectory class has been tweaked to support simple linear interpolation of states. (Pre-PR implementation essentially simulated a step function)
- TODO issue should be put up to support custom interpolations and port over spline interpolations from ros_controllers if this PR goes in. https://github.com/ros-controls/ros2_controllers/issues/30
- Partial joints are not implemented yet. https://github.com/ros-controls/ros2_controllers/issues/31



