### PR TITLE
Pull control-msgs foxy-devel branch instead of crystal-devel

### DIFF
--- a/travis/workspace.repos
+++ b/travis/workspace.repos
@@ -6,7 +6,7 @@ repositories:
   control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
-    version: crystal-devel
+    version: foxy-devel
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Mandatory to start working with the new flexible joint state messages.