### PR TITLE
Fixed package xml, used depend tag

### DIFF
--- a/joint_state_controller/package.xml
+++ b/joint_state_controller/package.xml
@@ -12,21 +12,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>controller_interface</build_depend>
   <build_depend>pluginlib</build_depend>
-  <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>rcutils</build_depend>
-  <build_depend>sensor_msgs</build_depend>
 
-  <build_export_depend>controller_interface</build_export_depend>
-  <build_export_depend>rclcpp_lifecycle</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-
-  <exec_depend>controller_interface</exec_depend>
   <exec_depend>pluginlib</exec_depend>
-  <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>rcutils</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
+
+  <depend>controller_interface</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -13,31 +13,21 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>angles</build_depend>
-  <build_depend>controller_interface</build_depend>
-  <build_depend>control_msgs</build_depend>
-  <build_depend>hardware_interface</build_depend>
   <build_depend>pluginlib</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>realtime_tools</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
 
-  <build_export_depend>controller_interface</build_export_depend>
-  <build_export_depend>control_msgs</build_export_depend>
-  <build_export_depend>hardware_interface</build_export_depend>
-  <build_export_depend>rclcpp</build_export_depend>
-  <build_export_depend>rclcpp_lifecycle</build_export_depend>
-  <build_export_depend>trajectory_msgs</build_export_depend>
-
-  <exec_depend>controller_interface</exec_depend>
-  <exec_depend>control_msgs</exec_depend>
-  <exec_depend>hardware_interface</exec_depend>
+  <exec_depend>angles</exec_depend>
   <exec_depend>pluginlib</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>rcutils</exec_depend>
-  <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>realtime_tools</exec_depend>
+
+  <depend>controller_interface</depend>
+  <depend>control_msgs</depend>
+  <depend>hardware_interface</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>trajectory_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
As described in the [REP 149](https://www.ros.org/reps/rep-0149.html#depend-multiple)

> `<depend>` tag is equivalent to specifying `<build_depend>`, `<build_export_depend>` and `<exec_depend>`,

Signed-off-by: ahcorde <ahcorde@gmail.com>