### PR TITLE
Add on_activate to JointStateController

### DIFF
--- a/joint_state_controller/include/joint_state_controller/joint_state_controller.hpp
+++ b/joint_state_controller/include/joint_state_controller/joint_state_controller.hpp
@@ -44,6 +44,10 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State & previous_state) override;
 
+  JOINT_STATE_CONTROLLER_PUBLIC
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
 private:
   std::vector<const hardware_interface::JointStateHandle *> registered_joint_handles_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::JointState>>

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -56,6 +56,15 @@ JointStateController::on_configure(const rclcpp_lifecycle::State & previous_stat
 
   joint_state_publisher_ = lifecycle_node_->create_publisher<sensor_msgs::msg::JointState>(
     "joint_states", rclcpp::SystemDefaultsQoS());
+
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+JointStateController::on_activate(const rclcpp_lifecycle::State & previous_state)
+{
+  (void) previous_state;
+
   joint_state_publisher_->on_activate();
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;


### PR DESCRIPTION
`JointTrajectoryController::on_activate` calls `LifecyclePublisher::on_activate`. https://github.com/ros-controls/ros2_controllers/blob/master/joint_trajectory_controller/src/joint_trajectory_controller.cpp#L411
But `JointStateController` calls it `on_configure` instead. This PR simply fixed it.