### PR TITLE
[diff-drive] Port over launch tests

### DIFF
--- a/.github/workspace.repos
+++ b/.github/workspace.repos
@@ -15,3 +15,7 @@ repositories:
     type: git
     url: https://github.com/ros/angles.git
     version: ros2
+  xacro:
+    type: git
+    url: https://github.com/ros/xacro.git
+    version: dashing-devel

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(diff_drive_controller SHARED
   src/diff_drive_controller.cpp
   src/odometry.cpp
   src/speed_limiter.cpp
+  src/urdf_util.cpp
 )
 
 target_include_directories(diff_drive_controller PRIVATE include)
@@ -112,7 +113,7 @@ if(BUILD_TESTING)
 
   # Diffbot
   # Robot with a DiffDriveController used for integration testing
-  add_executable(diffbot test/diffbot.h test/diffbot.cpp)
+  add_executable(diffbot test/diffbot.hpp test/diffbot.cpp)
   ament_target_dependencies(diffbot hardware_interface controller_manager rclcpp rosgraph_msgs lifecycle_msgs std_srvs)
   # End Diffbot
 
@@ -130,12 +131,11 @@ if(BUILD_TESTING)
     test_diff_drive_pub_wheel_joint_controller_state
     test_diff_drive_default_odom_frame
     test_diff_drive_odom_frame
-    test_diff_drive_multiple_cmd_vel_publishers
-    )
+    test_diff_drive_multiple_cmd_vel_publishers)
 
   foreach(launch_gtest IN LISTS launch_gtests)
     ament_add_gtest_executable(${launch_gtest}
-      test/test_common.h
+      test/test_common.hpp
       test/${launch_gtest}.cpp)
     ament_target_dependencies(${launch_gtest} tf2_ros std_srvs)
     target_link_libraries(${launch_gtest} diff_drive_controller)
@@ -153,13 +153,13 @@ if(BUILD_TESTING)
 
   # Skidsteerbot
   # Robot with a DiffDriveController used for integration testing
-  add_executable(skidsteerbot test/diffbot.h test/skidsteerbot.cpp)
+  add_executable(skidsteerbot test/diffbot.hpp test/skidsteerbot.cpp)
   ament_target_dependencies(skidsteerbot hardware_interface controller_manager rclcpp rosgraph_msgs lifecycle_msgs std_srvs)
   # End Skidsteerbot
 
   add_ros_test(test/test_skid_steer.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
   add_ros_test(test/test_skid_steer_no_wheels.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
-endif ()
+endif()
 
 ament_export_dependencies(
   controller_interface

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(controller_interface REQUIRED)
+find_package(control_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(nav_msgs REQUIRED)
@@ -22,6 +23,7 @@ find_package(realtime_tools REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
+find_package(urdf REQUIRED)
 
 add_library(diff_drive_controller SHARED
   src/diff_drive_controller.cpp
@@ -43,6 +45,8 @@ ament_target_dependencies(diff_drive_controller
   sensor_msgs
   tf2
   tf2_msgs
+  control_msgs
+  urdf
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -61,6 +65,7 @@ install(TARGETS diff_drive_controller
 )
 
 if(BUILD_TESTING)
+  find_package(ros_testing REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(controller_manager REQUIRED)
@@ -68,27 +73,7 @@ if(BUILD_TESTING)
 
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gtest(test_diff_drive_controller
-    test/test_diff_drive_controller.cpp
-    ENV config_file=${CMAKE_CURRENT_SOURCE_DIR}/test/config/test_diff_drive_controller.yaml)
-  target_include_directories(test_diff_drive_controller PRIVATE include)
-  target_link_libraries(test_diff_drive_controller
-    diff_drive_controller
-  )
-
-  ament_target_dependencies(test_diff_drive_controller
-    geometry_msgs
-    hardware_interface
-    nav_msgs
-    rclcpp
-    rclcpp_lifecycle
-    realtime_tools
-    sensor_msgs
-    test_robot_hardware
-    tf2
-    tf2_msgs
-  )
-
+  # Unit test: test_load_diff_drive_controller
   ament_add_gtest(
     test_load_diff_drive_controller
     test/test_load_diff_drive_controller.cpp
@@ -99,6 +84,7 @@ if(BUILD_TESTING)
     controller_manager
     test_robot_hardware
   )
+  # End Unit test: test_load_diff_drive_controller
 
   ament_add_gtest(
     test_accumulator
@@ -108,7 +94,72 @@ if(BUILD_TESTING)
   target_include_directories(test_accumulator PRIVATE include)
   ament_target_dependencies(test_accumulator)
 
-endif()
+
+  # Unit test: test_diff_drive_controller
+  ament_add_gtest(test_diff_drive_controller
+    test/test_diff_drive_controller.cpp
+    ENV config_file=${CMAKE_CURRENT_SOURCE_DIR}/test/config/test_diff_drive_controller.yaml)
+  target_include_directories(test_diff_drive_controller PRIVATE include)
+  target_link_libraries(test_diff_drive_controller
+    diff_drive_controller
+  )
+  ament_target_dependencies(test_diff_drive_controller test_robot_hardware)
+  # End Unit test: test_diff_drive_controller
+
+  find_package(rosgraph_msgs REQUIRED)
+  find_package(std_srvs REQUIRED)
+  find_package(tf2_ros REQUIRED)
+
+  # Diffbot
+  # Robot with a DiffDriveController used for integration testing
+  add_executable(diffbot test/diffbot.h test/diffbot.cpp)
+  ament_target_dependencies(diffbot hardware_interface controller_manager rclcpp rosgraph_msgs lifecycle_msgs std_srvs)
+  # End Diffbot
+
+  # Gtest executables used in launch tests
+  set(launch_gtests
+    test_diff_drive
+    test_diff_drive_nan
+    test_diff_drive_limits
+    test_diff_drive_timeout
+    test_diff_drive_fail
+    test_diff_drive_odom_tf
+    test_diff_drive_default_cmd_vel_out
+    test_diff_drive_pub_cmd_vel_out
+    test_diff_drive_default_wheel_joint_controller_state
+    test_diff_drive_pub_wheel_joint_controller_state
+    test_diff_drive_default_odom_frame
+    test_diff_drive_odom_frame
+    test_diff_drive_multiple_cmd_vel_publishers
+    )
+
+  foreach(launch_gtest IN LISTS launch_gtests)
+    ament_add_gtest_executable(${launch_gtest}
+      test/test_common.h
+      test/${launch_gtest}.cpp)
+    ament_target_dependencies(${launch_gtest} tf2_ros std_srvs)
+    target_link_libraries(${launch_gtest} diff_drive_controller)
+    add_ros_test(test/${launch_gtest}.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+  endforeach()
+
+  add_ros_test(test/test_diff_drive_multipliers.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+  add_ros_test(test/test_diff_drive_open_loop.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+
+  add_ros_test(test/test_diff_drive_radius_sphere.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+  add_ros_test(test/test_diff_drive_radius_param.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+  add_ros_test(test/test_diff_drive_radius_param_fail.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+  add_ros_test(test/test_diff_drive_separation_param.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+  add_ros_test(test/test_diff_drive_bad_urdf.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+
+  # Skidsteerbot
+  # Robot with a DiffDriveController used for integration testing
+  add_executable(skidsteerbot test/diffbot.h test/skidsteerbot.cpp)
+  ament_target_dependencies(skidsteerbot hardware_interface controller_manager rclcpp rosgraph_msgs lifecycle_msgs std_srvs)
+  # End Skidsteerbot
+
+  add_ros_test(test/test_skid_steer.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+  add_ros_test(test/test_skid_steer_no_wheels.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+endif ()
 
 ament_export_dependencies(
   controller_interface

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
@@ -19,7 +19,6 @@
 #ifndef DIFF_DRIVE_CONTROLLER__DIFF_DRIVE_CONTROLLER_HPP_
 #define DIFF_DRIVE_CONTROLLER__DIFF_DRIVE_CONTROLLER_HPP_
 
-#include <tf2/LinearMath/Quaternion.h>
 #include <chrono>
 #include <cmath>
 #include <memory>
@@ -44,6 +43,7 @@
 #include "realtime_tools/realtime_buffer.h"
 #include "realtime_tools/realtime_publisher.h"
 #include "sensor_msgs/msg/joint_state.hpp"
+#include "tf2/LinearMath/Quaternion.h"
 #include "tf2_msgs/msg/tf_message.hpp"
 
 namespace diff_drive_controller
@@ -226,8 +226,8 @@ protected:
   std::vector<double> vel_left_actual_previous_;
   std::vector<double> vel_right_actual_previous_;
   /// Previous desired velocities
-  double vel_left_desired_previous_;
-  double vel_right_desired_previous_;
+  double vel_left_desired_previous_ = 0.0;
+  double vel_right_desired_previous_ = 0.0;
 
   // Flag for using open loop calculation for odometry
   bool open_loop_ = false;

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
@@ -135,8 +135,7 @@ protected:
   Odometry odometry_;
 
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Odometry>> odometry_publisher_
-    =
-    nullptr;
+    = nullptr;
   std::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::msg::Odometry>>
   realtime_odometry_publisher_ = nullptr;
 

--- a/diff_drive_controller/include/diff_drive_controller/urdf_util.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/urdf_util.hpp
@@ -1,0 +1,43 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DIFF_DRIVE_CONTROLLER__URDF_UTIL_HPP_
+#define DIFF_DRIVE_CONTROLLER__URDF_UTIL_HPP_
+
+#include <urdf/urdfdom_compatibility.h>
+#include <urdf_parser/urdf_parser.h>
+#include <rclcpp/logging.hpp>
+
+namespace urdf_util
+{
+/**
+ * \brief Calculate L2 distance between two vectors
+ * \param vec1 first vector
+ * \param vec2 second vector
+ * \return distance between the two
+ */
+double euclidean_of_vectors(const urdf::Vector3 & vec1, const urdf::Vector3 & vec2);
+
+/*
+ * \brief Get the wheel radius
+ * \param [in]  wheel_link   Wheel link
+ * \param [out] wheel_radius Wheel radius [m]
+ * \return true if the wheel radius was found; false otherwise
+ */
+bool get_wheel_radius(
+  const urdf::LinkConstSharedPtr & wheel_link, double & wheel_radius,
+  const rclcpp::Logger & logger);
+}  // namespace urdf_util
+
+#endif  // DIFF_DRIVE_CONTROLLER__URDF_UTIL_HPP_

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>controller_interface</depend>
+  <depend>control_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>
@@ -19,6 +20,7 @@
   <depend>realtime_tools</depend>
   <depend>tf2</depend>
   <depend>tf2_msgs</depend>
+  <depend>urdf</depend>
 
   <build_depend>pluginlib</build_depend>
 
@@ -27,6 +29,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>test_robot_hardware</test_depend>
+  <test_depend>xacro</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -28,7 +28,10 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>ros_testing</test_depend>
+  <test_depend>std_srvs</test_depend>
   <test_depend>test_robot_hardware</test_depend>
+  <test_depend>tf2_ros</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -16,128 +16,30 @@
  * Author: Bence Magyar, Enrique Fernández, Manuel Meraz
  */
 
+#include "diff_drive_controller/diff_drive_controller.hpp"
+
 #include <memory>
 #include <queue>
 #include <string>
 #include <utility>
 #include <vector>
+#include <algorithm>
+#include <limits>
 
-#include "diff_drive_controller/diff_drive_controller.hpp"
-#include "diff_drive_controller/diff_drive_controller.hpp"
+#include "diff_drive_controller/urdf_util.hpp"
+#include "tf2/LinearMath/Quaternion.h"
+#include "lifecycle_msgs/msg/state.hpp"
 
-#include <tf2/LinearMath/Quaternion.h>
-#include <urdf/urdfdom_compatibility.h>
-#include <urdf_parser/urdf_parser.h>
-#include <lifecycle_msgs/msg/state.hpp>
-#include <utility>
 
-namespace urdf_util
-{
-double euclidean_of_vectors(const urdf::Vector3 & vec1, const urdf::Vector3 & vec2)
-{
-  return std::sqrt(
-    std::pow(vec1.x - vec2.x, 2) + std::pow(vec1.y - vec2.y, 2) + std::pow(vec1.z - vec2.z, 2));
-}
-
-/*
-* \brief Check that a link exists and has a geometry collision.
-* \param link The link
-* \return true if the link has a collision element with geometry
-*/
-bool has_collision_geometry(const urdf::LinkConstSharedPtr & link, const rclcpp::Logger & logger)
-{
-  if (!link) {
-    RCLCPP_ERROR(logger, "Link pointer is null.");
-    return false;
-  }
-
-  if (!link->collision) {
-    RCLCPP_ERROR_STREAM(
-      logger,
-      "Link "
-        << link->name
-        << " does not have collision description. Add collision description for link to urdf.");
-    return false;
-  }
-
-  if (!link->collision->geometry) {
-    RCLCPP_ERROR_STREAM(
-      logger, "Link " << link->name
-                      << " does not have collision geometry description. Add collision geometry "
-                         "description for link to urdf.");
-    return false;
-  }
-  return true;
-}
-
-/*
- * \brief Check if the link is modeled as a cylinder
- * \param link Link
- * \return true if the link is modeled as a Cylinder; false otherwise
- */
-bool is_cylinder(const urdf::LinkConstSharedPtr & link, const rclcpp::Logger & logger)
-{
-  if (!has_collision_geometry(link, logger)) {
-    return false;
-  }
-
-  if (link->collision->geometry->type != urdf::Geometry::CYLINDER) {
-    RCLCPP_DEBUG_STREAM(logger, "Link " << link->name << " does not have cylinder geometry");
-    return false;
-  }
-
-  return true;
-}
-
-/*
- * \brief Check if the link is modeled as a sphere
- * \param link Link
- * \return true if the link is modeled as a Sphere; false otherwise
- */
-
-bool is_sphere(const urdf::LinkConstSharedPtr & link, const rclcpp::Logger & logger)
-{
-  if (!has_collision_geometry(link, logger)) {
-    return false;
-  }
-
-  if (link->collision->geometry->type != urdf::Geometry::SPHERE) {
-    RCLCPP_DEBUG_STREAM(logger, "Link " << link->name << " does not have sphere geometry");
-    return false;
-  }
-
-  return true;
-}
-/*
- * \brief Get the wheel radius
- * \param [in]  wheel_link   Wheel link
- * \param [out] wheel_radius Wheel radius [m]
- * \return true if the wheel radius was found; false otherwise
- */
-bool get_wheel_radius(
-  const urdf::LinkConstSharedPtr & wheel_link, double & wheel_radius, const rclcpp::Logger & logger)
-{
-  if (is_cylinder(wheel_link, logger)) {
-    wheel_radius = (static_cast<urdf::Cylinder *>(wheel_link->collision->geometry.get()))->radius;
-    return true;
-  } else if (is_sphere(wheel_link, logger)) {
-    wheel_radius = (static_cast<urdf::Sphere *>(wheel_link->collision->geometry.get()))->radius;
-    return true;
-  }
-
-  RCLCPP_ERROR_STREAM(
-    logger, "Wheel link " << wheel_link->name << " is NOT modeled as a cylinder or sphere!");
-  return false;
-}
-}  // namespace urdf_util
+// namespace urdf_util
 
 namespace
 {
-constexpr auto DEFAULT_COMMAND_TOPIC = "/cmd_vel";
-constexpr auto DEFAULT_COMMAND_OUT_TOPIC = "/cmd_vel_out";
-constexpr auto DEFAULT_ODOMETRY_TOPIC = "/odom";
+constexpr auto DEFAULT_COMMAND_TOPIC = "cmd_vel";
+constexpr auto DEFAULT_COMMAND_OUT_TOPIC = "cmd_vel_out";
+constexpr auto DEFAULT_ODOMETRY_TOPIC = "odom";
 constexpr auto DEFAULT_TRANSFORM_TOPIC = "/tf";
-constexpr auto DEFAULT_WHEEL_JOINT_CONTROLLER_STATE_TOPIC = "/wheel_joint_controller_state";
+constexpr auto DEFAULT_WHEEL_JOINT_CONTROLLER_STATE_TOPIC = "wheel_joint_controller_state";
 }  // namespace
 
 namespace diff_drive_controller
@@ -150,14 +52,14 @@ DiffDriveController::DiffDriveController()
 : controller_interface::ControllerInterface() {}
 
 DiffDriveController::DiffDriveController(
-  std::vector<std::string> left_wheel_names,
-  std::vector<std::string> right_wheel_names,
+  std::vector<std::string> left_wheel_names, std::vector<std::string> right_wheel_names,
   std::vector<std::string> write_op_names)
 : controller_interface::ControllerInterface(),
   left_wheel_names_(std::move(left_wheel_names)),
   right_wheel_names_(std::move(right_wheel_names)),
   write_op_names_(std::move(write_op_names))
-{}
+{
+}
 
 controller_interface::return_type
 DiffDriveController::init(
@@ -170,34 +72,25 @@ DiffDriveController::init(
     return ret;
   }
 
-  // with the lifecycle node being initialized, we can declare parameters
   lifecycle_node_->declare_parameter<std::vector<std::string>>(
-    "left_wheel_names",
-    left_wheel_names_);
+    "left_wheel_names", left_wheel_names_);
   lifecycle_node_->declare_parameter<std::vector<std::string>>(
-    "right_wheel_names",
-    right_wheel_names_);
+    "right_wheel_names", right_wheel_names_);
   lifecycle_node_->declare_parameter<std::vector<std::string>>("write_op_modes", write_op_names_);
 
-  lifecycle_node_->declare_parameter<double>("wheel_separation", wheel_params_.separation);
-  lifecycle_node_->declare_parameter<double>("wheel_radius", wheel_params_.radius);
-  lifecycle_node_->declare_parameter<double>(
-    "wheel_separation_multiplier",
-    wheel_params_.separation_multiplier);
-  lifecycle_node_->declare_parameter<double>(
-    "left_wheel_radius_multiplier",
-    wheel_params_.left_radius_multiplier);
-  lifecycle_node_->declare_parameter<double>(
-    "right_wheel_radius_multiplier",
-    wheel_params_.right_radius_multiplier);
+  lifecycle_node_->declare_parameter<double>("wheel_separation", 0.0);
+  lifecycle_node_->declare_parameter<double>("wheel_radius", 0.0);
+  lifecycle_node_->declare_parameter<double>("wheel_separation_multiplier", 1.0);
+  lifecycle_node_->declare_parameter<double>("left_wheel_radius_multiplier", 1.0);
+  lifecycle_node_->declare_parameter<double>("right_wheel_radius_multiplier", 1.0);
   lifecycle_node_->declare_parameter("robot_description");
 
-  lifecycle_node_->declare_parameter<std::string>("odom_frame_id", odom_params_.odom_frame_id);
-  lifecycle_node_->declare_parameter<std::string>("base_frame_id", odom_params_.base_frame_id);
+  lifecycle_node_->declare_parameter<std::string>("odom_frame_id", odom_frame_id_);
+  lifecycle_node_->declare_parameter<std::string>("base_frame_id", base_frame_id_);
   lifecycle_node_->declare_parameter<std::vector<double>>("pose_covariance_diagonal", {});
   lifecycle_node_->declare_parameter<std::vector<double>>("twist_covariance_diagonal", {});
-  lifecycle_node_->declare_parameter<bool>("open_loop", odom_params_.open_loop);
-  lifecycle_node_->declare_parameter<bool>("enable_odom_tf", odom_params_.enable_odom_tf);
+  lifecycle_node_->declare_parameter<bool>("open_loop", open_loop_);
+  lifecycle_node_->declare_parameter<bool>("enable_odom_tf", enable_odom_tf_);
 
   lifecycle_node_->declare_parameter<int>("cmd_vel_timeout", cmd_vel_timeout_.count());
   lifecycle_node_->declare_parameter<bool>(
@@ -243,18 +136,12 @@ controller_interface::return_type DiffDriveController::update()
 
   const auto current_time = lifecycle_node_->get_clock()->now();
 
-  // Apply (possibly new) multipliers:
-  const auto wheels = wheel_params_;
-  const double wheel_separation = wheels.separation_multiplier * wheels.separation;
-  const double left_wheel_radius = wheels.left_radius_multiplier * wheels.radius;
-  const double right_wheel_radius = wheels.right_radius_multiplier * wheels.radius;
-
-  if (odom_params_.open_loop) {
+  if (open_loop_) {
     odometry_.updateOpenLoop(last0_cmd_.lin, last0_cmd_.ang, current_time);
   } else {
     double left_position_mean = 0.0;
     double right_position_mean = 0.0;
-    for (size_t index = 0; index < wheels.wheels_per_side; ++index) {
+    for (size_t index = 0; index < wheels_per_side_; ++index) {
       const double left_position = registered_left_wheel_handles_[index].state->get_position();
       const double right_position = registered_right_wheel_handles_[index].state->get_position();
 
@@ -268,8 +155,8 @@ controller_interface::return_type DiffDriveController::update()
       left_position_mean += left_position;
       right_position_mean += right_position;
     }
-    left_position_mean /= wheels.wheels_per_side;
-    right_position_mean /= wheels.wheels_per_side;
+    left_position_mean /= wheels_per_side_;
+    right_position_mean /= wheels_per_side_;
 
     odometry_.update(left_position_mean, right_position_mean, current_time);
   }
@@ -277,40 +164,14 @@ controller_interface::return_type DiffDriveController::update()
   tf2::Quaternion orientation;
   orientation.setRPY(0.0, 0.0, odometry_.getHeading());
 
-  if (odometry_publisher_->is_activated() && realtime_odometry_publisher_->trylock()) {
-    auto & odometry_message = realtime_odometry_publisher_->msg_;
-    odometry_message.header.stamp = current_time;
-    odometry_message.pose.pose.position.x = odometry_.getX();
-    odometry_message.pose.pose.position.y = odometry_.getY();
-    odometry_message.pose.pose.orientation.x = orientation.x();
-    odometry_message.pose.pose.orientation.y = orientation.y();
-    odometry_message.pose.pose.orientation.z = orientation.z();
-    odometry_message.pose.pose.orientation.w = orientation.w();
-    odometry_message.twist.twist.linear.x = odometry_.getLinear();
-    odometry_message.twist.twist.angular.z = odometry_.getAngular();
-    realtime_odometry_publisher_->unlockAndPublish();
-  }
+  publish_odom(current_time, orientation);
+  publish_odom_tf(current_time, orientation);
 
-  if (odom_params_.enable_odom_tf && odometry_transform_publisher_->is_activated() &&
-    realtime_odometry_transform_publisher_->trylock())
-  {
-    auto & transform = realtime_odometry_transform_publisher_->msg_.transforms.front();
-    transform.header.stamp = current_time;
-    transform.transform.translation.x = odometry_.getX();
-    transform.transform.translation.y = odometry_.getY();
-    transform.transform.rotation.x = orientation.x();
-    transform.transform.rotation.y = orientation.y();
-    transform.transform.rotation.z = orientation.z();
-    transform.transform.rotation.w = orientation.w();
-    realtime_odometry_transform_publisher_->unlockAndPublish();
-  }
-
-  // Retrieve current velocity command and time step:
+  // Retrieve last velocity command received
   Commands curr_cmd = *(command_.readFromRT());
 
   // Brake if cmd_vel has timeout
-  const auto dt = current_time - curr_cmd.stamp;
-  if (dt > cmd_vel_timeout_) {
+  if (current_time - curr_cmd.stamp > cmd_vel_timeout_) {
     curr_cmd.lin = 0.0;
     curr_cmd.ang = 0.0;
   }
@@ -318,39 +179,30 @@ controller_interface::return_type DiffDriveController::update()
   // Time elapsed since last update iteration
   const auto update_dt = current_time - previous_update_timestamp_;
 
-  publish_wheel_data(
-    current_time, update_dt, curr_cmd, wheel_separation, left_wheel_radius, right_wheel_radius);
+  // NOTE: publish_wheel_joint_controller_state() must be called before limiter is applied.
+  publish_wheel_joint_controller_state(current_time, update_dt, curr_cmd);
 
   // Enforce limiters
   limiter_linear_.limit(curr_cmd.lin, last0_cmd_.lin, last1_cmd_.lin, update_dt.seconds());
   limiter_angular_.limit(curr_cmd.ang, last0_cmd_.ang, last1_cmd_.ang, update_dt.seconds());
 
-  //    Publish limited velocity
-  if (publish_limited_velocity_ && limited_velocity_publisher_->is_activated() &&
-    realtime_limited_velocity_publisher_->trylock())
-  {
-    auto & limited_velocity_command = realtime_limited_velocity_publisher_->msg_;
-    limited_velocity_command.header.stamp = current_time;
-    limited_velocity_command.twist.linear.x = curr_cmd.lin;
-    limited_velocity_command.twist.angular.z = curr_cmd.ang;
-    realtime_limited_velocity_publisher_->unlockAndPublish();
-  }
+  publish_cmd_vel_out(current_time, curr_cmd);
 
   // Compute wheels velocities:
   const double velocity_left =
-    (curr_cmd.lin - curr_cmd.ang * wheel_separation / 2.0) / left_wheel_radius;
+    (curr_cmd.lin - curr_cmd.ang * wheel_separation_ / 2.0) / left_wheel_radius_;
   const double velocity_right =
-    (curr_cmd.lin + curr_cmd.ang * wheel_separation / 2.0) / right_wheel_radius;
+    (curr_cmd.lin + curr_cmd.ang * wheel_separation_ / 2.0) / right_wheel_radius_;
 
-  // Set wheels velocities:
-  for (size_t index = 0; index < wheels.wheels_per_side; ++index) {
+  // Send wheel velocity commands:
+  for (size_t index = 0; index < wheels_per_side_; ++index) {
     registered_left_wheel_handles_[index].command->set_cmd(velocity_left);
     registered_right_wheel_handles_[index].command->set_cmd(velocity_right);
   }
 
   set_op_mode(hardware_interface::OperationMode::ACTIVE);
 
-  // push back
+  // push back command history
   last1_cmd_ = last0_cmd_;
   last0_cmd_ = curr_cmd;
   previous_update_timestamp_ = current_time;
@@ -366,68 +218,64 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
 
   auto logger = lifecycle_node_->get_logger();
 
-  // update parameters
   left_wheel_names_ = lifecycle_node_->get_parameter("left_wheel_names").as_string_array();
   right_wheel_names_ = lifecycle_node_->get_parameter("right_wheel_names").as_string_array();
-  write_op_names_ = lifecycle_node_->get_parameter("write_op_modes").as_string_array();
 
-  wheel_params_.separation = lifecycle_node_->get_parameter("wheel_separation").as_double();
-  wheel_params_.radius = lifecycle_node_->get_parameter("wheel_radius").as_double();
-  wheel_params_.separation_multiplier =
+  if (left_wheel_names_.size() != right_wheel_names_.size()) {
+    RCLCPP_ERROR(
+      logger, "The number of left wheels [%d] and the number of right wheels [%d] are different",
+      left_wheel_names_.size(), right_wheel_names_.size());
+    return CallbackReturn::ERROR;
+  }
+
+  auto raw_separation = lifecycle_node_->get_parameter("wheel_separation").as_double();
+  auto raw_radius = lifecycle_node_->get_parameter("wheel_radius").as_double();
+  auto separation_multiplier =
     lifecycle_node_->get_parameter("wheel_separation_multiplier").as_double();
-  wheel_params_.left_radius_multiplier =
+  auto left_radius_multiplier =
     lifecycle_node_->get_parameter("left_wheel_radius_multiplier").as_double();
-  wheel_params_.right_radius_multiplier =
+  auto right_radius_multiplier =
     lifecycle_node_->get_parameter("right_wheel_radius_multiplier").as_double();
 
-  const auto wheel_separation_missing = wheel_params_.separation == 0.0;
-  const auto wheel_radius_missing = wheel_params_.radius == 0.0;
-  if (!set_odom_params_from_urdf(
-        left_wheel_names_[0], right_wheel_names_[0], wheel_separation_missing,
-        wheel_radius_missing)) {
+  if (!set_wheel_params_from_urdf(
+      left_wheel_names_[0], right_wheel_names_[0], raw_separation, raw_radius))
+  {
     RCLCPP_ERROR_STREAM(
-      lifecycle_node_->get_logger(),
-      "The following configurations must be set via parameter or urdf: "
-        << (wheel_separation_missing ? "'wheel_separation' " : "")
-        << (wheel_radius_missing ? "'wheel_radius'" : ""));
+      logger, "The following configurations must be set via parameter or urdf: " <<
+      (raw_separation == 0.0 ? "'wheel_separation' " : "") <<
+      (raw_radius == 0.0 ? "'wheel_radius'" : ""));
     return CallbackReturn::FAILURE;
   }
 
-  const auto & wheels = wheel_params_;
+  wheel_separation_ = separation_multiplier * raw_separation;
+  left_wheel_radius_ = left_radius_multiplier * raw_radius;
+  right_wheel_radius_ = right_radius_multiplier * raw_radius;
+  wheels_per_side_ = left_wheel_names_.size();
 
-  const double wheel_separation = wheels.separation_multiplier * wheels.separation;
-  const double left_wheel_radius = wheels.left_radius_multiplier * wheels.radius;
-  const double right_wheel_radius = wheels.right_radius_multiplier * wheels.radius;
-
-  odometry_.setWheelParams(wheel_separation, left_wheel_radius, right_wheel_radius);
+  odometry_.setWheelParams(wheel_separation_, left_wheel_radius_, right_wheel_radius_);
   odometry_.setVelocityRollingWindowSize(
-    lifecycle_node_->get_parameter(
-      "velocity_rolling_window_size").as_int());
+    lifecycle_node_->get_parameter("velocity_rolling_window_size").as_int());
 
-  odom_params_.odom_frame_id = lifecycle_node_->get_parameter("odom_frame_id").as_string();
-  odom_params_.base_frame_id = lifecycle_node_->get_parameter("base_frame_id").as_string();
+  odom_frame_id_ = lifecycle_node_->get_parameter("odom_frame_id").as_string();
+  base_frame_id_ = lifecycle_node_->get_parameter("base_frame_id").as_string();
 
   auto pose_diagonal = lifecycle_node_->get_parameter("pose_covariance_diagonal").as_double_array();
-  std::copy(
-    pose_diagonal.begin(), pose_diagonal.end(),
-    odom_params_.pose_covariance_diagonal.begin());
+  std::copy(pose_diagonal.begin(), pose_diagonal.end(), pose_covariance_diagonal_.begin());
 
   auto twist_diagonal =
     lifecycle_node_->get_parameter("twist_covariance_diagonal").as_double_array();
-  std::copy(
-    twist_diagonal.begin(),
-    twist_diagonal.end(), odom_params_.twist_covariance_diagonal.begin());
+  std::copy(twist_diagonal.begin(), twist_diagonal.end(), twist_covariance_diagonal_.begin());
 
-  odom_params_.open_loop = lifecycle_node_->get_parameter("open_loop").as_bool();
-  odom_params_.enable_odom_tf = lifecycle_node_->get_parameter("enable_odom_tf").as_bool();
+  open_loop_ = lifecycle_node_->get_parameter("open_loop").as_bool();
+  enable_odom_tf_ = lifecycle_node_->get_parameter("enable_odom_tf").as_bool();
 
   cmd_vel_timeout_ =
     std::chrono::milliseconds{lifecycle_node_->get_parameter("cmd_vel_timeout").as_int()};
   allow_multiple_cmd_vel_publishers_ =
     lifecycle_node_->get_parameter("allow_multiple_cmd_vel_publishers").as_bool();
   RCLCPP_INFO_STREAM(
-    logger, "Allow multiple cmd_vel publishers is "
-              << (allow_multiple_cmd_vel_publishers_ ? "enabled" : "disabled"));
+    logger, "Allow multiple cmd_vel publishers is " <<
+    (allow_multiple_cmd_vel_publishers_ ? "enabled" : "disabled"));
 
   publish_limited_velocity_ = lifecycle_node_->get_parameter("publish_limited_velocity").as_bool();
   publish_wheel_joint_controller_state_ =
@@ -455,15 +303,6 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
     lifecycle_node_->get_parameter("angular.z.min_jerk").as_double(),
     lifecycle_node_->get_parameter("angular.z.max_jerk").as_double());
 
-  if (left_wheel_names_.size() != right_wheel_names_.size()) {
-    RCLCPP_ERROR(
-      logger,
-      "The number of left wheels [%d] and the number of right wheels [%d] are different",
-      left_wheel_names_.size(),
-      right_wheel_names_.size());
-    return CallbackReturn::ERROR;
-  }
-
   if (auto robot_hardware = robot_hardware_.lock()) {
     const auto left_result =
       configure_side("left", left_wheel_names_, registered_left_wheel_handles_, *robot_hardware);
@@ -473,6 +312,8 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
     if (left_result == CallbackReturn::FAILURE || right_result == CallbackReturn::FAILURE) {
       return CallbackReturn::FAILURE;
     }
+
+    write_op_names_ = lifecycle_node_->get_parameter("write_op_modes").as_string_array();
 
     registered_operation_mode_handles_.resize(write_op_names_.size());
     for (size_t index = 0; index < write_op_names_.size(); ++index) {
@@ -485,12 +326,12 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
         return CallbackReturn::FAILURE;
       }
     }
-
   } else {
     return CallbackReturn::ERROR;
   }
 
-  if (registered_left_wheel_handles_.empty() || registered_right_wheel_handles_.empty() ||
+  if (
+    registered_left_wheel_handles_.empty() || registered_right_wheel_handles_.empty() ||
     registered_operation_mode_handles_.empty())
   {
     RCLCPP_ERROR(
@@ -499,14 +340,9 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
     return CallbackReturn::ERROR;
   }
 
-  // left and right sides are both equal at this point
-  wheel_params_.wheels_per_side = registered_left_wheel_handles_.size();
-
   if (publish_limited_velocity_) {
-    limited_velocity_publisher_ =
-      lifecycle_node_->create_publisher<Twist>(
-      DEFAULT_COMMAND_OUT_TOPIC,
-      rclcpp::SystemDefaultsQoS());
+    limited_velocity_publisher_ = lifecycle_node_->create_publisher<Twist>(
+      DEFAULT_COMMAND_OUT_TOPIC, rclcpp::SystemDefaultsQoS());
     realtime_limited_velocity_publisher_ =
       std::make_shared<realtime_tools::RealtimePublisher<Twist>>(limited_velocity_publisher_);
   }
@@ -514,12 +350,12 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
   if (publish_wheel_joint_controller_state_) {
     wheel_joint_controller_state_publisher_ =
       lifecycle_node_->create_publisher<control_msgs::msg::JointTrajectoryControllerState>(
-        DEFAULT_WHEEL_JOINT_CONTROLLER_STATE_TOPIC, rclcpp::SystemDefaultsQoS());
+      DEFAULT_WHEEL_JOINT_CONTROLLER_STATE_TOPIC, rclcpp::SystemDefaultsQoS());
     realtime_wheel_joint_controller_state_publisher_ = std::make_shared<
       realtime_tools::RealtimePublisher<control_msgs::msg::JointTrajectoryControllerState>>(
       wheel_joint_controller_state_publisher_);
 
-    const size_t num_wheels = wheel_params_.wheels_per_side * 2;
+    const size_t num_wheels = wheels_per_side_ * 2;
 
     realtime_wheel_joint_controller_state_publisher_->msg_.joint_names.resize(num_wheels);
 
@@ -538,14 +374,14 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
     realtime_wheel_joint_controller_state_publisher_->msg_.error.accelerations.resize(num_wheels);
     realtime_wheel_joint_controller_state_publisher_->msg_.error.effort.resize(num_wheels);
 
-    for (size_t i = 0; i < wheel_params_.wheels_per_side; ++i) {
+    for (size_t i = 0; i < wheels_per_side_; ++i) {
       realtime_wheel_joint_controller_state_publisher_->msg_.joint_names[i] = left_wheel_names_[i];
-      realtime_wheel_joint_controller_state_publisher_->msg_
-        .joint_names[i + wheel_params_.wheels_per_side] = right_wheel_names_[i];
+      realtime_wheel_joint_controller_state_publisher_->msg_.joint_names[i + wheels_per_side_] =
+        right_wheel_names_[i];
     }
 
-    vel_left_previous_.resize(wheel_params_.wheels_per_side, 0.0);
-    vel_right_previous_.resize(wheel_params_.wheels_per_side, 0.0);
+    vel_left_actual_previous_.resize(wheels_per_side_, 0.0);
+    vel_right_actual_previous_.resize(wheels_per_side_, 0.0);
   }
 
   // Zero-initialize command
@@ -557,57 +393,19 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
 
   // initialize command subscriber
   velocity_command_subscriber_ = lifecycle_node_->create_subscription<Twist>(
-    DEFAULT_COMMAND_TOPIC, rclcpp::SystemDefaultsQoS(), [this](
-      const std::shared_ptr<Twist> msg) -> void {
-      if (!subscriber_is_active_) {
-        RCLCPP_WARN(
-          lifecycle_node_->get_logger(),
-          "Can't accept new commands. subscriber is inactive");
-        return;
-      }
+    DEFAULT_COMMAND_TOPIC, rclcpp::SystemDefaultsQoS(),
+    [this](const std::shared_ptr<Twist> msg) -> void {on_cmd_vel(msg);});
 
-      auto & clk = *lifecycle_node_->get_clock().get();
-      if (
-        !allow_multiple_cmd_vel_publishers_ &&
-        velocity_command_subscriber_->get_publisher_count() > 1) {
-        RCLCPP_ERROR_STREAM_THROTTLE(
-          lifecycle_node_->get_logger(), clk, 1000,
-          "Detected " << velocity_command_subscriber_->get_publisher_count()
-                      << " publishers. Only 1 publisher is allowed. Going to brake.");
-        halt();
-        return;
-      }
-
-      if (!std::isfinite(msg->twist.angular.z) || !std::isfinite(msg->twist.linear.x)) {
-        RCLCPP_WARN_THROTTLE(
-          lifecycle_node_->get_logger(), clk, 1000, "Received NaN in velocity command. Ignoring.");
-        return;
-      }
-
-      command_struct_.ang = msg->twist.angular.z;
-      command_struct_.lin = msg->twist.linear.x;
-      command_struct_.stamp = clk.now();
-      command_.writeFromNonRT (command_struct_);
-      RCLCPP_DEBUG_STREAM(lifecycle_node_->get_logger(),
-        "Added values to command. "
-          << "Ang: "   << command_struct_.ang << ", "
-          << "Lin: "   << command_struct_.lin << ", "
-          << "Stamp: " << command_struct_.stamp.seconds());
-
-    });
-
-  // initialize odometry publisher and messasge
-  odometry_publisher_ =
-    lifecycle_node_->create_publisher<nav_msgs::msg::Odometry>(
-    DEFAULT_ODOMETRY_TOPIC,
-    rclcpp::SystemDefaultsQoS());
+  // initialize odometry publisher and message
+  odometry_publisher_ = lifecycle_node_->create_publisher<nav_msgs::msg::Odometry>(
+    DEFAULT_ODOMETRY_TOPIC, rclcpp::SystemDefaultsQoS());
   realtime_odometry_publisher_ =
-    std::make_shared<
-    realtime_tools::RealtimePublisher<nav_msgs::msg::Odometry>>(odometry_publisher_);
+    std::make_shared<realtime_tools::RealtimePublisher<nav_msgs::msg::Odometry>>(
+    odometry_publisher_);
 
   auto & odometry_message = realtime_odometry_publisher_->msg_;
-  odometry_message.header.frame_id = odom_params_.odom_frame_id;
-  odometry_message.child_frame_id = odom_params_.base_frame_id;
+  odometry_message.header.frame_id = odom_frame_id_;
+  odometry_message.child_frame_id = base_frame_id_;
 
   // initialize odom values zeros
   odometry_message.twist = geometry_msgs::msg::TwistWithCovariance();
@@ -616,16 +414,13 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
   for (size_t index = 0; index < 6; ++index) {
     // 0, 7, 14, 21, 28, 35
     const size_t diagonal_index = NUM_DIMENSIONS * index + index;
-    odometry_message.pose.covariance[diagonal_index] = odom_params_.pose_covariance_diagonal[index];
-    odometry_message.twist.covariance[diagonal_index] =
-      odom_params_.twist_covariance_diagonal[index];
+    odometry_message.pose.covariance[diagonal_index] = pose_covariance_diagonal_[index];
+    odometry_message.twist.covariance[diagonal_index] = twist_covariance_diagonal_[index];
   }
 
   // initialize transform publisher and message
-  odometry_transform_publisher_ =
-    lifecycle_node_->create_publisher<tf2_msgs::msg::TFMessage>(
-    DEFAULT_TRANSFORM_TOPIC,
-    rclcpp::SystemDefaultsQoS());
+  odometry_transform_publisher_ = lifecycle_node_->create_publisher<tf2_msgs::msg::TFMessage>(
+    DEFAULT_TRANSFORM_TOPIC, rclcpp::SystemDefaultsQoS());
   realtime_odometry_transform_publisher_ =
     std::make_shared<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>>(
     odometry_transform_publisher_);
@@ -633,8 +428,8 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
   // keeping track of odom and base_link transforms only
   auto & odometry_transform_message = realtime_odometry_transform_publisher_->msg_;
   odometry_transform_message.transforms.resize(1);
-  odometry_transform_message.transforms.front().header.frame_id = odom_params_.odom_frame_id;
-  odometry_transform_message.transforms.front().child_frame_id = odom_params_.base_frame_id;
+  odometry_transform_message.transforms.front().header.frame_id = odom_frame_id_;
+  odometry_transform_message.transforms.front().child_frame_id = base_frame_id_;
 
   previous_update_timestamp_ = lifecycle_node_->get_clock()->now();
   set_op_mode(hardware_interface::OperationMode::INACTIVE);
@@ -752,10 +547,8 @@ void DiffDriveController::halt()
 }
 
 CallbackReturn DiffDriveController::configure_side(
-  const std::string & side,
-  const std::vector<std::string> & wheel_names,
-  std::vector<WheelHandle> & registered_handles,
-  hardware_interface::RobotHardware & robot_hardware)
+  const std::string & side, const std::vector<std::string> & wheel_names,
+  std::vector<WheelHandle> & registered_handles, hardware_interface::RobotHardware & robot_hardware)
 {
   auto logger = lifecycle_node_->get_logger();
 
@@ -788,10 +581,12 @@ CallbackReturn DiffDriveController::configure_side(
   return CallbackReturn::SUCCESS;
 }
 
-bool DiffDriveController::set_odom_params_from_urdf(
-  const std::string & left_wheel_name, const std::string & right_wheel_name,
-  bool lookup_wheel_separation, bool lookup_wheel_radius)
+bool DiffDriveController::set_wheel_params_from_urdf(
+  const std::string & left_wheel_name, const std::string & right_wheel_name, double & separation,
+  double & radius)
 {
+  auto lookup_wheel_separation = separation == 0.0;
+  auto lookup_wheel_radius = radius == 0.0;
   if (!(lookup_wheel_separation || lookup_wheel_radius)) {
     // Short-circuit in case we don't need to look up anything, so we don't have to parse the URDF
     return true;
@@ -829,20 +624,20 @@ bool DiffDriveController::set_odom_params_from_urdf(
 
     RCLCPP_INFO_STREAM(
       lifecycle_node_->get_logger(),
-      "left wheel to origin: " << left_wheel_joint->parent_to_joint_origin_transform.position.x
-                               << ","
-                               << left_wheel_joint->parent_to_joint_origin_transform.position.y
-                               << ", "
-                               << left_wheel_joint->parent_to_joint_origin_transform.position.z);
+      "left wheel to origin: " << left_wheel_joint->parent_to_joint_origin_transform.position.x <<
+        "," <<
+        left_wheel_joint->parent_to_joint_origin_transform.position.y <<
+        ", " <<
+        left_wheel_joint->parent_to_joint_origin_transform.position.z);
     RCLCPP_INFO_STREAM(
       lifecycle_node_->get_logger(),
-      "right wheel to origin: " << right_wheel_joint->parent_to_joint_origin_transform.position.x
-                                << ","
-                                << right_wheel_joint->parent_to_joint_origin_transform.position.y
-                                << ", "
-                                << right_wheel_joint->parent_to_joint_origin_transform.position.z);
+      "right wheel to origin: " << right_wheel_joint->parent_to_joint_origin_transform.position.x <<
+        "," <<
+        right_wheel_joint->parent_to_joint_origin_transform.position.y <<
+        ", " <<
+        right_wheel_joint->parent_to_joint_origin_transform.position.z);
 
-    wheel_params_.separation = urdf_util::euclidean_of_vectors(
+    separation = urdf_util::euclidean_of_vectors(
       left_wheel_joint->parent_to_joint_origin_transform.position,
       right_wheel_joint->parent_to_joint_origin_transform.position);
   }
@@ -850,8 +645,9 @@ bool DiffDriveController::set_odom_params_from_urdf(
   if (lookup_wheel_radius) {
     // Get wheel radius
     if (!urdf_util::get_wheel_radius(
-          model->getLink(left_wheel_joint->child_link_name), wheel_params_.radius,
-          lifecycle_node_->get_logger())) {
+        model->getLink(left_wheel_joint->child_link_name), radius,
+        lifecycle_node_->get_logger()))
+    {
       RCLCPP_ERROR_STREAM(
         lifecycle_node_->get_logger(), "Couldn't retrieve " << left_wheel_name << " wheel radius");
       return false;
@@ -861,47 +657,136 @@ bool DiffDriveController::set_odom_params_from_urdf(
   return true;
 }
 
-void DiffDriveController::publish_wheel_data(
-  const rclcpp::Time & time, const rclcpp::Duration & period, const Commands & curr_cmd,
-  double wheel_separation, double left_wheel_radius, double right_wheel_radius)
+void DiffDriveController::on_cmd_vel(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+{
+  if (!subscriber_is_active_) {
+    RCLCPP_WARN(lifecycle_node_->get_logger(), "Can't accept new commands. subscriber is inactive");
+    return;
+  }
+
+  auto & clk = *lifecycle_node_->get_clock().get();
+  if (
+    !allow_multiple_cmd_vel_publishers_ &&
+    velocity_command_subscriber_->get_publisher_count() > 1)
+  {
+    RCLCPP_ERROR_STREAM_THROTTLE(
+      lifecycle_node_->get_logger(), clk, 1000,
+      "Detected " << velocity_command_subscriber_->get_publisher_count() <<
+        " publishers. Only 1 publisher is allowed. Going to brake.");
+    halt();
+    return;
+  }
+
+  if (!std::isfinite(msg->twist.angular.z) || !std::isfinite(msg->twist.linear.x)) {
+    RCLCPP_WARN_THROTTLE(
+      lifecycle_node_->get_logger(), clk, 1000, "Received NaN in velocity command. Ignoring.");
+    return;
+  }
+
+  command_struct_.ang = msg->twist.angular.z;
+  command_struct_.lin = msg->twist.linear.x;
+  command_struct_.stamp = clk.now();
+  command_.writeFromNonRT(command_struct_);
+  RCLCPP_DEBUG_STREAM(
+    lifecycle_node_->get_logger(), "Added values to command. " <<
+      "Ang: " << command_struct_.ang << ", " <<
+      "Lin: " << command_struct_.lin << ", " <<
+      "Stamp: " << command_struct_.stamp.seconds());
+}
+
+void DiffDriveController::publish_odom(
+  const rclcpp::Time & current_time, const tf2::Quaternion & orientation) const
+{
+  if (odometry_publisher_->is_activated() && realtime_odometry_publisher_->trylock()) {
+    auto & odometry_message = realtime_odometry_publisher_->msg_;
+    odometry_message.header.stamp = current_time;
+    odometry_message.pose.pose.position.x = odometry_.getX();
+    odometry_message.pose.pose.position.y = odometry_.getY();
+    odometry_message.pose.pose.orientation.x = orientation.x();
+    odometry_message.pose.pose.orientation.y = orientation.y();
+    odometry_message.pose.pose.orientation.z = orientation.z();
+    odometry_message.pose.pose.orientation.w = orientation.w();
+    odometry_message.twist.twist.linear.x = odometry_.getLinear();
+    odometry_message.twist.twist.angular.z = odometry_.getAngular();
+    realtime_odometry_publisher_->unlockAndPublish();
+  }
+}
+
+void DiffDriveController::publish_odom_tf(
+  const rclcpp::Time & current_time, const tf2::Quaternion & orientation) const
+{
+  if (
+    enable_odom_tf_ && odometry_transform_publisher_->is_activated() &&
+    realtime_odometry_transform_publisher_->trylock())
+  {
+    auto & transform = realtime_odometry_transform_publisher_->msg_.transforms.front();
+    transform.header.stamp = current_time;
+    transform.transform.translation.x = odometry_.getX();
+    transform.transform.translation.y = odometry_.getY();
+    transform.transform.rotation.x = orientation.x();
+    transform.transform.rotation.y = orientation.y();
+    transform.transform.rotation.z = orientation.z();
+    transform.transform.rotation.w = orientation.w();
+    realtime_odometry_transform_publisher_->unlockAndPublish();
+  }
+}
+
+void DiffDriveController::publish_cmd_vel_out(
+  const rclcpp::Time & current_time, const DiffDriveController::Commands & curr_cmd) const
+{
+  if (
+    publish_limited_velocity_ && limited_velocity_publisher_->is_activated() &&
+    realtime_limited_velocity_publisher_->trylock())
+  {
+    auto & limited_velocity_command = realtime_limited_velocity_publisher_->msg_;
+    limited_velocity_command.header.stamp = current_time;
+    limited_velocity_command.twist.linear.x = curr_cmd.lin;
+    limited_velocity_command.twist.angular.z = curr_cmd.ang;
+    realtime_limited_velocity_publisher_->unlockAndPublish();
+  }
+}
+
+void DiffDriveController::publish_wheel_joint_controller_state(
+  const rclcpp::Time & time, const rclcpp::Duration & period, const Commands & curr_cmd)
 {
   if (
     publish_wheel_joint_controller_state_ &&
-    realtime_wheel_joint_controller_state_publisher_->trylock()) {
+    wheel_joint_controller_state_publisher_->is_activated() &&
+    realtime_wheel_joint_controller_state_publisher_->trylock())
+  {
     const auto cmd_dt = period.seconds();
 
     // Compute desired wheels velocities, that is before applying limits:
     const auto vel_left_desired =
-      (curr_cmd.lin - curr_cmd.ang * wheel_separation / 2.0) / left_wheel_radius;
+      (curr_cmd.lin - curr_cmd.ang * wheel_separation_ / 2.0) / left_wheel_radius_;
     const auto vel_right_desired =
-      (curr_cmd.lin + curr_cmd.ang * wheel_separation / 2.0) / right_wheel_radius;
+      (curr_cmd.lin + curr_cmd.ang * wheel_separation_ / 2.0) / right_wheel_radius_;
 
     auto & msg = realtime_wheel_joint_controller_state_publisher_->msg_;
     msg.header.stamp = time;
 
-    const auto & wheels_per_side = wheel_params_.wheels_per_side;
-    for (size_t i = 0; i < wheels_per_side; ++i) {
+    for (size_t i = 0; i < wheels_per_side_; ++i) {
       const auto control_duration = (time - previous_update_timestamp_).seconds();
 
+      auto vel_left_actual = registered_left_wheel_handles_[i].state->get_velocity();
       const auto left_wheel_acc =
-        (registered_left_wheel_handles_[i].state->get_velocity() - vel_left_previous_[i]) /
-        control_duration;
+        (vel_left_actual - vel_left_actual_previous_[i]) / control_duration;
       const auto right_wheel_acc =
-        (registered_right_wheel_handles_[i].state->get_velocity() - vel_right_previous_[i]) /
+        (registered_right_wheel_handles_[i].state->get_velocity() - vel_right_actual_previous_[i]) /
         control_duration;
 
       // Actual
       msg.actual.positions[i] = registered_left_wheel_handles_[i].state->get_position();
-      msg.actual.velocities[i] = registered_left_wheel_handles_[i].state->get_velocity();
+      msg.actual.velocities[i] = vel_left_actual;
       msg.actual.accelerations[i] = left_wheel_acc;
       msg.actual.effort[i] = registered_left_wheel_handles_[i].state->get_effort();
 
-      msg.actual.positions[i + wheels_per_side] =
+      msg.actual.positions[i + wheels_per_side_] =
         registered_right_wheel_handles_[i].state->get_position();
-      msg.actual.velocities[i + wheels_per_side] =
+      msg.actual.velocities[i + wheels_per_side_] =
         registered_right_wheel_handles_[i].state->get_velocity();
-      msg.actual.accelerations[i + wheels_per_side] = right_wheel_acc;
-      msg.actual.effort[i + wheels_per_side] =
+      msg.actual.accelerations[i + wheels_per_side_] = right_wheel_acc;
+      msg.actual.effort[i + wheels_per_side_] =
         registered_right_wheel_handles_[i].state->get_effort();
 
       // Desired
@@ -910,11 +795,11 @@ void DiffDriveController::publish_wheel_data(
       msg.desired.accelerations[i] = (vel_left_desired - vel_left_desired_previous_) * cmd_dt;
       msg.desired.effort[i] = std::numeric_limits<double>::quiet_NaN();
 
-      msg.desired.positions[i + wheels_per_side] += vel_right_desired * cmd_dt;
-      msg.desired.velocities[i + wheels_per_side] = vel_right_desired;
-      msg.desired.accelerations[i + wheels_per_side] =
+      msg.desired.positions[i + wheels_per_side_] += vel_right_desired * cmd_dt;
+      msg.desired.velocities[i + wheels_per_side_] = vel_right_desired;
+      msg.desired.accelerations[i + wheels_per_side_] =
         (vel_right_desired - vel_right_desired_previous_) * cmd_dt;
-      msg.desired.effort[i + wheels_per_side] = std::numeric_limits<double>::quiet_NaN();
+      msg.desired.effort[i + wheels_per_side_] = std::numeric_limits<double>::quiet_NaN();
 
       // Error
       msg.error.positions[i] = msg.desired.positions[i] - msg.actual.positions[i];
@@ -922,19 +807,19 @@ void DiffDriveController::publish_wheel_data(
       msg.error.accelerations[i] = msg.desired.accelerations[i] - msg.actual.accelerations[i];
       msg.error.effort[i] = msg.desired.effort[i] - msg.actual.effort[i];
 
-      msg.error.positions[i + wheels_per_side] =
-        msg.desired.positions[i + wheels_per_side] - msg.actual.positions[i + wheels_per_side];
-      msg.error.velocities[i + wheels_per_side] =
-        msg.desired.velocities[i + wheels_per_side] - msg.actual.velocities[i + wheels_per_side];
-      msg.error.accelerations[i + wheels_per_side] =
-        msg.desired.accelerations[i + wheels_per_side] -
-        msg.actual.accelerations[i + wheels_per_side];
-      msg.error.effort[i + wheels_per_side] =
-        msg.desired.effort[i + wheels_per_side] - msg.actual.effort[i + wheels_per_side];
+      msg.error.positions[i + wheels_per_side_] =
+        msg.desired.positions[i + wheels_per_side_] - msg.actual.positions[i + wheels_per_side_];
+      msg.error.velocities[i + wheels_per_side_] =
+        msg.desired.velocities[i + wheels_per_side_] - msg.actual.velocities[i + wheels_per_side_];
+      msg.error.accelerations[i + wheels_per_side_] =
+        msg.desired.accelerations[i + wheels_per_side_] -
+        msg.actual.accelerations[i + wheels_per_side_];
+      msg.error.effort[i + wheels_per_side_] =
+        msg.desired.effort[i + wheels_per_side_] - msg.actual.effort[i + wheels_per_side_];
 
       // Save previous velocities to compute acceleration
-      vel_left_previous_[i] = registered_left_wheel_handles_[i].state->get_velocity();
-      vel_right_previous_[i] = registered_right_wheel_handles_[i].state->get_velocity();
+      vel_left_actual_previous_[i] = vel_left_actual;
+      vel_right_actual_previous_[i] = registered_right_wheel_handles_[i].state->get_velocity();
       vel_left_desired_previous_ = vel_left_desired;
       vel_right_desired_previous_ = vel_right_desired;
     }
@@ -942,11 +827,9 @@ void DiffDriveController::publish_wheel_data(
     realtime_wheel_joint_controller_state_publisher_->unlockAndPublish();
   }
 }
-
 }  // namespace diff_drive_controller
 
 #include "class_loader/register_macro.hpp"
 
 CLASS_LOADER_REGISTER_CLASS(
-  diff_drive_controller::DiffDriveController,
-  controller_interface::ControllerInterface)
+  diff_drive_controller::DiffDriveController, controller_interface::ControllerInterface)

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -23,20 +23,121 @@
 #include <vector>
 
 #include "diff_drive_controller/diff_drive_controller.hpp"
-#include "lifecycle_msgs/msg/state.hpp"
-#include "tf2/LinearMath/Quaternion.h"
 #include "diff_drive_controller/diff_drive_controller.hpp"
 
-#include <lifecycle_msgs/msg/state.hpp>
 #include <tf2/LinearMath/Quaternion.h>
+#include <urdf/urdfdom_compatibility.h>
+#include <urdf_parser/urdf_parser.h>
+#include <lifecycle_msgs/msg/state.hpp>
 #include <utility>
+
+namespace urdf_util
+{
+double euclidean_of_vectors(const urdf::Vector3 & vec1, const urdf::Vector3 & vec2)
+{
+  return std::sqrt(
+    std::pow(vec1.x - vec2.x, 2) + std::pow(vec1.y - vec2.y, 2) + std::pow(vec1.z - vec2.z, 2));
+}
+
+/*
+* \brief Check that a link exists and has a geometry collision.
+* \param link The link
+* \return true if the link has a collision element with geometry
+*/
+bool has_collision_geometry(const urdf::LinkConstSharedPtr & link, const rclcpp::Logger & logger)
+{
+  if (!link) {
+    RCLCPP_ERROR(logger, "Link pointer is null.");
+    return false;
+  }
+
+  if (!link->collision) {
+    RCLCPP_ERROR_STREAM(
+      logger,
+      "Link "
+        << link->name
+        << " does not have collision description. Add collision description for link to urdf.");
+    return false;
+  }
+
+  if (!link->collision->geometry) {
+    RCLCPP_ERROR_STREAM(
+      logger, "Link " << link->name
+                      << " does not have collision geometry description. Add collision geometry "
+                         "description for link to urdf.");
+    return false;
+  }
+  return true;
+}
+
+/*
+ * \brief Check if the link is modeled as a cylinder
+ * \param link Link
+ * \return true if the link is modeled as a Cylinder; false otherwise
+ */
+bool is_cylinder(const urdf::LinkConstSharedPtr & link, const rclcpp::Logger & logger)
+{
+  if (!has_collision_geometry(link, logger)) {
+    return false;
+  }
+
+  if (link->collision->geometry->type != urdf::Geometry::CYLINDER) {
+    RCLCPP_DEBUG_STREAM(logger, "Link " << link->name << " does not have cylinder geometry");
+    return false;
+  }
+
+  return true;
+}
+
+/*
+ * \brief Check if the link is modeled as a sphere
+ * \param link Link
+ * \return true if the link is modeled as a Sphere; false otherwise
+ */
+
+bool is_sphere(const urdf::LinkConstSharedPtr & link, const rclcpp::Logger & logger)
+{
+  if (!has_collision_geometry(link, logger)) {
+    return false;
+  }
+
+  if (link->collision->geometry->type != urdf::Geometry::SPHERE) {
+    RCLCPP_DEBUG_STREAM(logger, "Link " << link->name << " does not have sphere geometry");
+    return false;
+  }
+
+  return true;
+}
+/*
+ * \brief Get the wheel radius
+ * \param [in]  wheel_link   Wheel link
+ * \param [out] wheel_radius Wheel radius [m]
+ * \return true if the wheel radius was found; false otherwise
+ */
+bool get_wheel_radius(
+  const urdf::LinkConstSharedPtr & wheel_link, double & wheel_radius, const rclcpp::Logger & logger)
+{
+  if (is_cylinder(wheel_link, logger)) {
+    wheel_radius = (static_cast<urdf::Cylinder *>(wheel_link->collision->geometry.get()))->radius;
+    return true;
+  } else if (is_sphere(wheel_link, logger)) {
+    wheel_radius = (static_cast<urdf::Sphere *>(wheel_link->collision->geometry.get()))->radius;
+    return true;
+  }
+
+  RCLCPP_ERROR_STREAM(
+    logger, "Wheel link " << wheel_link->name << " is NOT modeled as a cylinder or sphere!");
+  return false;
+}
+}  // namespace urdf_util
 
 namespace
 {
-constexpr auto DEFAULT_COMMAND_TOPIC = "~/cmd_vel";
-constexpr auto DEFAULT_COMMAND_OUT_TOPIC = "~/cmd_vel_out";
+constexpr auto DEFAULT_COMMAND_TOPIC = "/cmd_vel";
+constexpr auto DEFAULT_COMMAND_OUT_TOPIC = "/cmd_vel_out";
 constexpr auto DEFAULT_ODOMETRY_TOPIC = "/odom";
 constexpr auto DEFAULT_TRANSFORM_TOPIC = "/tf";
+constexpr auto DEFAULT_WHEEL_JOINT_CONTROLLER_STATE_TOPIC = "/wheel_joint_controller_state";
 }  // namespace
 
 namespace diff_drive_controller
@@ -79,7 +180,6 @@ DiffDriveController::init(
   lifecycle_node_->declare_parameter<std::vector<std::string>>("write_op_modes", write_op_names_);
 
   lifecycle_node_->declare_parameter<double>("wheel_separation", wheel_params_.separation);
-  lifecycle_node_->declare_parameter<int>("wheels_per_side", wheel_params_.wheels_per_side);
   lifecycle_node_->declare_parameter<double>("wheel_radius", wheel_params_.radius);
   lifecycle_node_->declare_parameter<double>(
     "wheel_separation_multiplier",
@@ -90,6 +190,7 @@ DiffDriveController::init(
   lifecycle_node_->declare_parameter<double>(
     "right_wheel_radius_multiplier",
     wheel_params_.right_radius_multiplier);
+  lifecycle_node_->declare_parameter("robot_description");
 
   lifecycle_node_->declare_parameter<std::string>("odom_frame_id", odom_params_.odom_frame_id);
   lifecycle_node_->declare_parameter<std::string>("base_frame_id", odom_params_.base_frame_id);
@@ -99,7 +200,11 @@ DiffDriveController::init(
   lifecycle_node_->declare_parameter<bool>("enable_odom_tf", odom_params_.enable_odom_tf);
 
   lifecycle_node_->declare_parameter<int>("cmd_vel_timeout", cmd_vel_timeout_.count());
+  lifecycle_node_->declare_parameter<bool>(
+    "allow_multiple_cmd_vel_publishers", allow_multiple_cmd_vel_publishers_);
   lifecycle_node_->declare_parameter<bool>("publish_limited_velocity", publish_limited_velocity_);
+  lifecycle_node_->declare_parameter<bool>(
+    "publish_wheel_joint_controller_state", publish_wheel_joint_controller_state_);
   lifecycle_node_->declare_parameter<int>("velocity_rolling_window_size", 10);
 
   lifecycle_node_->declare_parameter<bool>("linear.x.has_velocity_limits", false);
@@ -128,7 +233,7 @@ DiffDriveController::init(
 controller_interface::return_type DiffDriveController::update()
 {
   auto logger = lifecycle_node_->get_logger();
-  if (lifecycle_node_->get_current_state().id() == State::PRIMARY_STATE_INACTIVE) {
+  if (lifecycle_node_->get_current_state().id() != State::PRIMARY_STATE_ACTIVE) {
     if (!is_halted) {
       halt();
       is_halted = true;
@@ -137,8 +242,6 @@ controller_interface::return_type DiffDriveController::update()
   }
 
   const auto current_time = lifecycle_node_->get_clock()->now();
-  double & linear_command = received_velocity_msg_ptr_->twist.linear.x;
-  double & angular_command = received_velocity_msg_ptr_->twist.angular.z;
 
   // Apply (possibly new) multipliers:
   const auto wheels = wheel_params_;
@@ -147,7 +250,7 @@ controller_interface::return_type DiffDriveController::update()
   const double right_wheel_radius = wheels.right_radius_multiplier * wheels.radius;
 
   if (odom_params_.open_loop) {
-    odometry_.updateOpenLoop(linear_command, angular_command, current_time);
+    odometry_.updateOpenLoop(last0_cmd_.lin, last0_cmd_.ang, current_time);
   } else {
     double left_position_mean = 0.0;
     double right_position_mean = 0.0;
@@ -202,27 +305,25 @@ controller_interface::return_type DiffDriveController::update()
     realtime_odometry_transform_publisher_->unlockAndPublish();
   }
 
-  const auto dt = current_time - received_velocity_msg_ptr_->header.stamp;
+  // Retrieve current velocity command and time step:
+  Commands curr_cmd = *(command_.readFromRT());
 
   // Brake if cmd_vel has timeout
+  const auto dt = current_time - curr_cmd.stamp;
   if (dt > cmd_vel_timeout_) {
-    linear_command = 0.0;
-    angular_command = 0.0;
+    curr_cmd.lin = 0.0;
+    curr_cmd.ang = 0.0;
   }
 
+  // Time elapsed since last update iteration
   const auto update_dt = current_time - previous_update_timestamp_;
-  previous_update_timestamp_ = current_time;
 
-  auto & last_command = previous_commands_.back().twist;
-  auto & second_to_last_command = previous_commands_.front().twist;
-  limiter_linear_.limit(
-    linear_command, last_command.linear.x, second_to_last_command.linear.x,
-    update_dt.seconds());
-  limiter_angular_.limit(
-    angular_command, last_command.angular.z, second_to_last_command.angular.z, update_dt.seconds());
+  publish_wheel_data(
+    current_time, update_dt, curr_cmd, wheel_separation, left_wheel_radius, right_wheel_radius);
 
-  previous_commands_.pop();
-  previous_commands_.emplace(*received_velocity_msg_ptr_);
+  // Enforce limiters
+  limiter_linear_.limit(curr_cmd.lin, last0_cmd_.lin, last1_cmd_.lin, update_dt.seconds());
+  limiter_angular_.limit(curr_cmd.ang, last0_cmd_.ang, last1_cmd_.ang, update_dt.seconds());
 
   //    Publish limited velocity
   if (publish_limited_velocity_ && limited_velocity_publisher_->is_activated() &&
@@ -230,21 +331,16 @@ controller_interface::return_type DiffDriveController::update()
   {
     auto & limited_velocity_command = realtime_limited_velocity_publisher_->msg_;
     limited_velocity_command.header.stamp = current_time;
-    limited_velocity_command.twist.linear.x = linear_command;
-    limited_velocity_command.twist.angular.z = angular_command;
+    limited_velocity_command.twist.linear.x = curr_cmd.lin;
+    limited_velocity_command.twist.angular.z = curr_cmd.ang;
     realtime_limited_velocity_publisher_->unlockAndPublish();
   }
 
-  if (received_velocity_msg_ptr_ == nullptr) {
-    RCLCPP_WARN(logger, "Velocity message received was a nullptr.");
-    return controller_interface::return_type::ERROR;
-  }
-
   // Compute wheels velocities:
-  const double velocity_left = (linear_command - angular_command * wheel_separation / 2.0) /
-    left_wheel_radius;
-  const double velocity_right = (linear_command + angular_command * wheel_separation / 2.0) /
-    right_wheel_radius;
+  const double velocity_left =
+    (curr_cmd.lin - curr_cmd.ang * wheel_separation / 2.0) / left_wheel_radius;
+  const double velocity_right =
+    (curr_cmd.lin + curr_cmd.ang * wheel_separation / 2.0) / right_wheel_radius;
 
   // Set wheels velocities:
   for (size_t index = 0; index < wheels.wheels_per_side; ++index) {
@@ -253,11 +349,21 @@ controller_interface::return_type DiffDriveController::update()
   }
 
   set_op_mode(hardware_interface::OperationMode::ACTIVE);
+
+  // push back
+  last1_cmd_ = last0_cmd_;
+  last0_cmd_ = curr_cmd;
+  previous_update_timestamp_ = current_time;
+
   return controller_interface::return_type::SUCCESS;
 }
 
 CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &)
 {
+  if (!reset()) {
+    return CallbackReturn::ERROR;
+  }
+
   auto logger = lifecycle_node_->get_logger();
 
   // update parameters
@@ -266,17 +372,28 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
   write_op_names_ = lifecycle_node_->get_parameter("write_op_modes").as_string_array();
 
   wheel_params_.separation = lifecycle_node_->get_parameter("wheel_separation").as_double();
-  wheel_params_.wheels_per_side =
-    static_cast<size_t>(lifecycle_node_->get_parameter("wheels_per_side").as_int());
   wheel_params_.radius = lifecycle_node_->get_parameter("wheel_radius").as_double();
   wheel_params_.separation_multiplier =
     lifecycle_node_->get_parameter("wheel_separation_multiplier").as_double();
-  wheel_params_.left_radius_multiplier = lifecycle_node_->get_parameter(
-    "left_wheel_radius_multiplier").as_double();
-  wheel_params_.right_radius_multiplier = lifecycle_node_->get_parameter(
-    "right_wheel_radius_multiplier").as_double();
+  wheel_params_.left_radius_multiplier =
+    lifecycle_node_->get_parameter("left_wheel_radius_multiplier").as_double();
+  wheel_params_.right_radius_multiplier =
+    lifecycle_node_->get_parameter("right_wheel_radius_multiplier").as_double();
 
-  const auto wheels = wheel_params_;
+  const auto wheel_separation_missing = wheel_params_.separation == 0.0;
+  const auto wheel_radius_missing = wheel_params_.radius == 0.0;
+  if (!set_odom_params_from_urdf(
+        left_wheel_names_[0], right_wheel_names_[0], wheel_separation_missing,
+        wheel_radius_missing)) {
+    RCLCPP_ERROR_STREAM(
+      lifecycle_node_->get_logger(),
+      "The following configurations must be set via parameter or urdf: "
+        << (wheel_separation_missing ? "'wheel_separation' " : "")
+        << (wheel_radius_missing ? "'wheel_radius'" : ""));
+    return CallbackReturn::FAILURE;
+  }
+
+  const auto & wheels = wheel_params_;
 
   const double wheel_separation = wheels.separation_multiplier * wheels.separation;
   const double left_wheel_radius = wheels.left_radius_multiplier * wheels.radius;
@@ -306,7 +423,15 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
 
   cmd_vel_timeout_ =
     std::chrono::milliseconds{lifecycle_node_->get_parameter("cmd_vel_timeout").as_int()};
+  allow_multiple_cmd_vel_publishers_ =
+    lifecycle_node_->get_parameter("allow_multiple_cmd_vel_publishers").as_bool();
+  RCLCPP_INFO_STREAM(
+    logger, "Allow multiple cmd_vel publishers is "
+              << (allow_multiple_cmd_vel_publishers_ ? "enabled" : "disabled"));
+
   publish_limited_velocity_ = lifecycle_node_->get_parameter("publish_limited_velocity").as_bool();
+  publish_wheel_joint_controller_state_ =
+    lifecycle_node_->get_parameter("publish_wheel_joint_controller_state").as_bool();
 
   limiter_linear_ = SpeedLimiter(
     lifecycle_node_->get_parameter("linear.x.has_velocity_limits").as_bool(),
@@ -336,10 +461,6 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
       "The number of left wheels [%d] and the number of right wheels [%d] are different",
       left_wheel_names_.size(),
       right_wheel_names_.size());
-    return CallbackReturn::ERROR;
-  }
-
-  if (!reset()) {
     return CallbackReturn::ERROR;
   }
 
@@ -390,11 +511,49 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
       std::make_shared<realtime_tools::RealtimePublisher<Twist>>(limited_velocity_publisher_);
   }
 
-  received_velocity_msg_ptr_ = std::make_shared<Twist>();
+  if (publish_wheel_joint_controller_state_) {
+    wheel_joint_controller_state_publisher_ =
+      lifecycle_node_->create_publisher<control_msgs::msg::JointTrajectoryControllerState>(
+        DEFAULT_WHEEL_JOINT_CONTROLLER_STATE_TOPIC, rclcpp::SystemDefaultsQoS());
+    realtime_wheel_joint_controller_state_publisher_ = std::make_shared<
+      realtime_tools::RealtimePublisher<control_msgs::msg::JointTrajectoryControllerState>>(
+      wheel_joint_controller_state_publisher_);
+
+    const size_t num_wheels = wheel_params_.wheels_per_side * 2;
+
+    realtime_wheel_joint_controller_state_publisher_->msg_.joint_names.resize(num_wheels);
+
+    realtime_wheel_joint_controller_state_publisher_->msg_.desired.positions.resize(num_wheels);
+    realtime_wheel_joint_controller_state_publisher_->msg_.desired.velocities.resize(num_wheels);
+    realtime_wheel_joint_controller_state_publisher_->msg_.desired.accelerations.resize(num_wheels);
+    realtime_wheel_joint_controller_state_publisher_->msg_.desired.effort.resize(num_wheels);
+
+    realtime_wheel_joint_controller_state_publisher_->msg_.actual.positions.resize(num_wheels);
+    realtime_wheel_joint_controller_state_publisher_->msg_.actual.velocities.resize(num_wheels);
+    realtime_wheel_joint_controller_state_publisher_->msg_.actual.accelerations.resize(num_wheels);
+    realtime_wheel_joint_controller_state_publisher_->msg_.actual.effort.resize(num_wheels);
+
+    realtime_wheel_joint_controller_state_publisher_->msg_.error.positions.resize(num_wheels);
+    realtime_wheel_joint_controller_state_publisher_->msg_.error.velocities.resize(num_wheels);
+    realtime_wheel_joint_controller_state_publisher_->msg_.error.accelerations.resize(num_wheels);
+    realtime_wheel_joint_controller_state_publisher_->msg_.error.effort.resize(num_wheels);
+
+    for (size_t i = 0; i < wheel_params_.wheels_per_side; ++i) {
+      realtime_wheel_joint_controller_state_publisher_->msg_.joint_names[i] = left_wheel_names_[i];
+      realtime_wheel_joint_controller_state_publisher_->msg_
+        .joint_names[i + wheel_params_.wheels_per_side] = right_wheel_names_[i];
+    }
+
+    vel_left_previous_.resize(wheel_params_.wheels_per_side, 0.0);
+    vel_right_previous_.resize(wheel_params_.wheels_per_side, 0.0);
+  }
+
+  // Zero-initialize command
+  command_.initRT(Commands());
 
   // Fill last two commands with default constructed commands
-  previous_commands_.emplace(*received_velocity_msg_ptr_);
-  previous_commands_.emplace(*received_velocity_msg_ptr_);
+  last0_cmd_ = Commands();
+  last1_cmd_ = Commands();
 
   // initialize command subscriber
   velocity_command_subscriber_ = lifecycle_node_->create_subscription<Twist>(
@@ -407,7 +566,34 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
         return;
       }
 
-      received_velocity_msg_ptr_ = std::move(msg);
+      auto & clk = *lifecycle_node_->get_clock().get();
+      if (
+        !allow_multiple_cmd_vel_publishers_ &&
+        velocity_command_subscriber_->get_publisher_count() > 1) {
+        RCLCPP_ERROR_STREAM_THROTTLE(
+          lifecycle_node_->get_logger(), clk, 1000,
+          "Detected " << velocity_command_subscriber_->get_publisher_count()
+                      << " publishers. Only 1 publisher is allowed. Going to brake.");
+        halt();
+        return;
+      }
+
+      if (!std::isfinite(msg->twist.angular.z) || !std::isfinite(msg->twist.linear.x)) {
+        RCLCPP_WARN_THROTTLE(
+          lifecycle_node_->get_logger(), clk, 1000, "Received NaN in velocity command. Ignoring.");
+        return;
+      }
+
+      command_struct_.ang = msg->twist.angular.z;
+      command_struct_.lin = msg->twist.linear.x;
+      command_struct_.stamp = clk.now();
+      command_.writeFromNonRT (command_struct_);
+      RCLCPP_DEBUG_STREAM(lifecycle_node_->get_logger(),
+        "Added values to command. "
+          << "Ang: "   << command_struct_.ang << ", "
+          << "Lin: "   << command_struct_.lin << ", "
+          << "Stamp: " << command_struct_.stamp.seconds());
+
     });
 
   // initialize odometry publisher and messasge
@@ -424,8 +610,7 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
   odometry_message.child_frame_id = odom_params_.base_frame_id;
 
   // initialize odom values zeros
-  odometry_message.twist = geometry_msgs::msg::TwistWithCovariance(
-    rosidl_runtime_cpp::MessageInitialization::ALL);
+  odometry_message.twist = geometry_msgs::msg::TwistWithCovariance();
 
   constexpr size_t NUM_DIMENSIONS = 6;
   for (size_t index = 0; index < 6; ++index) {
@@ -466,6 +651,9 @@ CallbackReturn DiffDriveController::on_activate(const rclcpp_lifecycle::State &)
   if (publish_limited_velocity_) {
     limited_velocity_publisher_->on_activate();
   }
+  if (publish_wheel_joint_controller_state_) {
+    wheel_joint_controller_state_publisher_->on_activate();
+  }
 
   RCLCPP_INFO(
     lifecycle_node_->get_logger(), "Lifecycle subscriber and publisher are currently active.");
@@ -474,22 +662,26 @@ CallbackReturn DiffDriveController::on_activate(const rclcpp_lifecycle::State &)
 
 CallbackReturn DiffDriveController::on_deactivate(const rclcpp_lifecycle::State &)
 {
+  halt();
   subscriber_is_active_ = false;
   odometry_transform_publisher_->on_deactivate();
   odometry_publisher_->on_deactivate();
   if (publish_limited_velocity_) {
     limited_velocity_publisher_->on_deactivate();
   }
+  if (publish_wheel_joint_controller_state_) {
+    wheel_joint_controller_state_publisher_->on_deactivate();
+  }
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn DiffDriveController::on_cleanup(const rclcpp_lifecycle::State &)
 {
+  halt();
   if (!reset()) {
     return CallbackReturn::ERROR;
   }
 
-  received_velocity_msg_ptr_ = std::make_shared<Twist>();
   return CallbackReturn::SUCCESS;
 }
 
@@ -516,13 +708,26 @@ bool DiffDriveController::reset()
   subscriber_is_active_ = false;
   velocity_command_subscriber_.reset();
 
-  received_velocity_msg_ptr_.reset();
+  odometry_publisher_.reset();
+  realtime_odometry_publisher_.reset();
+  odometry_transform_publisher_.reset();
+  realtime_odometry_transform_publisher_.reset();
+  limited_velocity_publisher_.reset();
+  realtime_limited_velocity_publisher_.reset();
+  wheel_joint_controller_state_publisher_.reset();
+  realtime_wheel_joint_controller_state_publisher_.reset();
+
   is_halted = false;
   return true;
 }
 
 CallbackReturn DiffDriveController::on_shutdown(const rclcpp_lifecycle::State &)
 {
+  halt();
+  if (!reset()) {
+    return CallbackReturn::ERROR;
+  }
+
   return CallbackReturn::SUCCESS;
 }
 
@@ -582,6 +787,162 @@ CallbackReturn DiffDriveController::configure_side(
 
   return CallbackReturn::SUCCESS;
 }
+
+bool DiffDriveController::set_odom_params_from_urdf(
+  const std::string & left_wheel_name, const std::string & right_wheel_name,
+  bool lookup_wheel_separation, bool lookup_wheel_radius)
+{
+  if (!(lookup_wheel_separation || lookup_wheel_radius)) {
+    // Short-circuit in case we don't need to look up anything, so we don't have to parse the URDF
+    return true;
+  }
+
+  // Parse robot description
+  const std::string model_param_name = "robot_description";
+  std::string robot_model_str;
+  if (!lifecycle_node_->get_parameter(model_param_name, robot_model_str)) {
+    RCLCPP_ERROR(
+      lifecycle_node_->get_logger(), "Robot description couldn't be retrieved from param server.");
+    return false;
+  }
+
+  urdf::ModelInterfaceSharedPtr model(urdf::parseURDF(robot_model_str));
+
+  urdf::JointConstSharedPtr left_wheel_joint(model->getJoint(left_wheel_name));
+  urdf::JointConstSharedPtr right_wheel_joint(model->getJoint(right_wheel_name));
+
+  if (lookup_wheel_separation) {
+    // Get wheel separation
+    if (!left_wheel_joint) {
+      RCLCPP_ERROR_STREAM(
+        lifecycle_node_->get_logger(),
+        left_wheel_name << " couldn't be retrieved from model description");
+      return false;
+    }
+
+    if (!right_wheel_joint) {
+      RCLCPP_ERROR_STREAM(
+        lifecycle_node_->get_logger(),
+        right_wheel_name << " couldn't be retrieved from model description");
+      return false;
+    }
+
+    RCLCPP_INFO_STREAM(
+      lifecycle_node_->get_logger(),
+      "left wheel to origin: " << left_wheel_joint->parent_to_joint_origin_transform.position.x
+                               << ","
+                               << left_wheel_joint->parent_to_joint_origin_transform.position.y
+                               << ", "
+                               << left_wheel_joint->parent_to_joint_origin_transform.position.z);
+    RCLCPP_INFO_STREAM(
+      lifecycle_node_->get_logger(),
+      "right wheel to origin: " << right_wheel_joint->parent_to_joint_origin_transform.position.x
+                                << ","
+                                << right_wheel_joint->parent_to_joint_origin_transform.position.y
+                                << ", "
+                                << right_wheel_joint->parent_to_joint_origin_transform.position.z);
+
+    wheel_params_.separation = urdf_util::euclidean_of_vectors(
+      left_wheel_joint->parent_to_joint_origin_transform.position,
+      right_wheel_joint->parent_to_joint_origin_transform.position);
+  }
+
+  if (lookup_wheel_radius) {
+    // Get wheel radius
+    if (!urdf_util::get_wheel_radius(
+          model->getLink(left_wheel_joint->child_link_name), wheel_params_.radius,
+          lifecycle_node_->get_logger())) {
+      RCLCPP_ERROR_STREAM(
+        lifecycle_node_->get_logger(), "Couldn't retrieve " << left_wheel_name << " wheel radius");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void DiffDriveController::publish_wheel_data(
+  const rclcpp::Time & time, const rclcpp::Duration & period, const Commands & curr_cmd,
+  double wheel_separation, double left_wheel_radius, double right_wheel_radius)
+{
+  if (
+    publish_wheel_joint_controller_state_ &&
+    realtime_wheel_joint_controller_state_publisher_->trylock()) {
+    const auto cmd_dt = period.seconds();
+
+    // Compute desired wheels velocities, that is before applying limits:
+    const auto vel_left_desired =
+      (curr_cmd.lin - curr_cmd.ang * wheel_separation / 2.0) / left_wheel_radius;
+    const auto vel_right_desired =
+      (curr_cmd.lin + curr_cmd.ang * wheel_separation / 2.0) / right_wheel_radius;
+
+    auto & msg = realtime_wheel_joint_controller_state_publisher_->msg_;
+    msg.header.stamp = time;
+
+    const auto & wheels_per_side = wheel_params_.wheels_per_side;
+    for (size_t i = 0; i < wheels_per_side; ++i) {
+      const auto control_duration = (time - previous_update_timestamp_).seconds();
+
+      const auto left_wheel_acc =
+        (registered_left_wheel_handles_[i].state->get_velocity() - vel_left_previous_[i]) /
+        control_duration;
+      const auto right_wheel_acc =
+        (registered_right_wheel_handles_[i].state->get_velocity() - vel_right_previous_[i]) /
+        control_duration;
+
+      // Actual
+      msg.actual.positions[i] = registered_left_wheel_handles_[i].state->get_position();
+      msg.actual.velocities[i] = registered_left_wheel_handles_[i].state->get_velocity();
+      msg.actual.accelerations[i] = left_wheel_acc;
+      msg.actual.effort[i] = registered_left_wheel_handles_[i].state->get_effort();
+
+      msg.actual.positions[i + wheels_per_side] =
+        registered_right_wheel_handles_[i].state->get_position();
+      msg.actual.velocities[i + wheels_per_side] =
+        registered_right_wheel_handles_[i].state->get_velocity();
+      msg.actual.accelerations[i + wheels_per_side] = right_wheel_acc;
+      msg.actual.effort[i + wheels_per_side] =
+        registered_right_wheel_handles_[i].state->get_effort();
+
+      // Desired
+      msg.desired.positions[i] += vel_left_desired * cmd_dt;
+      msg.desired.velocities[i] = vel_left_desired;
+      msg.desired.accelerations[i] = (vel_left_desired - vel_left_desired_previous_) * cmd_dt;
+      msg.desired.effort[i] = std::numeric_limits<double>::quiet_NaN();
+
+      msg.desired.positions[i + wheels_per_side] += vel_right_desired * cmd_dt;
+      msg.desired.velocities[i + wheels_per_side] = vel_right_desired;
+      msg.desired.accelerations[i + wheels_per_side] =
+        (vel_right_desired - vel_right_desired_previous_) * cmd_dt;
+      msg.desired.effort[i + wheels_per_side] = std::numeric_limits<double>::quiet_NaN();
+
+      // Error
+      msg.error.positions[i] = msg.desired.positions[i] - msg.actual.positions[i];
+      msg.error.velocities[i] = msg.desired.velocities[i] - msg.actual.velocities[i];
+      msg.error.accelerations[i] = msg.desired.accelerations[i] - msg.actual.accelerations[i];
+      msg.error.effort[i] = msg.desired.effort[i] - msg.actual.effort[i];
+
+      msg.error.positions[i + wheels_per_side] =
+        msg.desired.positions[i + wheels_per_side] - msg.actual.positions[i + wheels_per_side];
+      msg.error.velocities[i + wheels_per_side] =
+        msg.desired.velocities[i + wheels_per_side] - msg.actual.velocities[i + wheels_per_side];
+      msg.error.accelerations[i + wheels_per_side] =
+        msg.desired.accelerations[i + wheels_per_side] -
+        msg.actual.accelerations[i + wheels_per_side];
+      msg.error.effort[i + wheels_per_side] =
+        msg.desired.effort[i + wheels_per_side] - msg.actual.effort[i + wheels_per_side];
+
+      // Save previous velocities to compute acceleration
+      vel_left_previous_[i] = registered_left_wheel_handles_[i].state->get_velocity();
+      vel_right_previous_[i] = registered_right_wheel_handles_[i].state->get_velocity();
+      vel_left_desired_previous_ = vel_left_desired;
+      vel_right_desired_previous_ = vel_right_desired;
+    }
+
+    realtime_wheel_joint_controller_state_publisher_->unlockAndPublish();
+  }
+}
+
 }  // namespace diff_drive_controller
 
 #include "class_loader/register_macro.hpp"

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -27,11 +27,8 @@
 #include <limits>
 
 #include "diff_drive_controller/urdf_util.hpp"
-#include "tf2/LinearMath/Quaternion.h"
 #include "lifecycle_msgs/msg/state.hpp"
-
-
-// namespace urdf_util
+#include "tf2/LinearMath/Quaternion.h"
 
 namespace
 {

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -25,6 +25,11 @@
 #include "diff_drive_controller/diff_drive_controller.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "tf2/LinearMath/Quaternion.h"
+#include "diff_drive_controller/diff_drive_controller.hpp"
+
+#include <lifecycle_msgs/msg/state.hpp>
+#include <tf2/LinearMath/Quaternion.h>
+#include <utility>
 
 namespace
 {

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -492,10 +492,6 @@ bool DiffDriveController::reset()
 {
   odometry_.resetOdometry();
 
-  // release the old queue
-  std::queue<Twist> empty;
-  std::swap(previous_commands_, empty);
-
   registered_left_wheel_handles_.clear();
   registered_right_wheel_handles_.clear();
   registered_operation_mode_handles_.clear();

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -67,7 +67,6 @@ bool Odometry::update(double left_pos, double right_pos, const rclcpp::Time & ti
 
   // Compute linear and angular diff:
   const double linear = (right_wheel_est_vel + left_wheel_est_vel) * 0.5;
-  // Now there is a bug about scout angular velocity
   const double angular = (right_wheel_est_vel - left_wheel_est_vel) / wheel_separation_;
 
   // Integrate odometry:

--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -90,7 +90,7 @@ double SpeedLimiter::limit_jerk(double & v, double v0, double v1, double dt)
     const double dv = v - v0;
     const double dv0 = v0 - v1;
 
-    const double dt2 = 2. * dt * dt;
+    const double dt2 = dt * dt;
 
     const double da_min = min_jerk_ * dt2;
     const double da_max = max_jerk_ * dt2;

--- a/diff_drive_controller/src/urdf_util.cpp
+++ b/diff_drive_controller/src/urdf_util.cpp
@@ -1,0 +1,109 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "diff_drive_controller/urdf_util.hpp"
+
+namespace urdf_util
+{
+double euclidean_of_vectors(const urdf::Vector3 & vec1, const urdf::Vector3 & vec2)
+{
+  return sqrt(
+    std::pow(vec1.x - vec2.x, 2) + std::pow(vec1.y - vec2.y, 2) + std::pow(vec1.z - vec2.z, 2));
+}
+
+/*
+* \brief Check that a link exists and has a geometry collision.
+* \param link The link
+* \return true if the link has a collision element with geometry
+*/
+bool has_collision_geometry(const urdf::LinkConstSharedPtr & link, const rclcpp::Logger & logger)
+{
+  if (!link) {
+    RCLCPP_ERROR(logger, "Link pointer is null.");
+    return false;
+  }
+
+  if (!link->collision) {
+    RCLCPP_ERROR_STREAM(
+      logger,
+      "Link " <<
+        link->name <<
+        " does not have collision description. Add collision description for link to urdf.");
+    return false;
+  }
+
+  if (!link->collision->geometry) {
+    RCLCPP_ERROR_STREAM(
+      logger, "Link " << link->name <<
+        " does not have collision geometry description. Add collision geometry "
+        "description for link to urdf.");
+    return false;
+  }
+  return true;
+}
+
+/*
+ * \brief Check if the link is modeled as a cylinder
+ * \param link Link
+ * \return true if the link is modeled as a Cylinder; false otherwise
+ */
+bool is_cylinder(const urdf::LinkConstSharedPtr & link, const rclcpp::Logger & logger)
+{
+  if (!has_collision_geometry(link, logger)) {
+    return false;
+  }
+
+  if (link->collision->geometry->type != urdf::Geometry::CYLINDER) {
+    RCLCPP_DEBUG_STREAM(logger, "Link " << link->name << " does not have cylinder geometry");
+    return false;
+  }
+
+  return true;
+}
+
+/*
+ * \brief Check if the link is modeled as a sphere
+ * \param link Link
+ * \return true if the link is modeled as a Sphere; false otherwise
+ */
+
+bool is_sphere(const urdf::LinkConstSharedPtr & link, const rclcpp::Logger & logger)
+{
+  if (!has_collision_geometry(link, logger)) {
+    return false;
+  }
+
+  if (link->collision->geometry->type != urdf::Geometry::SPHERE) {
+    RCLCPP_DEBUG_STREAM(logger, "Link " << link->name << " does not have sphere geometry");
+    return false;
+  }
+
+  return true;
+}
+
+bool get_wheel_radius(
+  const urdf::LinkConstSharedPtr & wheel_link, double & wheel_radius, const rclcpp::Logger & logger)
+{
+  if (is_cylinder(wheel_link, logger)) {
+    wheel_radius = (static_cast<urdf::Cylinder *>(wheel_link->collision->geometry.get()))->radius;
+    return true;
+  } else if (is_sphere(wheel_link, logger)) {
+    wheel_radius = (static_cast<urdf::Sphere *>(wheel_link->collision->geometry.get()))->radius;
+    return true;
+  }
+
+  RCLCPP_ERROR_STREAM(
+    logger, "Wheel link " << wheel_link->name << " is NOT modeled as a cylinder or sphere!");
+  return false;
+}
+}  // namespace urdf_util

--- a/diff_drive_controller/test/config/diffbot.xacro
+++ b/diff_drive_controller/test/config/diffbot.xacro
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!--
+  Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF-Controller%20Example
+  -->
+  <xacro:include filename="wheel.xacro"/>
+
+  <xacro:property name="deg_to_rad" value="0.01745329251994329577"/>
+
+  <!-- Constants for robot dimensions -->
+  <xacro:property name="width" value="0.5" /> <!-- Square dimensions (widthxwidth) of beams -->
+  <xacro:property name="wheel_radius" value="0.11" /> <!-- Link 1 -->
+  <xacro:property name="thickness" value="0.086" /> <!-- Link 2 -->
+  <xacro:property name="axel_offset" value="0.05" /> <!-- Space btw top of beam and the each joint -->
+
+  <!-- Links: inertial,visual,collision -->
+  <link name="base_link">
+    <inertial>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="5"/>
+      <inertia ixx="5" ixy="0" ixz="0" iyy="5" iyz="0" izz="5"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </visual>
+    <collision>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+
+
+  <link name="base_footprint">
+    <visual>
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <sphere radius="0.00000001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="base_footprint_joint" type="fixed">
+    <origin xyz="0 0 ${wheel_radius}" rpy="0 0 0"/>
+    <child link="base_link"/>
+    <parent link="base_footprint"/>
+  </joint>
+
+
+  <!-- Wheels -->
+  <xacro:wheel name="wheel_0" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:wheel>
+  <xacro:wheel name="wheel_1" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${-width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:wheel>
+
+
+  <!-- Colour -->
+  <gazebo reference="base_link">
+    <material>Gazebo/Green</material>
+  </gazebo>
+
+  <gazebo reference="base_footprint">
+    <material>Gazebo/Purple</material>
+  </gazebo>
+
+</robot>

--- a/diff_drive_controller/test/config/diffbot.yaml
+++ b/diff_drive_controller/test/config/diffbot.yaml
@@ -1,0 +1,9 @@
+diffbot_controller:  # Name of DiffDriveController node
+  ros__parameters:
+    left_wheel_names: ["wheel_0_joint"]
+    right_wheel_names: ["wheel_1_joint"]
+    write_op_modes: ["op_status"]
+
+    pose_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
+    twist_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
+    cmd_vel_timeout: 20000   # in ms

--- a/diff_drive_controller/test/config/diffbot.yaml
+++ b/diff_drive_controller/test/config/diffbot.yaml
@@ -1,4 +1,4 @@
-diffbot_controller:  # Name of DiffDriveController node
+/**:  # Note: Wildcard necessary to permit parameter override via launch file
   ros__parameters:
     left_wheel_names: ["wheel_0_joint"]
     right_wheel_names: ["wheel_1_joint"]

--- a/diff_drive_controller/test/config/diffbot_bad.xacro
+++ b/diff_drive_controller/test/config/diffbot_bad.xacro
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!--
+  Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF-Controller%20Example
+  -->
+  <!-- Constants for robot dimensions -->
+  <xacro:property name="PI" value="3.1415926535897931"/>
+  <xacro:property name="width" value="0.5" /> <!-- Square dimensions (widthxwidth) of beams -->
+  <xacro:property name="wheel_radius" value="0.11" /> <!-- Link 1 -->
+  <xacro:property name="thickness" value="0.086" /> <!-- Link 2 -->
+  <xacro:property name="axel_offset" value="0.05" /> <!-- Space btw top of beam and the each joint -->
+
+  <!-- Links: inertial,visual,collision -->
+  <link name="base_link">
+    <inertial>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="5"/>
+      <inertia ixx="5" ixy="0" ixz="0" iyy="5" iyz="0" izz="5"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </visual>
+    <collision>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+
+
+  <link name="base_footprint">
+    <visual>
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <sphere radius="0.00000001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="base_footprint_joint" type="fixed">
+    <origin xyz="0 0 ${wheel_radius}" rpy="0 0 0"/>
+    <child link="base_link"/>
+    <parent link="base_footprint"/>
+  </joint>
+
+
+  <link name="wheel1">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1"/>
+      <inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 ${PI/2} 0"/>
+      <geometry>
+        <sphere radius="${wheel_radius}"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 ${PI/2} 0"/>
+      <geometry>
+        <sphere radius="${wheel_radius}"/>
+      </geometry>
+    </collision>
+  </link>
+<!--  name should not match yaml -->
+  <joint name="joint_w1" type="continuous">
+    <parent link="base_link"/>
+    <child link="wheel1"/>
+    <origin xyz="${width/2+axel_offset} 0 0" rpy="${-PI/2} 0 0"/>
+    <axis xyz="0 1 0"/>
+  </joint>
+
+
+  <link name="wheel2">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1"/>
+      <inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 ${PI/2} 0"/>
+      <geometry>
+        <sphere radius="${wheel_radius}"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 ${PI/2} 0"/>
+      <geometry>
+        <sphere radius="${wheel_radius}"/>
+      </geometry>
+    </collision>
+  </link>
+  <!--  name should not match yaml -->
+  <joint name="joint_w2" type="continuous">
+    <parent link="base_link"/>
+    <child link="wheel2"/>
+    <origin xyz="${-width/2-axel_offset} 0 0" rpy="${-PI/2} 0 0"/>
+    <axis xyz="0 1 0"/>
+  </joint>
+
+
+  <!-- Transmission is important to link the joints and the controller -->
+  <transmission name="joint_w1_trans" type="SimpleTransmission">
+    <actuator name="joint_w1_motor" />
+    <joint name="joint_w1" />
+    <mechanicalReduction>1</mechanicalReduction>
+    <motorTorqueConstant>1</motorTorqueConstant>
+  </transmission>
+
+  <transmission name="joint_w2_trans" type="SimpleTransmission">
+    <actuator name="joint_w2_motor" />
+    <joint name="joint_w2" />
+    <mechanicalReduction>1</mechanicalReduction>
+    <motorTorqueConstant>1</motorTorqueConstant>
+  </transmission>
+
+  <!-- Colour -->
+  <gazebo reference="base_link">
+    <material>Gazebo/Green</material>
+  </gazebo>
+
+  <gazebo reference="wheel1">
+    <material>Gazebo/Red</material>
+  </gazebo>
+
+  <gazebo reference="wheel2">
+    <material>Gazebo/Blue</material>
+  </gazebo>
+
+  <gazebo reference="base_footprint">
+    <material>Gazebo/Purple</material>
+  </gazebo>
+
+</robot>

--- a/diff_drive_controller/test/config/diffbot_sphere_wheels.xacro
+++ b/diff_drive_controller/test/config/diffbot_sphere_wheels.xacro
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!--
+  Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF-Controller%20Example
+  -->
+  <xacro:include filename="sphere_wheel.xacro"/>
+  <xacro:property name="deg_to_rad" value="0.01745329251994329577"/>
+
+  <!-- Constants for robot dimensions -->
+  <xacro:property name="width" value="0.5" /> <!-- Square dimensions (widthxwidth) of beams -->
+  <xacro:property name="wheel_radius" value="0.11" /> <!-- Link 1 -->
+  <xacro:property name="axel_offset" value="0.05" /> <!-- Space btw top of beam and the each joint -->
+
+  <!-- Links: inertial,visual,collision -->
+  <link name="base_link">
+    <inertial>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="5"/>
+      <inertia ixx="5" ixy="0" ixz="0" iyy="5" iyz="0" izz="5"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </visual>
+    <collision>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+
+
+  <link name="base_footprint">
+    <visual>
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <sphere radius="0.00000001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="base_footprint_joint" type="fixed">
+    <origin xyz="0 0 ${wheel_radius}" rpy="0 0 0"/>
+    <child link="base_link"/>
+    <parent link="base_footprint"/>
+  </joint>
+
+
+  <!-- Wheels -->
+  <xacro:sphere_wheel name="wheel_0" parent="base" radius="${wheel_radius}">
+    <origin xyz="${width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:sphere_wheel>
+  <xacro:sphere_wheel name="wheel_1" parent="base" radius="${wheel_radius}">
+    <origin xyz="${-width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:sphere_wheel>
+
+
+  <!-- Colour -->
+  <gazebo reference="base_link">
+    <material>Gazebo/Green</material>
+  </gazebo>
+
+  <gazebo reference="base_footprint">
+    <material>Gazebo/Purple</material>
+  </gazebo>
+
+</robot>

--- a/diff_drive_controller/test/config/diffbot_square_wheels.xacro
+++ b/diff_drive_controller/test/config/diffbot_square_wheels.xacro
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!--
+  Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF-Controller%20Example
+  -->
+  <xacro:include filename="square_wheel.xacro"/>
+  <xacro:property name="deg_to_rad" value="0.01745329251994329577"/>
+
+  <!-- Constants for robot dimensions -->
+  <xacro:property name="width" value="0.5" /> <!-- Square dimensions (widthxwidth) of beams -->
+  <xacro:property name="wheel_radius" value="0.11" /> <!-- Link 1 -->
+  <xacro:property name="axel_offset" value="0.05" /> <!-- Space btw top of beam and the each joint -->
+
+  <!-- Links: inertial,visual,collision -->
+  <link name="base_link">
+    <inertial>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="5"/>
+      <inertia ixx="5" ixy="0" ixz="0" iyy="5" iyz="0" izz="5"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </visual>
+    <collision>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+
+
+  <link name="base_footprint">
+    <visual>
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <sphere radius="0.00000001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="base_footprint_joint" type="fixed">
+    <origin xyz="0 0 ${wheel_radius}" rpy="0 0 0"/>
+    <child link="base_link"/>
+    <parent link="base_footprint"/>
+  </joint>
+
+
+  <!-- Wheels -->
+  <xacro:square_wheel name="wheel_0" parent="base" radius="${wheel_radius}">
+    <origin xyz="${width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:square_wheel>
+  <xacro:square_wheel name="wheel_1" parent="base" radius="${wheel_radius}">
+    <origin xyz="${-width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:square_wheel>
+
+
+  <!-- Colour -->
+  <gazebo reference="base_link">
+    <material>Gazebo/Green</material>
+  </gazebo>
+
+  <gazebo reference="base_footprint">
+    <material>Gazebo/Purple</material>
+  </gazebo>
+
+</robot>

--- a/diff_drive_controller/test/config/skidsteerbot.xacro
+++ b/diff_drive_controller/test/config/skidsteerbot.xacro
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!--
+  Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF-Controller%20Example
+  -->
+  <xacro:include filename="wheel.xacro"/>
+
+  <xacro:property name="deg_to_rad" value="0.01745329251994329577"/>
+
+  <!-- Constants for robot dimensions -->
+  <xacro:property name="width" value="0.5" /> <!-- Square dimensions (widthxwidth) of beams -->
+  <xacro:property name="wheel_radius" value="0.11" /> <!-- Link 1 -->
+  <xacro:property name="thickness" value="0.086" /> <!-- Link 2 -->
+  <xacro:property name="axel_offset" value="0.05" /> <!-- Space btw top of beam and the each joint -->
+  <xacro:property name="y_offset" value="0.35" /> <!-- Offset for the wheels on the same side -->
+
+  <!-- Links: inertial,visual,collision -->
+  <link name="base_link">
+    <inertial>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="5"/>
+      <inertia ixx="5" ixy="0" ixz="0" iyy="5" iyz="0" izz="5"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </visual>
+    <collision>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <box size="${width} 0.1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+
+
+  <link name="base_footprint">
+    <visual>
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <sphere radius="0.00000001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="base_footprint_joint" type="fixed">
+    <origin xyz="0 0 ${wheel_radius}" rpy="0 0 0"/>
+    <child link="base_link"/>
+    <parent link="base_footprint"/>
+  </joint>
+
+
+  <!-- Wheels -->
+  <xacro:wheel name="wheel_0" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${width/2+axel_offset} ${y_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:wheel>
+  <xacro:wheel name="wheel_1" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:wheel>
+  <xacro:wheel name="wheel_2" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${width/2+axel_offset} ${-y_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:wheel>
+  <xacro:wheel name="wheel_3" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${-width/2+axel_offset} ${y_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:wheel>
+  <xacro:wheel name="wheel_4" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${-width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:wheel>
+  <xacro:wheel name="wheel_5" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${-width/2+axel_offset} ${-y_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </xacro:wheel>
+
+
+  <!-- Colour -->
+  <gazebo reference="base_link">
+    <material>Gazebo/Green</material>
+  </gazebo>
+
+  <gazebo reference="base_footprint">
+    <material>Gazebo/Purple</material>
+  </gazebo>
+
+</robot>

--- a/diff_drive_controller/test/config/skidsteerbot.yaml
+++ b/diff_drive_controller/test/config/skidsteerbot.yaml
@@ -1,4 +1,4 @@
-diffbot_controller:  # Name of DiffDriveController node
+/**: # Note: Wildcard necessary to permit parameter override via launch file
   ros__parameters:
     left_wheel_names: ["wheel_0_joint", "wheel_1_joint", "wheel_2_joint"]
     right_wheel_names: ["wheel_3_joint", "wheel_4_joint", "wheel_5_joint"]

--- a/diff_drive_controller/test/config/skidsteerbot.yaml
+++ b/diff_drive_controller/test/config/skidsteerbot.yaml
@@ -1,0 +1,9 @@
+diffbot_controller:  # Name of DiffDriveController node
+  ros__parameters:
+    left_wheel_names: ["wheel_0_joint", "wheel_1_joint", "wheel_2_joint"]
+    right_wheel_names: ["wheel_3_joint", "wheel_4_joint", "wheel_5_joint"]
+    write_op_modes: ["op_status"]
+
+    pose_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
+    twist_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
+    cmd_vel_timeout: 20000   # in ms

--- a/diff_drive_controller/test/config/sphere_wheel.xacro
+++ b/diff_drive_controller/test/config/sphere_wheel.xacro
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="sphere_wheel" params="name parent radius *origin">
+    <link name="${name}_link">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="1"/>
+        <inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <sphere radius="${wheel_radius}"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <sphere radius="${wheel_radius}"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${name}_joint" type="continuous">
+      <parent link="${parent}_link"/>
+      <child link="${name}_link"/>
+      <xacro:insert_block name="origin"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+
+    <!-- Transmission is important to link the joints and the controller -->
+    <transmission name="${name}_joint_trans" type="SimpleTransmission">
+      <actuator name="${name}_joint_motor"/>
+      <joint name="${name}_joint"/>
+      <mechanicalReduction>1</mechanicalReduction>
+      <motorTorqueConstant>1</motorTorqueConstant>
+    </transmission>
+
+    <gazebo reference="${name}_link">
+      <material>Gazebo/Red</material>
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/diff_drive_controller/test/config/sphere_wheel.xacro
+++ b/diff_drive_controller/test/config/sphere_wheel.xacro
@@ -10,13 +10,13 @@
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <sphere radius="${wheel_radius}"/>
+          <sphere radius="${radius}"/>
         </geometry>
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <sphere radius="${wheel_radius}"/>
+          <sphere radius="${radius}"/>
         </geometry>
       </collision>
     </link>

--- a/diff_drive_controller/test/config/square_wheel.xacro
+++ b/diff_drive_controller/test/config/square_wheel.xacro
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="square_wheel" params="name parent radius *origin">
+    <link name="${name}_link">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="1"/>
+        <inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <!-- use boxes for wheels, scale radius to account for "circumference" difference -->
+          <box size="${wheel_radius*1.11} ${wheel_radius*1.11} ${wheel_radius*1.11} "/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="${wheel_radius*1.11} ${wheel_radius*1.11} ${wheel_radius*1.11} "/>
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${name}_joint" type="continuous">
+      <parent link="${parent}_link"/>
+      <child link="${name}_link"/>
+      <xacro:insert_block name="origin"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+
+    <!-- Transmission is important to link the joints and the controller -->
+    <transmission name="${name}_joint_trans" type="SimpleTransmission">
+      <actuator name="${name}_joint_motor"/>
+      <joint name="${name}_joint"/>
+      <mechanicalReduction>1</mechanicalReduction>
+      <motorTorqueConstant>1</motorTorqueConstant>
+    </transmission>
+
+    <gazebo reference="${name}_link">
+      <material>Gazebo/Red</material>
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/diff_drive_controller/test/config/square_wheel.xacro
+++ b/diff_drive_controller/test/config/square_wheel.xacro
@@ -11,13 +11,13 @@
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <!-- use boxes for wheels, scale radius to account for "circumference" difference -->
-          <box size="${wheel_radius*1.11} ${wheel_radius*1.11} ${wheel_radius*1.11} "/>
+          <box size="${radius*1.11} ${radius*1.11} ${radius*1.11} "/>
         </geometry>
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <box size="${wheel_radius*1.11} ${wheel_radius*1.11} ${wheel_radius*1.11} "/>
+          <box size="${radius*1.11} ${radius*1.11} ${radius*1.11} "/>
         </geometry>
       </collision>
     </link>

--- a/diff_drive_controller/test/config/wheel.xacro
+++ b/diff_drive_controller/test/config/wheel.xacro
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="wheel" params="name parent radius thickness *origin">
+    <link name="${name}_link">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="1"/>
+        <inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${name}_joint" type="continuous">
+      <parent link="${parent}_link"/>
+      <child link="${name}_link"/>
+      <xacro:insert_block name="origin"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+
+    <!-- Transmission is important to link the joints and the controller -->
+    <transmission name="${name}_joint_trans" type="SimpleTransmission">
+      <actuator name="${name}_joint_motor"/>
+      <joint name="${name}_joint"/>
+      <mechanicalReduction>1</mechanicalReduction>
+      <motorTorqueConstant>1</motorTorqueConstant>
+    </transmission>
+
+    <gazebo reference="${name}_link">
+      <material>Gazebo/Red</material>
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/diff_drive_controller/test/config/wheel.xacro
+++ b/diff_drive_controller/test/config/wheel.xacro
@@ -10,13 +10,13 @@
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+          <cylinder radius="${radius}" length="${thickness}"/>
         </geometry>
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+          <cylinder radius="${radius}" length="${thickness}"/>
         </geometry>
       </collision>
     </link>

--- a/diff_drive_controller/test/diffbot.cpp
+++ b/diff_drive_controller/test/diffbot.cpp
@@ -1,0 +1,17 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "diffbot.h"
+
+int main(int argc, char ** argv) { diffbot_main_runner<2>(argc, argv); }

--- a/diff_drive_controller/test/diffbot.cpp
+++ b/diff_drive_controller/test/diffbot.cpp
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "diffbot.h"
+#include "diffbot.hpp"
 
-int main(int argc, char ** argv) { diffbot_main_runner<2>(argc, argv); }
+int main(int argc, char ** argv) {diffbot_main_runner<2>(argc, argv);}

--- a/diff_drive_controller/test/diffbot.h
+++ b/diff_drive_controller/test/diffbot.h
@@ -1,0 +1,280 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DIFFBOT_H_
+#define DIFFBOT_H_
+
+#include <controller_manager/controller_manager.hpp>
+#include <hardware_interface/robot_hardware.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
+#include <std_srvs/srv/empty.hpp>
+
+#include <limits>
+#include <memory>
+#include <sstream>
+
+template <unsigned int NUM_JOINTS = 2>
+class Diffbot : public hardware_interface::RobotHardware
+{
+public:
+  hardware_interface::hardware_interface_ret_t init() override
+  {
+    // Setup service used for testing NaN read in test_diff_drive_nan.cpp
+    node_ = std::make_shared<rclcpp::Node>("diffbot_robot_hardware");
+    running_ = true;  // Running by default.
+    start_srv_ = node_->create_service<std_srvs::srv::Empty>(
+      "start_diffbot",
+      std::bind(&Diffbot::start_callback, this, std::placeholders::_1, std::placeholders::_2));
+    stop_srv_ = node_->create_service<std_srvs::srv::Empty>(
+      "stop_diffbot",
+      std::bind(&Diffbot::stop_callback, this, std::placeholders::_1, std::placeholders::_2));
+
+    // Initialize raw data
+    std::fill_n(pos_, NUM_JOINTS, 0);
+    std::fill_n(vel_, NUM_JOINTS, 0);
+    std::fill_n(eff_, NUM_JOINTS, 0);
+    std::fill_n(cmd_, NUM_JOINTS, 0);
+    op_status_ = hardware_interface::OperationMode::INACTIVE;
+
+    // Connect and register the joint state and velocity interface
+    hardware_interface::hardware_interface_ret_t ret;
+
+    op_handle_ = hardware_interface::OperationModeHandle("op_status", &op_status_);
+    ret = register_operation_mode_handle(&op_handle_);
+    if (ret != hardware_interface::HW_RET_OK) {
+      RCLCPP_WARN(node_->get_logger(), "Cannot register operation handle: op_status");
+      return ret;
+    }
+
+    for (auto i = 0u; i < NUM_JOINTS; i++) {
+      std::ostringstream joint_name_os;
+      joint_name_os << "wheel_" << i << "_joint";
+
+      js_handle_[i] =
+        hardware_interface::JointStateHandle(joint_name_os.str(), &pos_[i], &vel_[i], &eff_[i]);
+      ret = register_joint_state_handle(&js_handle_[i]);
+      if (ret != hardware_interface::HW_RET_OK) {
+        RCLCPP_WARN(node_->get_logger(), "Cannot register joint state handle: %s", js_handle_[i]);
+        return ret;
+      }
+
+      jcmd_handle_[i] = hardware_interface::JointCommandHandle(joint_name_os.str(), &cmd_[i]);
+      ret = register_joint_command_handle(&jcmd_handle_[i]);
+      if (ret != hardware_interface::HW_RET_OK) {
+        RCLCPP_WARN(
+          node_->get_logger(), "Cannot register joint command handle: %s", jcmd_handle_[i]);
+        return ret;
+      }
+    }
+    return hardware_interface::HW_RET_OK;
+  }
+
+  [[nodiscard]] rclcpp::Duration get_period() const { return period_; }
+
+  // Diffbot assumes read is called with frequency of 1/period_.
+  hardware_interface::hardware_interface_ret_t read() override
+  {
+    // Read the joint state of the robot into the hardware interface
+    if (running_) {
+      for (auto i = 0u; i < NUM_JOINTS; ++i) {
+        pos_[i] += vel_[i] * get_period().seconds();  // update position
+        vel_[i] = cmd_[i];                            // might add smoothing here later
+      }
+    } else {
+      std::fill_n(pos_, NUM_JOINTS, std::numeric_limits<double>::quiet_NaN());
+      std::fill_n(vel_, NUM_JOINTS, std::numeric_limits<double>::quiet_NaN());
+    }
+
+    return hardware_interface::HW_RET_OK;
+  }
+
+  hardware_interface::hardware_interface_ret_t write() override
+  {
+    // Write the commands to the joints
+    std::ostringstream os;
+    for (auto i = 0u; i < NUM_JOINTS - 1; ++i) {
+      os << cmd_[i] << ", ";
+    }
+    os << cmd_[NUM_JOINTS - 1];
+
+    RCLCPP_DEBUG_STREAM(node_->get_logger(), "Commands for joints: " << os.str());
+    return hardware_interface::HW_RET_OK;
+  }
+
+  rclcpp::Node::SharedPtr & get_node() { return node_; }
+
+  void start_callback(
+    std_srvs::srv::Empty::Request::SharedPtr /*req*/,
+    std_srvs::srv::Empty::Response::SharedPtr /*res*/)
+  {
+    running_ = true;
+    // Reset state
+    std::fill_n(pos_, NUM_JOINTS, 0);
+    std::fill_n(vel_, NUM_JOINTS, 0);
+    std::fill_n(eff_, NUM_JOINTS, 0);
+    std::fill_n(cmd_, NUM_JOINTS, 0);
+  }
+
+  void stop_callback(
+    std_srvs::srv::Empty::Request::SharedPtr /*req*/,
+    std_srvs::srv::Empty::Response::SharedPtr /*res*/)
+  {
+    running_ = false;
+  }
+
+private:
+  double pos_[NUM_JOINTS];
+  double vel_[NUM_JOINTS];
+  double eff_[NUM_JOINTS];
+  double cmd_[NUM_JOINTS];
+  hardware_interface::OperationMode op_status_;
+
+  rclcpp::Node::SharedPtr node_;
+
+private:
+  bool running_;
+  rclcpp::ServiceBase::SharedPtr start_srv_;
+  rclcpp::ServiceBase::SharedPtr stop_srv_;
+
+  hardware_interface::JointStateHandle js_handle_[NUM_JOINTS];
+  hardware_interface::JointCommandHandle jcmd_handle_[NUM_JOINTS];
+  hardware_interface::OperationModeHandle op_handle_;
+
+  rclcpp::Duration period_ =
+    std::chrono::milliseconds(10);  // Period assumed to elapse between each read
+};
+
+/**
+ * \brief Ensure that a ROS TIME simulation is active
+ * \param sim_clk
+ * \param logger
+ */
+void ensure_sim_clock_is_active(
+  const rclcpp::Clock::SharedPtr & sim_clk, const rclcpp::Logger & logger)
+{
+  auto attempt = 0;
+  while (!sim_clk->ros_time_is_active()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    if (attempt > 4) {
+      RCLCPP_FATAL(
+        logger,
+        "Failed to activate ROS TIME simulation. Make sure 'use_sim_time' is set for a node "
+        "clock.");
+      throw std::runtime_error("Failed to activate ROS TIME simulation");
+    }
+    ++attempt;
+  }
+}
+
+constexpr auto DIFF_DRIVE_CONTROLLER_NAME = "diffbot_controller";
+constexpr auto CONTROLLER_MANAGER_NAME = "diffbot_controller_manager";
+
+/**
+ * \brief Main function used for running the Diffbot instance
+ * \tparam NUM_JOINTS The number of wheels of Diffbot
+ * \param argc main's argc
+ * \param argv main's argv
+ * \return exit code
+ */
+template <unsigned int NUM_JOINTS = 2>
+int diffbot_main_runner(
+  int argc, char * const * argv)
+{
+  rclcpp::init(argc, argv);
+  auto exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+  auto fut = std::async(std::launch::async, [&exec]() { exec->spin(); });
+  auto logger = rclcpp::get_logger("diffbot_control_loop");
+
+  // Initialize Diffbot RobotHardware
+  auto robot = std::make_shared<Diffbot<NUM_JOINTS>>();
+  if (robot->init() != hardware_interface::HW_RET_OK) {
+    RCLCPP_ERROR(logger, "Failed to initialize Diffbot");
+    return EXIT_FAILURE;
+  }
+  auto robot_hw_node = robot->get_node();
+  robot_hw_node->set_parameter({"use_sim_time", true});
+  exec->add_node(robot_hw_node);
+  ensure_sim_clock_is_active(robot_hw_node->get_clock(), robot_hw_node->get_logger());
+
+  // Set up ControllerManager with DiffDriveController using Diffbot. Use sim time.
+  auto cm =
+    std::make_shared<controller_manager::ControllerManager>(robot, exec, CONTROLLER_MANAGER_NAME);
+  cm->set_parameter({"use_sim_time", true});
+  exec->add_node(cm);
+  ensure_sim_clock_is_active(cm->get_clock(), cm->get_logger());
+
+  auto ddc = cm->load_controller(
+    DIFF_DRIVE_CONTROLLER_NAME, "diff_drive_controller/DiffDriveController");  // Load via pluginlib
+  const auto ddc_node = ddc->get_lifecycle_node();
+  ddc_node->set_parameter({"use_sim_time", true});
+  ensure_sim_clock_is_active(ddc_node->get_clock(), ddc_node->get_logger());
+
+  // Configure and activate controllers in ControllerManager
+  if (cm->configure() != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+    RCLCPP_ERROR(logger, "Failed to configure controllers.");
+    return EXIT_FAILURE;
+  }
+  if (cm->activate() != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+    RCLCPP_ERROR(logger, "Failed to activate controllers.");
+    return EXIT_FAILURE;
+  }
+
+  // Use controller manager node as sim time publisher
+  auto sim_clk_pub =
+    cm->template create_publisher<rosgraph_msgs::msg::Clock>("/clock", rclcpp::SystemDefaultsQoS());
+  auto sim_clk = *cm->get_clock().get();
+  auto sim_time = rclcpp::Time(0L, RCL_ROS_TIME);
+  const auto single_loop_period = robot->get_period();
+  auto sys_clk = rclcpp::Clock(RCL_SYSTEM_TIME);
+
+  // Loop approximated to iterate once every single_loop_period.
+  while (rclcpp::ok()) {
+    auto begin = sys_clk.now();
+    if (robot->read() != hardware_interface::HW_RET_OK) {
+      RCLCPP_WARN(logger, "Diffbot failed to read.");
+    }
+    if (cm->update() != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+      RCLCPP_WARN(logger, "Controller manager failed to update.");
+    }
+    if (robot->write() != hardware_interface::HW_RET_OK) {
+      RCLCPP_WARN(logger, "Diffbot failed to read.");
+    }
+    auto end = sys_clk.now();
+
+    auto actual_elapsed_secs = (end - begin).seconds();
+    auto wait_time = single_loop_period.seconds() - actual_elapsed_secs;
+    if (wait_time < 0.0) {
+      RCLCPP_WARN_STREAM_THROTTLE(
+        logger, sys_clk, 100,
+        "Control cycle is taking too much time, elapsed: " << actual_elapsed_secs);
+    } else {
+      RCLCPP_DEBUG_STREAM_THROTTLE(
+        logger, sys_clk, 1000, "Control cycle elapsed: " << actual_elapsed_secs);
+      std::this_thread::sleep_for(std::chrono::duration<double>(wait_time));
+    }
+
+    auto clk_msg = rosgraph_msgs::msg::Clock();
+    clk_msg.clock = sim_time;
+    sim_clk_pub->publish(clk_msg);
+    sim_time = sim_time + single_loop_period;
+  }
+
+  rclcpp::shutdown();
+
+  return EXIT_SUCCESS;
+}
+
+#endif  // DIFFBOT_H_

--- a/diff_drive_controller/test/diffbot.hpp
+++ b/diff_drive_controller/test/diffbot.hpp
@@ -53,7 +53,7 @@ public:
 
     op_handle_ = hardware_interface::OperationModeHandle("op_status", &op_status_);
     ret = register_operation_mode_handle(&op_handle_);
-    if (ret != hardware_interface::HW_RET_OK) {
+    if (ret != hardware_interface::return_type::OK) {
       RCLCPP_WARN(node_->get_logger(), "Cannot register operation handle: op_status");
       return ret;
     }
@@ -65,20 +65,20 @@ public:
       js_handle_[i] =
         hardware_interface::JointStateHandle(joint_name_os.str(), &pos_[i], &vel_[i], &eff_[i]);
       ret = register_joint_state_handle(&js_handle_[i]);
-      if (ret != hardware_interface::HW_RET_OK) {
+      if (ret != hardware_interface::return_type::OK) {
         RCLCPP_WARN(node_->get_logger(), "Cannot register joint state handle: %s", js_handle_[i]);
         return ret;
       }
 
       jcmd_handle_[i] = hardware_interface::JointCommandHandle(joint_name_os.str(), &cmd_[i]);
       ret = register_joint_command_handle(&jcmd_handle_[i]);
-      if (ret != hardware_interface::HW_RET_OK) {
+      if (ret != hardware_interface::return_type::OK) {
         RCLCPP_WARN(
           node_->get_logger(), "Cannot register joint command handle: %s", jcmd_handle_[i]);
         return ret;
       }
     }
-    return hardware_interface::HW_RET_OK;
+    return hardware_interface::return_type::OK;
   }
 
   [[nodiscard]] rclcpp::Duration get_period() const {return period_;}
@@ -97,7 +97,7 @@ public:
       std::fill_n(vel_, NUM_JOINTS, std::numeric_limits<double>::quiet_NaN());
     }
 
-    return hardware_interface::HW_RET_OK;
+    return hardware_interface::return_type::OK;
   }
 
   hardware_interface::hardware_interface_ret_t write() override
@@ -110,7 +110,7 @@ public:
     os << cmd_[NUM_JOINTS - 1];
 
     RCLCPP_DEBUG_STREAM(node_->get_logger(), "Commands for joints: " << os.str());
-    return hardware_interface::HW_RET_OK;
+    return hardware_interface::return_type::OK;
   }
 
   rclcpp::Node::SharedPtr & get_node() {return node_;}
@@ -199,7 +199,7 @@ int diffbot_main_runner(int argc, char * const * argv)
 
   // Initialize Diffbot RobotHardware
   auto robot = std::make_shared<Diffbot<NUM_JOINTS>>();
-  if (robot->init() != hardware_interface::HW_RET_OK) {
+  if (robot->init() != hardware_interface::return_type::OK) {
     RCLCPP_ERROR(logger, "Failed to initialize Diffbot");
     return EXIT_FAILURE;
   }
@@ -222,11 +222,11 @@ int diffbot_main_runner(int argc, char * const * argv)
   ensure_sim_clock_is_active(ddc_node->get_clock(), ddc_node->get_logger());
 
   // Configure and activate controllers in ControllerManager
-  if (cm->configure() != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+  if (cm->configure() != controller_interface::return_type::SUCCESS) {
     RCLCPP_ERROR(logger, "Failed to configure controllers.");
     return EXIT_FAILURE;
   }
-  if (cm->activate() != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+  if (cm->activate() != controller_interface::return_type::SUCCESS) {
     RCLCPP_ERROR(logger, "Failed to activate controllers.");
     return EXIT_FAILURE;
   }
@@ -242,13 +242,13 @@ int diffbot_main_runner(int argc, char * const * argv)
   // Loop approximated to iterate once every single_loop_period.
   while (rclcpp::ok()) {
     auto begin = sys_clk.now();
-    if (robot->read() != hardware_interface::HW_RET_OK) {
+    if (robot->read() != hardware_interface::return_type::OK) {
       RCLCPP_WARN(logger, "Diffbot failed to read.");
     }
-    if (cm->update() != controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS) {
+    if (cm->update() != controller_interface::return_type::SUCCESS) {
       RCLCPP_WARN(logger, "Controller manager failed to update.");
     }
-    if (robot->write() != hardware_interface::HW_RET_OK) {
+    if (robot->write() != hardware_interface::return_type::OK) {
       RCLCPP_WARN(logger, "Diffbot failed to read.");
     }
     auto end = sys_clk.now();

--- a/diff_drive_controller/test/diffbot.hpp
+++ b/diff_drive_controller/test/diffbot.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DIFFBOT_H_
-#define DIFFBOT_H_
+#ifndef DIFFBOT_HPP_
+#define DIFFBOT_HPP_
 
 #include <controller_manager/controller_manager.hpp>
 #include <hardware_interface/robot_hardware.hpp>
@@ -25,7 +25,7 @@
 #include <memory>
 #include <sstream>
 
-template <unsigned int NUM_JOINTS = 2>
+template<unsigned int NUM_JOINTS = 2>
 class Diffbot : public hardware_interface::RobotHardware
 {
 public:
@@ -81,7 +81,7 @@ public:
     return hardware_interface::HW_RET_OK;
   }
 
-  [[nodiscard]] rclcpp::Duration get_period() const { return period_; }
+  [[nodiscard]] rclcpp::Duration get_period() const {return period_;}
 
   // Diffbot assumes read is called with frequency of 1/period_.
   hardware_interface::hardware_interface_ret_t read() override
@@ -113,7 +113,7 @@ public:
     return hardware_interface::HW_RET_OK;
   }
 
-  rclcpp::Node::SharedPtr & get_node() { return node_; }
+  rclcpp::Node::SharedPtr & get_node() {return node_;}
 
   void start_callback(
     std_srvs::srv::Empty::Request::SharedPtr /*req*/,
@@ -189,13 +189,12 @@ constexpr auto CONTROLLER_MANAGER_NAME = "diffbot_controller_manager";
  * \param argv main's argv
  * \return exit code
  */
-template <unsigned int NUM_JOINTS = 2>
-int diffbot_main_runner(
-  int argc, char * const * argv)
+template<unsigned int NUM_JOINTS = 2>
+int diffbot_main_runner(int argc, char * const * argv)
 {
   rclcpp::init(argc, argv);
   auto exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
-  auto fut = std::async(std::launch::async, [&exec]() { exec->spin(); });
+  auto fut = std::async(std::launch::async, [&exec]() {exec->spin();});
   auto logger = rclcpp::get_logger("diffbot_control_loop");
 
   // Initialize Diffbot RobotHardware
@@ -277,4 +276,4 @@ int diffbot_main_runner(
   return EXIT_SUCCESS;
 }
 
-#endif  // DIFFBOT_H_
+#endif  // DIFFBOT_HPP_

--- a/diff_drive_controller/test/diffbot.hpp
+++ b/diff_drive_controller/test/diffbot.hpp
@@ -15,15 +15,15 @@
 #ifndef DIFFBOT_HPP_
 #define DIFFBOT_HPP_
 
-#include <controller_manager/controller_manager.hpp>
-#include <hardware_interface/robot_hardware.hpp>
-#include <rclcpp/rclcpp.hpp>
-#include <rosgraph_msgs/msg/clock.hpp>
-#include <std_srvs/srv/empty.hpp>
-
 #include <limits>
 #include <memory>
 #include <sstream>
+
+#include "controller_manager/controller_manager.hpp"
+#include "hardware_interface/robot_hardware.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rosgraph_msgs/msg/clock.hpp"
+#include "std_srvs/srv/empty.hpp"
 
 template<unsigned int NUM_JOINTS = 2>
 class Diffbot : public hardware_interface::RobotHardware

--- a/diff_drive_controller/test/diffbot_launch_test_common.py
+++ b/diff_drive_controller/test/diffbot_launch_test_common.py
@@ -1,0 +1,62 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import launch
+from launch.substitutions import PathJoinSubstitution, LaunchConfiguration
+from launch.some_substitutions_type import SomeSubstitutionsType
+import launch_ros
+from launch_ros.parameters_type import SomeParametersDict
+import launch_testing.actions
+from typing import Optional, SupportsFloat
+import xacro
+
+
+def generate_diffbot_test_description(*args,
+                                      gtest_name: SomeSubstitutionsType,
+                                      exec_name: SomeSubstitutionsType = 'diffbot',
+                                      param_yaml: SomeSubstitutionsType = 'diffbot.yaml',
+                                      robot_urdf: SomeSubstitutionsType = 'diffbot.xacro',
+                                      additional_params: Optional[SomeParametersDict] = None,
+                                      timeout: SupportsFloat = 40.0):
+    if additional_params is None:
+        additional_params = {}
+
+    # Parse xacro file
+    xacro_file = os.path.join(os.path.dirname(__file__), 'config/', robot_urdf)
+    robot_description = xacro.process(xacro_file)
+
+    diffbot_node = launch_ros.actions.Node(
+        node_executable=PathJoinSubstitution([LaunchConfiguration('test_binary_dir'), exec_name]),
+        parameters=[
+            additional_params,
+            {'robot_description': robot_description},
+            PathJoinSubstitution([os.path.dirname(__file__), 'config/', param_yaml])
+        ],
+        remappings=[('cmd_vel', 'diffbot_controller/cmd_vel'),
+                    ('odom', 'diffbot_controller/odom'),
+                    ('cmd_vel_out', 'diffbot_controller/cmd_vel_out'),
+                    ('wheel_joint_controller_state', 'diffbot_controller/wheel_joint_controller_state')]
+    )
+
+    diffbot_gtest = launch_testing.actions.GTest(
+        path=PathJoinSubstitution([LaunchConfiguration('test_binary_dir'), gtest_name]),
+        timeout=timeout, output='screen')
+
+    return launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument(name='test_binary_dir',
+                                             description='Binary directory of package containing test executables'),
+        diffbot_node,
+        diffbot_gtest,
+        launch_testing.actions.ReadyToTest()
+    ]), {'diffbot_node': diffbot_node, 'diffbot_gtest': diffbot_gtest}

--- a/diff_drive_controller/test/diffbot_launch_test_common.py
+++ b/diff_drive_controller/test/diffbot_launch_test_common.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+
+from typing import Optional, SupportsFloat
+
 import launch
-from launch.substitutions import PathJoinSubstitution, LaunchConfiguration
 from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 import launch_ros
 from launch_ros.parameters_type import SomeParametersDict
 import launch_testing.actions
-from typing import Optional, SupportsFloat
 import xacro
 
 
@@ -39,14 +41,15 @@ def generate_diffbot_test_description(*args,
     diffbot_node = launch_ros.actions.Node(
         node_executable=PathJoinSubstitution([LaunchConfiguration('test_binary_dir'), exec_name]),
         parameters=[
-            additional_params,
+            PathJoinSubstitution([os.path.dirname(__file__), 'config/', param_yaml]),
             {'robot_description': robot_description},
-            PathJoinSubstitution([os.path.dirname(__file__), 'config/', param_yaml])
+            additional_params
         ],
         remappings=[('cmd_vel', 'diffbot_controller/cmd_vel'),
                     ('odom', 'diffbot_controller/odom'),
                     ('cmd_vel_out', 'diffbot_controller/cmd_vel_out'),
-                    ('wheel_joint_controller_state', 'diffbot_controller/wheel_joint_controller_state')]
+                    ('wheel_joint_controller_state',
+                     'diffbot_controller/wheel_joint_controller_state')]
     )
 
     diffbot_gtest = launch_testing.actions.GTest(
@@ -55,7 +58,8 @@ def generate_diffbot_test_description(*args,
 
     return launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(name='test_binary_dir',
-                                             description='Binary directory of package containing test executables'),
+                                             description='Binary directory of package '
+                                                         'containing test executables'),
         diffbot_node,
         diffbot_gtest,
         launch_testing.actions.ReadyToTest()

--- a/diff_drive_controller/test/skidsteerbot.cpp
+++ b/diff_drive_controller/test/skidsteerbot.cpp
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "diffbot.h"
+#include "diffbot.hpp"
 
-int main(int argc, char ** argv) { return diffbot_main_runner<6>(argc, argv); }
+int main(int argc, char ** argv) {return diffbot_main_runner<6>(argc, argv);}

--- a/diff_drive_controller/test/skidsteerbot.cpp
+++ b/diff_drive_controller/test/skidsteerbot.cpp
@@ -1,0 +1,17 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "diffbot.h"
+
+int main(int argc, char ** argv) { return diffbot_main_runner<6>(argc, argv); }

--- a/diff_drive_controller/test/test_common.h
+++ b/diff_drive_controller/test/test_common.h
@@ -1,0 +1,387 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+
+#include <tf2_ros/transform_listener.h>
+#include <control_msgs/msg/joint_trajectory_controller_state.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <lifecycle_msgs/srv/get_state.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <cmath>
+#include <memory>
+#include <string>
+
+#ifndef TEST_COMMON_H_
+#define TEST_COMMON_H_
+
+// Floating-point value comparison threshold
+constexpr double EPS = 0.01;
+constexpr double POSITION_TOLERANCE = 0.01;               // 1 cm-s precision
+constexpr double VELOCITY_TOLERANCE = 0.02;               // 2 cm-s-1 precision
+constexpr double JERK_LINEAR_VELOCITY_TOLERANCE = 0.10;   // 10 cm-s-1 precision
+constexpr double JERK_ANGULAR_VELOCITY_TOLERANCE = 0.05;  // 3 deg-s-1 precision
+constexpr double ORIENTATION_TOLERANCE = 0.03;            // 0.57 degree precision
+
+constexpr auto DIFF_DRIVE_CONTROLLER_NAME = "diffbot_controller";
+constexpr auto DEFAULT_ODOM_FRAME_ID = "odom";
+constexpr auto DEFAULT_BASE_FRAME_ID = "base_link";
+
+using namespace std::chrono_literals;
+
+/*
+ * DiffDriveControllerTest fixture makes the following assumptions:
+ * 1. There exists an external simulated clock publisher
+ * 2. There exists a DiffDriveController with name DIFF_DRIVE_CONTROLLER_NAME running
+ * 3. All DiffDriveController topics are remapped to ${DIFF_DRIVE_CONTROLLER_NAME}/topic_name
+ */
+
+class DiffDriveControllerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Use simulated time
+    nh->set_parameter({"use_sim_time", true});
+    executor->add_node(nh);
+    executor_task_fut = std::async(std::launch::async, [this]() { this->executor->spin(); });
+  }
+  void TearDown() override { executor->cancel(); }
+
+  DiffDriveControllerTest()
+  : received_first_odom(false),
+    executor(std::make_shared<rclcpp::executors::SingleThreadedExecutor>()),
+    nh(std::make_shared<rclcpp::Node>("diffbot_controller_test")),
+    logger(nh->get_logger()),
+    cmd_pub(nh->create_publisher<geometry_msgs::msg::TwistStamped>(
+      std::string(DIFF_DRIVE_CONTROLLER_NAME) + "/cmd_vel", 100)),
+    odom_sub(nh->create_subscription<nav_msgs::msg::Odometry>(
+      std::string(DIFF_DRIVE_CONTROLLER_NAME) + "/odom", 100,
+      std::bind(&DiffDriveControllerTest::odom_callback, this, std::placeholders::_1))),
+    vel_out_sub(nh->create_subscription<geometry_msgs::msg::TwistStamped>(
+      std::string(DIFF_DRIVE_CONTROLLER_NAME) + "/cmd_vel_out", 100,
+      std::bind(&DiffDriveControllerTest::cmd_vel_out_callback, this, std::placeholders::_1))),
+    joint_traj_controller_state_sub(
+      nh->create_subscription<control_msgs::msg::JointTrajectoryControllerState>(
+        std::string(DIFF_DRIVE_CONTROLLER_NAME) + "/wheel_joint_controller_state", 100,
+        std::bind(
+          &DiffDriveControllerTest::joint_trajectory_controller_state_callback, this,
+          std::placeholders::_1)))
+  {
+  }
+
+  nav_msgs::msg::Odometry::ConstSharedPtr get_last_odom() { return last_odom; }
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr get_last_cmd_vel_out()
+  {
+    return last_cmd_vel_out;
+  }
+  control_msgs::msg::JointTrajectoryControllerState::ConstSharedPtr
+  get_last_wheel_joint_controller_state()
+  {
+    return last_joint_traj_controller_state;
+  }
+
+  void publish(geometry_msgs::msg::Twist cmd_vel)
+  {
+    auto cmd_vel_stamped = geometry_msgs::msg::TwistStamped();
+    cmd_vel_stamped.header.stamp = nh->now();
+    cmd_vel_stamped.twist = cmd_vel;
+    cmd_pub->publish(cmd_vel_stamped);
+  }
+
+  [[nodiscard]] bool is_controller_alive() const
+  {
+    return (odom_sub->get_publisher_count() > 0) && (cmd_pub->get_subscription_count() > 0);
+  }
+
+  /**
+   * \brief Waits for DiffDriverController instance with DIFF_DRIVE_CONTROLLER_NAME name to activate.
+   * \return returns true only if it is successfully confirmed.
+   */
+  [[nodiscard]] bool wait_for_controller() const
+  {
+    static constexpr auto max_wait_time = 10'000ms;
+
+    RCLCPP_DEBUG(logger, "Waiting for controller started");
+    auto system_clk = rclcpp::Clock(rcl_clock_type_t::RCL_SYSTEM_TIME);
+    auto start_time = system_clk.now();
+    auto time_limit = start_time + max_wait_time;
+    auto get_lifecycle_state_client = nh->create_client<lifecycle_msgs::srv::GetState>(
+      std::string(DIFF_DRIVE_CONTROLLER_NAME) + "/get_state");
+
+    if (!get_lifecycle_state_client->wait_for_service(max_wait_time)) {
+      RCLCPP_ERROR(
+        logger,
+        "Timed out waiting for /get_state service. Please make sure DiffDriveController node "
+        "process is running.");
+      return false;
+    }
+
+    using lifecycle_msgs::msg::State;
+    auto diff_drive_controller_current_state = State::PRIMARY_STATE_UNKNOWN;
+    while (diff_drive_controller_current_state != State::PRIMARY_STATE_ACTIVE) {
+      if (!rclcpp::ok()) {
+        RCLCPP_ERROR(
+          logger, "rclcpp::ok() returned false while waiting for controller to activate");
+        return false;
+      }
+
+      auto dur_left = time_limit - system_clk.now();
+      if (dur_left.seconds() <= 0) {
+        RCLCPP_ERROR(logger, "Timed out waiting for DiffDriveController node to activate.");
+        return false;
+      }
+
+      auto fut = get_lifecycle_state_client->async_send_request(
+        std::make_shared<lifecycle_msgs::srv::GetState_Request>());
+      // Wait for future to complete
+      auto fut_status = fut.wait_for(dur_left.to_chrono<std::chrono::nanoseconds>());
+      if (fut_status != std::future_status::ready) {
+        continue;
+      }
+
+      const auto & res = fut.get();
+      diff_drive_controller_current_state = res->current_state.id;
+      std::this_thread::sleep_for(100ms);
+      RCLCPP_DEBUG_STREAM_THROTTLE(
+        logger, system_clk, 500,
+        "DiffDriveController state at time " << system_clk.now().seconds() << ": "
+                                             << res->current_state.label);
+    }
+
+    // Another sanity check to make sure subscriptions/publishers are alive.
+    while (!is_controller_alive()) {
+      if (!rclcpp::ok()) {
+        RCLCPP_ERROR(
+          logger, "rclcpp::ok() returned false while waiting for controller to activate.");
+        return false;
+      }
+
+      auto dur_left = time_limit - system_clk.now();
+      if (dur_left.seconds() <= 0) {
+        RCLCPP_ERROR(logger, "Timed out waiting for DiffDriveController node to activate.");
+        return false;
+      }
+
+      RCLCPP_DEBUG_THROTTLE(logger, system_clk, 500, "Waiting for DiffDriveController node");
+      std::this_thread::sleep_for(100ms);
+    }
+
+    // Make sure ROS TIME is active
+    auto sim_clk = nh->get_clock();
+    if (!sim_clk->ros_time_is_active()) {
+      RCLCPP_ERROR(
+        logger, "ROS TIME is not active for this node. Make sure 'use_sim_time' parameter is set.");
+      return false;
+    }
+    // Make sure ROS TIME is ticking
+    auto sim_start = sim_clk->now();
+    while (sim_clk->now() <= sim_start) {
+      std::this_thread::sleep_for(100ms);
+
+      auto dur_left = time_limit - system_clk.now();
+      if (dur_left.seconds() <= 0) {
+        RCLCPP_ERROR(
+          logger,
+          "Timed out waiting for simulated clock to move. Sim start time: %f, Sim current time: %f",
+          sim_start.seconds(), sim_clk->now().seconds());
+        return false;
+      }
+    }
+
+    RCLCPP_DEBUG_STREAM(
+      logger, "Waiting for controller completed successfully,  Simulated time(sec): "
+                << nh->get_clock()->now().seconds() << " Actual: " << system_clk.now().seconds());
+    return true;
+  }
+
+  [[nodiscard]] bool has_received_first_odom() const { return received_first_odom; }
+
+  /**
+   * \brief Sleep using simulated clock. Implementation is loosely based off of how
+   * rclcpp::Duration::sleep() works in ROS1.
+   * https://github.com/ros/roscpp_core/blob/eabafec8f9b554d5389a1aa1b3c8145c07faaefb/rostime/src/time.cpp#L384
+   * \param dur Duration to sleep
+   * \param max_dur_multiplier Multiple of the duration that determines the maximum wait duration.
+   *                           Ex. dur=10s, max_dur_multiplier= 1.5 => maximum wait duration = 15s.
+    * \return true if slept for simulated clock duration
+   */
+  bool sim_sleep_for(const rclcpp::Duration & dur, double max_dur_multiplier = 2.0) const
+  {
+    static constexpr auto SLEEP_STEP = 1ms;  // Step used in ROS1
+
+    auto sim_clk = nh->get_clock();
+    // Make sure ROS TIME is active before attempting to sleep.
+    if (!sim_clk->ros_time_is_active()) {
+      RCLCPP_ERROR(
+        logger, "sim_sleep_for() method requires ROS TIME to be active. Aborting sleep.");
+      return false;
+    }
+
+    auto sim_start = sim_clk->now();
+    auto sim_end = sim_start + dur;
+
+    auto sys_clk = rclcpp::Clock(rcl_clock_type_t::RCL_SYSTEM_TIME);
+    auto sys_start = sys_clk.now();
+    auto time_limit = sys_start + max_dur_multiplier * dur.to_chrono<std::chrono::nanoseconds>();
+
+    RCLCPP_DEBUG_STREAM(
+      logger, "Sleeping for " << dur.seconds() << " seconds using simulated clock. Start time Sim: "
+                              << sim_start.seconds() << ", System: " << sys_start.seconds());
+    while (sim_clk->now() < sim_end) {
+      std::this_thread::sleep_for(SLEEP_STEP);
+
+      // If time jumps backwards from when we started sleeping, return immediately
+      if (sim_clk->now() < sim_start) {
+        RCLCPP_ERROR_STREAM(
+          logger,
+          "Simulated time jumped backward from start time. Stopping sleep. Sim started time: "
+            << sim_start.seconds() << ", Sim current time: " << sim_clk->now().seconds());
+        return false;
+      }
+      // if time limit is exceeded, return immediately
+      if (sys_clk.now() > time_limit) {
+        RCLCPP_WARN(logger, "Simulation sleep exceeded wait threshold. Stopping sleep");
+        return false;
+      }
+    }
+    RCLCPP_DEBUG_STREAM(
+      logger, "Simulation sleep finished. Duration (sec) Simulated: "
+                << (sim_clk->now() - sim_start).seconds()
+                << ", System: " << rclcpp::Duration(sys_clk.now() - sys_start).seconds());
+    return true;
+  }
+
+  [[nodiscard]] bool wait_for_odom_msgs() const
+  {
+    static const rclcpp::Duration timeout = 2s;
+
+    auto time_limit = nh->now() + timeout;
+    while (!has_received_first_odom()) {
+      if (!rclcpp::ok()) {
+        RCLCPP_ERROR(logger, "rclcpp::ok() returned false while waiting for first odom message.");
+        return false;
+      }
+      if (nh->now() > time_limit) {
+        RCLCPP_ERROR(logger, "wait_for_odom_msgs() waiting time expired.");
+        return false;
+      }
+
+      sim_sleep_for(100ms);
+    }
+
+    return has_received_first_odom();
+  }
+
+  [[nodiscard]] bool is_publishing_cmd_vel_out(const rclcpp::Duration & timeout = 1000ms) const
+  {
+    auto num_publishers = vel_out_sub->get_publisher_count();
+    auto time_limit = nh->now() + timeout;
+    while ((num_publishers == 0) && (nh->now() < time_limit)) {
+      sim_sleep_for(100ms);
+      num_publishers = vel_out_sub->get_publisher_count();
+    }
+    return num_publishers > 0;
+  }
+
+  [[nodiscard]] bool is_publishing_joint_trajectory_controller_state(
+    const rclcpp::Duration & timeout = 1000ms) const
+  {
+    auto num_publishers = joint_traj_controller_state_sub->get_publisher_count();
+    auto time_limit = nh->now() + timeout;
+    while ((num_publishers == 0) && (nh->now() < time_limit)) {
+      sim_sleep_for(100ms);
+      num_publishers = joint_traj_controller_state_sub->get_publisher_count();
+    }
+    return num_publishers > 0;
+  }
+
+  std::shared_ptr<tf2_ros::Buffer> & get_tf_buffer()
+  {
+    std::lock_guard<std::mutex> lg(tf_mutex);
+    if (tf_buffer == nullptr) {
+      tf_buffer = std::make_shared<tf2_ros::Buffer>(nh->get_clock());
+      tf_buffer->setUsingDedicatedThread(true);
+      tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, nh, false);
+    }
+
+    return tf_buffer;
+  }
+
+  rclcpp::Node::SharedPtr & get_node() { return nh; }
+
+private:
+  bool received_first_odom;
+  rclcpp::executor::Executor::SharedPtr executor;
+  rclcpp::Node::SharedPtr nh;
+  rclcpp::Logger logger;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_pub;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr vel_out_sub;
+  rclcpp::Subscription<control_msgs::msg::JointTrajectoryControllerState>::SharedPtr
+    joint_traj_controller_state_sub;
+  nav_msgs::msg::Odometry::ConstSharedPtr last_odom;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr last_cmd_vel_out;
+  control_msgs::msg::JointTrajectoryControllerState::ConstSharedPtr
+    last_joint_traj_controller_state;
+  std::future<void> executor_task_fut;
+
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer;
+  std::mutex tf_mutex;
+
+  void odom_callback(nav_msgs::msg::Odometry::ConstSharedPtr odom)
+  {
+    RCLCPP_DEBUG_STREAM(
+      logger, "Callback received at "
+                << odom->header.stamp.sec << ": pos.x: " << odom->pose.pose.position.x
+                << ", orient.z: " << odom->pose.pose.orientation.z << ", lin_est: "
+                << odom->twist.twist.linear.x << ", ang_est: " << odom->twist.twist.angular.z);
+    last_odom = odom;
+    received_first_odom = true;
+  }
+
+  void cmd_vel_out_callback(geometry_msgs::msg::TwistStamped::ConstSharedPtr cmd_vel_out)
+  {
+    RCLCPP_DEBUG_STREAM(
+      logger, "Callback received at " << cmd_vel_out->header.stamp.sec
+                                      << ": lin: " << cmd_vel_out->twist.linear.x
+                                      << ", ang: " << cmd_vel_out->twist.angular.z);
+    last_cmd_vel_out = cmd_vel_out;
+  }
+
+  void joint_trajectory_controller_state_callback(
+    control_msgs::msg::JointTrajectoryControllerState::ConstSharedPtr joint_traj_controller_state)
+  {
+    RCLCPP_DEBUG_STREAM(
+      logger, "Joint trajectory controller state callback received:\n"
+                << joint_traj_controller_state);
+
+    last_joint_traj_controller_state = joint_traj_controller_state;
+  }
+};
+
+inline tf2::Quaternion tf_quat_from_geom_quat(const geometry_msgs::msg::Quaternion & quat)
+{
+  return tf2::Quaternion(quat.x, quat.y, quat.z, quat.w);
+}
+
+#endif  // TEST_COMMON_H_

--- a/diff_drive_controller/test/test_common.hpp
+++ b/diff_drive_controller/test/test_common.hpp
@@ -14,21 +14,21 @@
 
 #pragma once
 
-#include <gtest/gtest.h>
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Quaternion.h>
-
-#include <tf2_ros/transform_listener.h>
-#include <control_msgs/msg/joint_trajectory_controller_state.hpp>
-#include <geometry_msgs/msg/quaternion.hpp>
-#include <geometry_msgs/msg/twist_stamped.hpp>
-#include <lifecycle_msgs/srv/get_state.hpp>
-#include <nav_msgs/msg/odometry.hpp>
-#include <rclcpp/rclcpp.hpp>
-
 #include <cmath>
 #include <memory>
 #include <string>
+
+#include "gtest/gtest.h"
+
+#include "control_msgs/msg/joint_trajectory_controller_state.hpp"
+#include "geometry_msgs/msg/quaternion.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2/LinearMath/Matrix3x3.h"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2_ros/transform_listener.h"
 
 #ifndef TEST_COMMON_HPP_
 #define TEST_COMMON_HPP_

--- a/diff_drive_controller/test/test_diff_drive.cpp
+++ b/diff_drive_controller/test/test_diff_drive.cpp
@@ -1,0 +1,135 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <tf2_ros/transform_listener.h>
+
+#include "test_common.h"
+
+namespace
+{
+}  // namespace
+
+TEST_F(DiffDriveControllerTest, test_forward)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(100ms);
+  // get initial odom
+  nav_msgs::msg::Odometry::ConstSharedPtr old_odom = get_last_odom();
+  // send a velocity command of 0.1 m/s
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  // wait for 10s std::this_thread::sleep_for(10'000ms);
+  sim_sleep_for(10'000ms);
+
+  nav_msgs::msg::Odometry::ConstSharedPtr new_odom = get_last_odom();
+
+  const rclcpp::Duration actual_elapsed_time =
+    rclcpp::Time(new_odom->header.stamp) - rclcpp::Time(old_odom->header.stamp);
+
+  const double expected_distance = cmd_vel.linear.x * actual_elapsed_time.seconds();
+
+  // check if the robot traveled 1 meter in XY plane, changes in z should be ~~0
+  const double dx = new_odom->pose.pose.position.x - old_odom->pose.pose.position.x;
+  const double dy = new_odom->pose.pose.position.y - old_odom->pose.pose.position.y;
+  const double dz = new_odom->pose.pose.position.z - old_odom->pose.pose.position.z;
+  EXPECT_NEAR(sqrt(dx * dx + dy * dy), expected_distance, POSITION_TOLERANCE);
+  EXPECT_LT(fabs(dz), EPS);
+
+  // convert to rpy and test that way
+  double roll_old, pitch_old, yaw_old;
+  double roll_new, pitch_new, yaw_new;
+  tf2::Matrix3x3(tf_quat_from_geom_quat(old_odom->pose.pose.orientation))
+    .getRPY(roll_old, pitch_old, yaw_old);
+  tf2::Matrix3x3(tf_quat_from_geom_quat(new_odom->pose.pose.orientation))
+    .getRPY(roll_new, pitch_new, yaw_new);
+  EXPECT_LT(fabs(roll_new - roll_old), EPS);
+  EXPECT_LT(fabs(pitch_new - pitch_old), EPS);
+  EXPECT_LT(fabs(yaw_new - yaw_old), EPS);
+  EXPECT_NEAR(fabs(new_odom->twist.twist.linear.x), cmd_vel.linear.x, EPS);
+  EXPECT_LT(fabs(new_odom->twist.twist.linear.y), EPS);
+  EXPECT_LT(fabs(new_odom->twist.twist.linear.z), EPS);
+
+  EXPECT_LT(fabs(new_odom->twist.twist.angular.x), EPS);
+  EXPECT_LT(fabs(new_odom->twist.twist.angular.y), EPS);
+  EXPECT_LT(fabs(new_odom->twist.twist.angular.z), EPS);
+}
+
+TEST_F(DiffDriveControllerTest, test_turn)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+
+  sim_sleep_for(100ms);
+  // get initial odom
+  nav_msgs::msg::Odometry::ConstSharedPtr old_odom = get_last_odom();
+  // send a velocity command
+  cmd_vel.angular.z = M_PI / 10.0;
+  publish(cmd_vel);
+  // wait for 10s
+  sim_sleep_for(10'000ms);
+
+  nav_msgs::msg::Odometry::ConstSharedPtr new_odom = get_last_odom();
+
+  // check if the robot rotated PI around z, changes in the other fields should be ~~0
+  EXPECT_LT(fabs(new_odom->pose.pose.position.x - old_odom->pose.pose.position.x), EPS);
+  EXPECT_LT(fabs(new_odom->pose.pose.position.y - old_odom->pose.pose.position.y), EPS);
+  EXPECT_LT(fabs(new_odom->pose.pose.position.z - old_odom->pose.pose.position.z), EPS);
+
+  const rclcpp::Duration actual_elapsed_time =
+    rclcpp::Time(new_odom->header.stamp) - rclcpp::Time(old_odom->header.stamp);
+  const double expected_rotation = cmd_vel.angular.z * actual_elapsed_time.seconds();
+
+  // convert to rpy and test that way
+  double roll_old, pitch_old, yaw_old;
+  double roll_new, pitch_new, yaw_new;
+  tf2::Matrix3x3(tf_quat_from_geom_quat(old_odom->pose.pose.orientation))
+    .getRPY(roll_old, pitch_old, yaw_old);
+  tf2::Matrix3x3(tf_quat_from_geom_quat(new_odom->pose.pose.orientation))
+    .getRPY(roll_new, pitch_new, yaw_new);
+  EXPECT_LT(fabs(roll_new - roll_old), EPS);
+  EXPECT_LT(fabs(pitch_new - pitch_old), EPS);
+  EXPECT_NEAR(fabs(yaw_new - yaw_old), expected_rotation, ORIENTATION_TOLERANCE);
+
+  EXPECT_LT(fabs(new_odom->twist.twist.linear.x), EPS);
+  EXPECT_LT(fabs(new_odom->twist.twist.linear.y), EPS);
+  EXPECT_LT(fabs(new_odom->twist.twist.linear.z), EPS);
+
+  EXPECT_LT(fabs(new_odom->twist.twist.angular.x), EPS);
+  EXPECT_LT(fabs(new_odom->twist.twist.angular.y), EPS);
+  EXPECT_NEAR(
+    fabs(new_odom->twist.twist.angular.z), expected_rotation / actual_elapsed_time.seconds(), EPS);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive.cpp
+++ b/diff_drive_controller/test/test_diff_drive.cpp
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-#include <tf2_ros/transform_listener.h>
+#include "tf2_ros/transform_listener.h"
 
 #include "test_common.hpp"
-
-namespace
-{
-}  // namespace
 
 TEST_F(DiffDriveControllerTest, test_forward)
 {

--- a/diff_drive_controller/test/test_diff_drive.cpp
+++ b/diff_drive_controller/test/test_diff_drive.cpp
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 #include <tf2_ros/transform_listener.h>
 
-#include "test_common.h"
+#include "test_common.hpp"
 
 namespace
 {
@@ -57,9 +57,9 @@ TEST_F(DiffDriveControllerTest, test_forward)
   double roll_old, pitch_old, yaw_old;
   double roll_new, pitch_new, yaw_new;
   tf2::Matrix3x3(tf_quat_from_geom_quat(old_odom->pose.pose.orientation))
-    .getRPY(roll_old, pitch_old, yaw_old);
+  .getRPY(roll_old, pitch_old, yaw_old);
   tf2::Matrix3x3(tf_quat_from_geom_quat(new_odom->pose.pose.orientation))
-    .getRPY(roll_new, pitch_new, yaw_new);
+  .getRPY(roll_new, pitch_new, yaw_new);
   EXPECT_LT(fabs(roll_new - roll_old), EPS);
   EXPECT_LT(fabs(pitch_new - pitch_old), EPS);
   EXPECT_LT(fabs(yaw_new - yaw_old), EPS);
@@ -107,9 +107,9 @@ TEST_F(DiffDriveControllerTest, test_turn)
   double roll_old, pitch_old, yaw_old;
   double roll_new, pitch_new, yaw_new;
   tf2::Matrix3x3(tf_quat_from_geom_quat(old_odom->pose.pose.orientation))
-    .getRPY(roll_old, pitch_old, yaw_old);
+  .getRPY(roll_old, pitch_old, yaw_old);
   tf2::Matrix3x3(tf_quat_from_geom_quat(new_odom->pose.pose.orientation))
-    .getRPY(roll_new, pitch_new, yaw_new);
+  .getRPY(roll_new, pitch_new, yaw_new);
   EXPECT_LT(fabs(roll_new - roll_old), EPS);
   EXPECT_LT(fabs(pitch_new - pitch_old), EPS);
   EXPECT_NEAR(fabs(yaw_new - yaw_old), expected_rotation, ORIENTATION_TOLERANCE);

--- a/diff_drive_controller/test/test_diff_drive.test.py
+++ b/diff_drive_controller/test/test_diff_drive.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -28,11 +29,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive.test.py
+++ b/diff_drive_controller/test/test_diff_drive.test.py
@@ -1,0 +1,38 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive',
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_bad_urdf.test.py
+++ b/diff_drive_controller/test/test_diff_drive_bad_urdf.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_bad_urdf.test.py
+++ b/diff_drive_controller/test/test_diff_drive_bad_urdf.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_fail',
+        robot_urdf='diffbot_bad.xacro',
+        additional_params={
+        },
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -32,11 +32,6 @@ class TestableDiffDriveController : public diff_drive_controller::DiffDriveContr
 {
 public:
   using DiffDriveController::DiffDriveController;
-  std::shared_ptr<geometry_msgs::msg::TwistStamped> getLastReceivedTwist() const
-  {
-    return received_velocity_msg_ptr_;
-  }
-
   /**
   * @brief wait_for_twist block until a new twist is received.
   * Requires that the executor is not spinned elsewhere between the
@@ -178,6 +173,12 @@ TEST_F(TestDiffDriveController, correct_initialization)
   auto ret = diff_drive_controller->init(initialized_robot, controller_name);
   ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
 
+  auto diff_drive_lifecycle_node = diff_drive_controller->get_lifecycle_node();
+  rclcpp::Parameter wheel_radius("wheel_radius", 1.0);
+  diff_drive_lifecycle_node->set_parameter(wheel_radius);
+  rclcpp::Parameter wheel_separation("wheel_separation", 1.0);
+  diff_drive_lifecycle_node->set_parameter(wheel_separation);
+
   auto inactive_state = diff_drive_controller->get_lifecycle_node()->configure();
   EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, inactive_state.id());
   EXPECT_EQ(1.1, initialized_robot->pos1);
@@ -196,6 +197,12 @@ TEST_F(TestDiffDriveController, configuration)
       test_robot,
       controller_name),
     controller_interface::return_type::SUCCESS);
+
+  auto diff_drive_lifecycle_node = diff_drive_controller->get_lifecycle_node();
+  rclcpp::Parameter wheel_radius("wheel_radius", 1.0);
+  diff_drive_lifecycle_node->set_parameter(wheel_radius);
+  rclcpp::Parameter wheel_separation("wheel_separation", 1.0);
+  diff_drive_lifecycle_node->set_parameter(wheel_separation);
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(diff_drive_controller->get_lifecycle_node()->get_node_base_interface());

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -74,7 +74,7 @@ protected:
 
     pub_node = std::make_shared<rclcpp::Node>("velocity_publisher");
     velocity_publisher = pub_node->create_publisher<geometry_msgs::msg::TwistStamped>(
-      controller_name + "/cmd_vel",
+      "/cmd_vel",
       rclcpp::SystemDefaultsQoS());
   }
 
@@ -174,10 +174,8 @@ TEST_F(TestDiffDriveController, correct_initialization)
   ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
 
   auto diff_drive_lifecycle_node = diff_drive_controller->get_lifecycle_node();
-  rclcpp::Parameter wheel_radius("wheel_radius", 1.0);
-  diff_drive_lifecycle_node->set_parameter(wheel_radius);
-  rclcpp::Parameter wheel_separation("wheel_separation", 1.0);
-  diff_drive_lifecycle_node->set_parameter(wheel_separation);
+  diff_drive_lifecycle_node->set_parameter(rclcpp::Parameter("wheel_separation", 1.0));
+  diff_drive_lifecycle_node->set_parameter(rclcpp::Parameter("wheel_radius", 1.0));
 
   auto inactive_state = diff_drive_controller->get_lifecycle_node()->configure();
   EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, inactive_state.id());
@@ -199,10 +197,8 @@ TEST_F(TestDiffDriveController, configuration)
     controller_interface::return_type::SUCCESS);
 
   auto diff_drive_lifecycle_node = diff_drive_controller->get_lifecycle_node();
-  rclcpp::Parameter wheel_radius("wheel_radius", 1.0);
-  diff_drive_lifecycle_node->set_parameter(wheel_radius);
-  rclcpp::Parameter wheel_separation("wheel_separation", 1.0);
-  diff_drive_lifecycle_node->set_parameter(wheel_separation);
+  diff_drive_lifecycle_node->set_parameter(rclcpp::Parameter("wheel_separation", 1.0));
+  diff_drive_lifecycle_node->set_parameter(rclcpp::Parameter("wheel_radius", 1.0));
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(diff_drive_controller->get_lifecycle_node()->get_node_base_interface());

--- a/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.cpp
+++ b/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.cpp
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
+#include "test_common.hpp"
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, test_default_cmd_vel_out_topic)

--- a/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.cpp
+++ b/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.cpp
@@ -1,0 +1,52 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_default_cmd_vel_out_topic)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+  // msgs are published in the same loop
+  // thus if odom is published cmd_vel_out
+  // should be as well (if enabled)
+  ASSERT_TRUE(wait_for_odom_msgs());
+
+  EXPECT_FALSE(is_publishing_cmd_vel_out());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(100ms);
+
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  sim_sleep_for(100ms);
+
+  EXPECT_FALSE(is_publishing_cmd_vel_out());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.cpp
+++ b/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 

--- a/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.test.py
+++ b/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_default_cmd_vel_out',
+        additional_params={
+            # 'publish_limited_velocity': False # Default value.
+        },
+        timeout=20.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.test.py
+++ b/diff_drive_controller/test/test_diff_drive_default_cmd_vel_out.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_default_odom_frame.cpp
+++ b/diff_drive_controller/test/test_diff_drive_default_odom_frame.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 
@@ -22,8 +22,9 @@ TEST_F(DiffDriveControllerTest, test_odom_frame)
   ASSERT_TRUE(wait_for_controller());
 
   // check the odom frame exist
-  EXPECT_TRUE(get_tf_buffer()->canTransform(
-    DEFAULT_BASE_FRAME_ID, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
+  EXPECT_TRUE(
+    get_tf_buffer()->canTransform(
+      DEFAULT_BASE_FRAME_ID, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
 }
 
 TEST_F(DiffDriveControllerTest, test_odom_topic)

--- a/diff_drive_controller/test/test_diff_drive_default_odom_frame.cpp
+++ b/diff_drive_controller/test/test_diff_drive_default_odom_frame.cpp
@@ -1,0 +1,49 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_odom_frame)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // check the odom frame exist
+  EXPECT_TRUE(get_tf_buffer()->canTransform(
+    DEFAULT_BASE_FRAME_ID, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
+}
+
+TEST_F(DiffDriveControllerTest, test_odom_topic)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+  ASSERT_TRUE(wait_for_odom_msgs());
+
+  // get an odom message
+  auto odom_msg = get_last_odom();
+  // check its frame_id
+  ASSERT_STREQ(odom_msg->header.frame_id.c_str(), DEFAULT_ODOM_FRAME_ID);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_default_odom_frame.cpp
+++ b/diff_drive_controller/test/test_diff_drive_default_odom_frame.cpp
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
+#include "test_common.hpp"
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, test_odom_frame)

--- a/diff_drive_controller/test/test_diff_drive_default_odom_frame.test.py
+++ b/diff_drive_controller/test/test_diff_drive_default_odom_frame.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -32,11 +33,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_default_odom_frame.test.py
+++ b/diff_drive_controller/test/test_diff_drive_default_odom_frame.test.py
@@ -1,0 +1,42 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_default_odom_frame',
+        additional_params={
+            #     'odom_frame_id': 'odom',                 # Default
+            #     'base_frame_id': 'base_link'
+        },
+        timeout=20.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.cpp
+++ b/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.cpp
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
+#include "test_common.hpp"
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, test_default_joint_trajectory_controller_state_topic)

--- a/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.cpp
+++ b/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.cpp
@@ -1,0 +1,47 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_default_joint_trajectory_controller_state_topic)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  EXPECT_FALSE(is_publishing_joint_trajectory_controller_state());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(100ms);
+
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  sim_sleep_for(100ms);
+
+  EXPECT_FALSE(is_publishing_joint_trajectory_controller_state());
+}
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.cpp
+++ b/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 

--- a/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.test.py
+++ b/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=30.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.test.py
+++ b/diff_drive_controller/test/test_diff_drive_default_wheel_joint_controller_state.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_default_wheel_joint_controller_state',
+        additional_params={
+            'publish_wheel_joint_controller_state': False
+        },
+        timeout=30.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=30.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_fail.cpp
+++ b/diff_drive_controller/test/test_diff_drive_fail.cpp
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
+#include "test_common.hpp"
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, test_wrong_joint_name)

--- a/diff_drive_controller/test/test_diff_drive_fail.cpp
+++ b/diff_drive_controller/test/test_diff_drive_fail.cpp
@@ -1,0 +1,33 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_wrong_joint_name)
+{
+  // the controller should never be alive
+  EXPECT_FALSE(wait_for_controller());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_fail.cpp
+++ b/diff_drive_controller/test/test_diff_drive_fail.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 

--- a/diff_drive_controller/test/test_diff_drive_fail.test.py
+++ b/diff_drive_controller/test/test_diff_drive_fail.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_fail.test.py
+++ b/diff_drive_controller/test/test_diff_drive_fail.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_fail',
+        additional_params={
+            'left_wheel_names': ['this_joint_does_not_exist']
+        },
+        timeout=20.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_limits.cpp
+++ b/diff_drive_controller/test/test_diff_drive_limits.cpp
@@ -1,0 +1,250 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+// TEST CASES
+// NOTE: All tests assume a controller parameterized by
+// linear:
+//   x:
+//     has_velocity_limits: true
+//     min_velocity: -0.5
+//     max_velocity: 1.0
+//     has_acceleration_limits: true
+//     min_acceleration: -0.5
+//     max_acceleration: 1.0
+//     has_jerk_limits: true
+//     min_jerk: -5.0
+//     max_jerk: 5.0
+// angular:
+//     z:
+//     has_velocity_limits: true
+//     min_velocity: -2.0
+//     max_velocity: 2.0
+//     has_acceleration_limits: true
+//     min_acceleration: -2.0
+//     max_acceleration: 2.0
+//     has_jerk_limits: true
+//     min_jerk: -10.0
+//     max_jerk: 10.0
+
+TEST_F(DiffDriveControllerTest, test_linear_jerk_limits)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(4s);
+  // get initial odom
+  nav_msgs::msg::Odometry::ConstSharedPtr oldest_odom = get_last_odom();
+  ASSERT_NEAR(oldest_odom->twist.twist.linear.x, 0, EPS);
+  ASSERT_NEAR(oldest_odom->twist.twist.angular.z, 0, EPS);
+  // send a big command
+  cmd_vel.linear.x = 10.0;
+  publish(cmd_vel);
+  // wait for a while
+  sim_sleep_for(250ms);
+  nav_msgs::msg::Odometry::ConstSharedPtr old_odom = get_last_odom();
+  sim_sleep_for(250ms);
+  nav_msgs::msg::Odometry::ConstSharedPtr new_odom = get_last_odom();
+
+  // check if jerk is below limit of 5.0m.s-3
+  EXPECT_LT(
+    fabs(
+      new_odom->twist.twist.linear.x - 2 * old_odom->twist.twist.linear.x +
+      oldest_odom->twist.twist.linear.x),
+    (5 * 0.25 * 0.25) + VELOCITY_TOLERANCE);
+  EXPECT_LT(fabs(new_odom->twist.twist.angular.z - old_odom->twist.twist.angular.z), EPS);
+
+  cmd_vel.linear.x = 0.0;
+  publish(cmd_vel);
+}
+
+TEST_F(DiffDriveControllerTest, test_linear_acceleration_limits)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(4s);
+  // get initial odom
+  nav_msgs::msg::Odometry::ConstSharedPtr old_odom = get_last_odom();
+  ASSERT_NEAR(old_odom->twist.twist.linear.x, 0, EPS);
+  ASSERT_NEAR(old_odom->twist.twist.angular.z, 0, EPS);
+  // send a big command
+  cmd_vel.linear.x = 10.0;
+  publish(cmd_vel);
+  // wait for a while
+  sim_sleep_for(500ms);
+
+  nav_msgs::msg::Odometry::ConstSharedPtr new_odom = get_last_odom();
+
+  // check if acceleration is below limit of 1.0m.s-2
+  EXPECT_LT(
+    fabs(new_odom->twist.twist.linear.x - old_odom->twist.twist.linear.x),
+    0.5 + VELOCITY_TOLERANCE);
+  EXPECT_LT(fabs(new_odom->twist.twist.angular.z - old_odom->twist.twist.angular.z), EPS);
+
+  cmd_vel.linear.x = 0.0;
+  publish(cmd_vel);
+}
+
+TEST_F(DiffDriveControllerTest, test_linear_velocity_limits)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(4s);
+  // get initial odom
+  nav_msgs::msg::Odometry::ConstSharedPtr old_odom = get_last_odom();
+  ASSERT_NEAR(old_odom->twist.twist.linear.x, 0, EPS);
+  ASSERT_NEAR(old_odom->twist.twist.angular.z, 0, EPS);
+  // send a big command
+  cmd_vel.linear.x = 10.0;
+  publish(cmd_vel);
+  // wait for a while
+  sim_sleep_for(5s);
+
+  nav_msgs::msg::Odometry::ConstSharedPtr new_odom = get_last_odom();
+
+  // check if the robot speed is now 1.0 m.s-1, the limit
+  EXPECT_NEAR(new_odom->twist.twist.linear.x, 1, VELOCITY_TOLERANCE);
+  EXPECT_LT(fabs(new_odom->twist.twist.angular.z - old_odom->twist.twist.angular.z), EPS);
+
+  cmd_vel.linear.x = 0.0;
+  publish(cmd_vel);
+}
+
+TEST_F(DiffDriveControllerTest, test_angular_jerk_limits)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(4s);
+  // get initial odom
+  nav_msgs::msg::Odometry::ConstSharedPtr oldest_odom = get_last_odom();
+  ASSERT_NEAR(oldest_odom->twist.twist.linear.x, 0, EPS);
+  ASSERT_NEAR(oldest_odom->twist.twist.angular.z, 0, EPS);
+  // send a big command
+  cmd_vel.angular.z = 10.0;
+  publish(cmd_vel);
+  // wait for a while
+  sim_sleep_for(250ms);
+  nav_msgs::msg::Odometry::ConstSharedPtr old_odom = get_last_odom();
+  sim_sleep_for(250ms);
+  nav_msgs::msg::Odometry::ConstSharedPtr new_odom = get_last_odom();
+
+  // check if jerk is below limit of 10.0rad.s-3
+  EXPECT_LT(
+    fabs(
+      new_odom->twist.twist.angular.z - 2 * old_odom->twist.twist.angular.z +
+      oldest_odom->twist.twist.angular.z),
+    (10.0 * 0.25 * 0.25) + VELOCITY_TOLERANCE);
+  EXPECT_LT(fabs(new_odom->twist.twist.linear.x - old_odom->twist.twist.linear.x), EPS);
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+}
+
+TEST_F(DiffDriveControllerTest, testAngularAccelerationLimits)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(4s);
+  // get initial odom
+  nav_msgs::msg::Odometry::ConstSharedPtr old_odom = get_last_odom();
+  ASSERT_NEAR(old_odom->twist.twist.linear.x, 0, EPS);
+  ASSERT_NEAR(old_odom->twist.twist.angular.z, 0, EPS);
+  // send a big command
+  cmd_vel.angular.z = 10.0;
+  publish(cmd_vel);
+  // wait for a while
+  sim_sleep_for(500ms);
+
+  nav_msgs::msg::Odometry::ConstSharedPtr new_odom = get_last_odom();
+
+  // check if acceleration is below limit of 2.0rad.s-2
+  EXPECT_LT(
+    fabs(new_odom->twist.twist.angular.z - old_odom->twist.twist.angular.z),
+    1.0 + VELOCITY_TOLERANCE);
+  EXPECT_LT(fabs(new_odom->twist.twist.linear.x - old_odom->twist.twist.linear.x), EPS);
+
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+}
+
+TEST_F(DiffDriveControllerTest, testAngularVelocityLimits)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(4s);
+  // get initial odom
+  nav_msgs::msg::Odometry::ConstSharedPtr old_odom = get_last_odom();
+  ASSERT_NEAR(old_odom->twist.twist.linear.x, 0, EPS);
+  ASSERT_NEAR(old_odom->twist.twist.angular.z, 0, EPS);
+  // send a big command
+  cmd_vel.angular.z = 10.0;
+  publish(cmd_vel);
+  // wait for a while
+  sim_sleep_for(5s);
+
+  nav_msgs::msg::Odometry::ConstSharedPtr new_odom = get_last_odom();
+
+  // check if the robot speed is now 2.0rad.s-1, the limit
+  EXPECT_NEAR(new_odom->twist.twist.angular.z, 2, VELOCITY_TOLERANCE);
+  EXPECT_LT(fabs(new_odom->twist.twist.linear.x - old_odom->twist.twist.linear.x), EPS);
+
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_limits.cpp
+++ b/diff_drive_controller/test/test_diff_drive_limits.cpp
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
+#include "test_common.hpp"
 
 // TEST CASES
 // NOTE: All tests assume a controller parameterized by

--- a/diff_drive_controller/test/test_diff_drive_limits.cpp
+++ b/diff_drive_controller/test/test_diff_drive_limits.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 

--- a/diff_drive_controller/test/test_diff_drive_limits.test.py
+++ b/diff_drive_controller/test/test_diff_drive_limits.test.py
@@ -1,0 +1,67 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_limits',
+        additional_params={
+            'linear': {
+                'x': {
+                    'has_velocity_limits': True,
+                    'min_velocity': -0.5,
+                    'max_velocity': 1.0,
+                    'has_acceleration_limits': True,
+                    'min_acceleration': -0.5,
+                    'max_acceleration': 1.0,
+                    'has_jerk_limits': True,
+                    'min_jerk': -5.0,
+                    'max_jerk': 5.0
+                }
+            },
+            'angular': {
+                'z': {
+                    'has_velocity_limits': True,
+                    'min_velocity': -2.0,
+                    'max_velocity': 2.0,
+                    'has_acceleration_limits': True,
+                    'min_acceleration': -2.0,
+                    'max_acceleration': 2.0,
+                    'has_jerk_limits': True,
+                    'min_jerk': -10.0,
+                    'max_jerk': 10.0
+                }
+            }
+        },
+        timeout=60.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=60.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)
+

--- a/diff_drive_controller/test/test_diff_drive_limits.test.py
+++ b/diff_drive_controller/test/test_diff_drive_limits.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -56,12 +57,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=60.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)
-

--- a/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.cpp
+++ b/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.cpp
@@ -1,0 +1,83 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_break_with_multiple_publishers)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+  ASSERT_TRUE(wait_for_odom_msgs());
+
+  auto old_odom = get_last_odom();
+
+  // Create another cmd_vel publisher
+  auto another_node = std::make_shared<rclcpp::Node>("another_node");
+  another_node->set_parameter({"use_sim_time", true});
+  auto another_cmd_pub = another_node->create_publisher<geometry_msgs::msg::TwistStamped>(
+    std::string(DIFF_DRIVE_CONTROLLER_NAME) + "/cmd_vel", 100);
+
+  // Create a timer where both nodes publish cmd_vel
+  auto & node = get_node();
+  auto & clk = *node->get_clock();
+  auto timer = node->create_wall_timer(100ms, [this, &another_cmd_pub, &clk]() {
+    geometry_msgs::msg::Twist cmd_vel_1;
+    cmd_vel_1.linear.x = 1.0;
+    publish(cmd_vel_1);
+    std::this_thread::sleep_for(30ms);
+
+    geometry_msgs::msg::TwistStamped cmd_vel_2;
+    cmd_vel_2.twist.linear.x = 2.0;
+    cmd_vel_2.header.stamp = clk.now();
+    another_cmd_pub->publish(cmd_vel_2);
+  });
+
+  // Wait for a while
+  sim_sleep_for(5s);
+  auto new_odom = get_last_odom();
+
+  const double dx = new_odom->pose.pose.position.x - old_odom->pose.pose.position.x;
+  const double dy = new_odom->pose.pose.position.y - old_odom->pose.pose.position.y;
+  const double dz = new_odom->pose.pose.position.z - old_odom->pose.pose.position.z;
+  EXPECT_NEAR(sqrt(dx * dx + dy * dy), 0.0, POSITION_TOLERANCE);
+  EXPECT_LT(fabs(dz), EPS);
+
+  // convert to rpy and test that way
+  double roll_old, pitch_old, yaw_old;
+  double roll_new, pitch_new, yaw_new;
+  tf2::Matrix3x3(tf_quat_from_geom_quat(old_odom->pose.pose.orientation))
+    .getRPY(roll_old, pitch_old, yaw_old);
+  tf2::Matrix3x3(tf_quat_from_geom_quat(new_odom->pose.pose.orientation))
+    .getRPY(roll_new, pitch_new, yaw_new);
+  EXPECT_LT(fabs(roll_new - roll_old), EPS);
+  EXPECT_LT(fabs(pitch_new - pitch_old), EPS);
+  EXPECT_LT(fabs(yaw_new - yaw_old), EPS);
+
+  timer.reset();
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.cpp
+++ b/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.cpp
@@ -11,12 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
-
-#include <gtest/gtest.h>
 
 #include <memory>
 #include <string>
+
+#include "test_common.hpp"
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, test_break_with_multiple_publishers)

--- a/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.cpp
+++ b/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 
@@ -36,17 +36,18 @@ TEST_F(DiffDriveControllerTest, test_break_with_multiple_publishers)
   // Create a timer where both nodes publish cmd_vel
   auto & node = get_node();
   auto & clk = *node->get_clock();
-  auto timer = node->create_wall_timer(100ms, [this, &another_cmd_pub, &clk]() {
-    geometry_msgs::msg::Twist cmd_vel_1;
-    cmd_vel_1.linear.x = 1.0;
-    publish(cmd_vel_1);
-    std::this_thread::sleep_for(30ms);
+  auto timer = node->create_wall_timer(
+    100ms, [this, &another_cmd_pub, &clk]() {
+      geometry_msgs::msg::Twist cmd_vel_1;
+      cmd_vel_1.linear.x = 1.0;
+      publish(cmd_vel_1);
+      std::this_thread::sleep_for(30ms);
 
-    geometry_msgs::msg::TwistStamped cmd_vel_2;
-    cmd_vel_2.twist.linear.x = 2.0;
-    cmd_vel_2.header.stamp = clk.now();
-    another_cmd_pub->publish(cmd_vel_2);
-  });
+      geometry_msgs::msg::TwistStamped cmd_vel_2;
+      cmd_vel_2.twist.linear.x = 2.0;
+      cmd_vel_2.header.stamp = clk.now();
+      another_cmd_pub->publish(cmd_vel_2);
+    });
 
   // Wait for a while
   sim_sleep_for(5s);
@@ -62,9 +63,9 @@ TEST_F(DiffDriveControllerTest, test_break_with_multiple_publishers)
   double roll_old, pitch_old, yaw_old;
   double roll_new, pitch_new, yaw_new;
   tf2::Matrix3x3(tf_quat_from_geom_quat(old_odom->pose.pose.orientation))
-    .getRPY(roll_old, pitch_old, yaw_old);
+  .getRPY(roll_old, pitch_old, yaw_old);
   tf2::Matrix3x3(tf_quat_from_geom_quat(new_odom->pose.pose.orientation))
-    .getRPY(roll_new, pitch_new, yaw_new);
+  .getRPY(roll_new, pitch_new, yaw_new);
   EXPECT_LT(fabs(roll_new - roll_old), EPS);
   EXPECT_LT(fabs(pitch_new - pitch_old), EPS);
   EXPECT_LT(fabs(yaw_new - yaw_old), EPS);

--- a/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.test.py
+++ b/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.test.py
+++ b/diff_drive_controller/test/test_diff_drive_multiple_cmd_vel_publishers.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_multiple_cmd_vel_publishers',
+        additional_params={
+            'allow_multiple_cmd_vel_publishers': False
+        },
+        timeout=20.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_multipliers.test.py
+++ b/diff_drive_controller/test/test_diff_drive_multipliers.test.py
@@ -1,0 +1,43 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive',
+        additional_params={
+            'wheel_separation_multiplier': 2.3,
+            'left_wheel_radius_multiplier': 1.4,
+            'right_wheel_radius_multiplier': 1.4
+        },
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_multipliers.test.py
+++ b/diff_drive_controller/test/test_diff_drive_multipliers.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -33,11 +34,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_nan.cpp
+++ b/diff_drive_controller/test/test_diff_drive_nan.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 #include <std_srvs/srv/empty.hpp>

--- a/diff_drive_controller/test/test_diff_drive_nan.cpp
+++ b/diff_drive_controller/test/test_diff_drive_nan.cpp
@@ -1,0 +1,108 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+#include <std_srvs/srv/empty.hpp>
+
+#include <limits>
+#include <memory>
+
+TEST_F(DiffDriveControllerTest, test_nan)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(2s);
+
+  // send a command
+  cmd_vel.linear.x = 0.1;
+  sim_sleep_for(2s);
+
+  // stop robot (will generate NaN)
+  auto node = get_node();
+  auto stop_diffbot_srv = node->create_client<std_srvs::srv::Empty>("stop_diffbot");
+  stop_diffbot_srv->async_send_request(std::make_shared<std_srvs::srv::Empty::Request>()).wait();
+  sim_sleep_for(2s);
+
+  nav_msgs::msg::Odometry::ConstSharedPtr odom = get_last_odom();
+
+  EXPECT_FALSE(std::isnan(odom->twist.twist.linear.x));
+  EXPECT_FALSE(std::isnan(odom->twist.twist.angular.z));
+  EXPECT_FALSE(std::isnan(odom->pose.pose.position.x));
+  EXPECT_FALSE(std::isnan(odom->pose.pose.position.y));
+  EXPECT_FALSE(std::isnan(odom->pose.pose.orientation.z));
+  EXPECT_FALSE(std::isnan(odom->pose.pose.orientation.w));
+
+  // start robot
+  auto start_diffbot_srv = node->create_client<std_srvs::srv::Empty>("start_diffbot");
+  start_diffbot_srv->async_send_request(std::make_shared<std_srvs::srv::Empty::Request>()).wait();
+  sim_sleep_for(2s);
+
+  odom = get_last_odom();
+
+  EXPECT_FALSE(std::isnan(odom->twist.twist.linear.x));
+  EXPECT_FALSE(std::isnan(odom->twist.twist.angular.z));
+  EXPECT_FALSE(std::isnan(odom->pose.pose.position.x));
+  EXPECT_FALSE(std::isnan(odom->pose.pose.position.y));
+  EXPECT_FALSE(std::isnan(odom->pose.pose.orientation.z));
+  EXPECT_FALSE(std::isnan(odom->pose.pose.orientation.w));
+}
+
+TEST_F(DiffDriveControllerTest, test_nan_cmd)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(100ms);
+
+  // send NaN
+  for (int i = 0; i < 10; ++i) {
+    cmd_vel.linear.x = NAN;
+    cmd_vel.angular.z = NAN;
+    publish(cmd_vel);
+    geometry_msgs::msg::TwistStamped::ConstSharedPtr cmd_vel_out_msg = get_last_cmd_vel_out();
+    EXPECT_FALSE(std::isnan(cmd_vel_out_msg->twist.linear.x));
+    EXPECT_FALSE(std::isnan(cmd_vel_out_msg->twist.angular.z));
+    sim_sleep_for(100ms);
+  }
+
+  nav_msgs::msg::Odometry::ConstSharedPtr odom = get_last_odom();
+  EXPECT_DOUBLE_EQ(odom->twist.twist.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(odom->pose.pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(odom->pose.pose.position.y, 0.0);
+
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr cmd_vel_out_msg = get_last_cmd_vel_out();
+  EXPECT_DOUBLE_EQ(cmd_vel_out_msg->twist.linear.x, 0.0);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_nan.cpp
+++ b/diff_drive_controller/test/test_diff_drive_nan.cpp
@@ -11,13 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
-
-#include <gtest/gtest.h>
-#include <std_srvs/srv/empty.hpp>
 
 #include <limits>
 #include <memory>
+
+#include "std_srvs/srv/empty.hpp"
+
+#include "test_common.hpp"
 
 TEST_F(DiffDriveControllerTest, test_nan)
 {

--- a/diff_drive_controller/test/test_diff_drive_nan.test.py
+++ b/diff_drive_controller/test/test_diff_drive_nan.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_nan.test.py
+++ b/diff_drive_controller/test/test_diff_drive_nan.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_nan',
+        additional_params={
+            'publish_limited_velocity': True
+        },
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_odom_frame.cpp
+++ b/diff_drive_controller/test/test_diff_drive_odom_frame.cpp
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
+#include "test_common.hpp"
 
 namespace
 {

--- a/diff_drive_controller/test/test_diff_drive_odom_frame.cpp
+++ b/diff_drive_controller/test/test_diff_drive_odom_frame.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 
@@ -30,8 +30,9 @@ TEST_F(DiffDriveControllerTest, test_no_default_odom_frame)
 
   auto tf_buffer = get_tf_buffer();
   // check the odom frame does not exist
-  EXPECT_FALSE(tf_buffer->canTransform(
-    DEFAULT_BASE_FRAME_ID, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
+  EXPECT_FALSE(
+    tf_buffer->canTransform(
+      DEFAULT_BASE_FRAME_ID, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
   EXPECT_FALSE(
     tf_buffer->canTransform(kParamBaseFrameId, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
 }

--- a/diff_drive_controller/test/test_diff_drive_odom_frame.cpp
+++ b/diff_drive_controller/test/test_diff_drive_odom_frame.cpp
@@ -1,0 +1,69 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+// These names should match with test_diff_drive_odom_frame.test.py
+constexpr auto kParamOdomFrameId = "diffbot_odom";
+constexpr auto kParamBaseFrameId = "diffbot_base_link";
+}  // namespace
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_no_default_odom_frame)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  auto tf_buffer = get_tf_buffer();
+  // check the odom frame does not exist
+  EXPECT_FALSE(tf_buffer->canTransform(
+    DEFAULT_BASE_FRAME_ID, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
+  EXPECT_FALSE(
+    tf_buffer->canTransform(kParamBaseFrameId, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
+}
+
+TEST_F(DiffDriveControllerTest, test_new_odom_frame)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // check the odom frame exist
+  EXPECT_TRUE(
+    get_tf_buffer()->canTransform(kParamBaseFrameId, kParamOdomFrameId, rclcpp::Time(0), 2'000ms));
+}
+
+TEST_F(DiffDriveControllerTest, test_odom_topic)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+  ASSERT_TRUE(wait_for_odom_msgs());
+
+  // get an odom message
+  auto odom_msg = get_last_odom();
+  // check its frame_id
+  ASSERT_STREQ(odom_msg->header.frame_id.c_str(), kParamOdomFrameId);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_odom_frame.test.py
+++ b/diff_drive_controller/test/test_diff_drive_odom_frame.test.py
@@ -1,0 +1,42 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_odom_frame',
+        additional_params={
+            'odom_frame_id': 'diffbot_odom',
+            'base_frame_id': 'diffbot_base_link'
+        },
+        timeout=20.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_odom_frame.test.py
+++ b/diff_drive_controller/test/test_diff_drive_odom_frame.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -32,11 +33,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_odom_tf.cpp
+++ b/diff_drive_controller/test/test_diff_drive_odom_tf.cpp
@@ -11,10 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
-#include <tf2_ros/transform_listener.h>
+#include "tf2_ros/transform_listener.h"
+
+#include "test_common.hpp"
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, test_no_odom_frame)

--- a/diff_drive_controller/test/test_diff_drive_odom_tf.cpp
+++ b/diff_drive_controller/test/test_diff_drive_odom_tf.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 #include <tf2_ros/transform_listener.h>
@@ -23,8 +23,9 @@ TEST_F(DiffDriveControllerTest, test_no_odom_frame)
   ASSERT_TRUE(wait_for_controller());
 
   // check the odom frame does not exist
-  EXPECT_FALSE(get_tf_buffer()->canTransform(
-    DEFAULT_BASE_FRAME_ID, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
+  EXPECT_FALSE(
+    get_tf_buffer()->canTransform(
+      DEFAULT_BASE_FRAME_ID, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
 }
 
 int main(int argc, char ** argv)

--- a/diff_drive_controller/test/test_diff_drive_odom_tf.cpp
+++ b/diff_drive_controller/test/test_diff_drive_odom_tf.cpp
@@ -1,0 +1,38 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+#include <tf2_ros/transform_listener.h>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_no_odom_frame)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  // check the odom frame does not exist
+  EXPECT_FALSE(get_tf_buffer()->canTransform(
+    DEFAULT_BASE_FRAME_ID, DEFAULT_ODOM_FRAME_ID, rclcpp::Time(0), 2'000ms));
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_odom_tf.test.py
+++ b/diff_drive_controller/test/test_diff_drive_odom_tf.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_odom_tf.test.py
+++ b/diff_drive_controller/test/test_diff_drive_odom_tf.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_odom_tf',
+        additional_params={
+            'enable_odom_tf': False
+        },
+        timeout=20.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_open_loop.test.py
+++ b/diff_drive_controller/test/test_diff_drive_open_loop.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive',
+        additional_params={
+            'open_loop': True
+        },
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_open_loop.test.py
+++ b/diff_drive_controller/test/test_diff_drive_open_loop.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.cpp
+++ b/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.cpp
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
+#include "test_common.hpp"
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, test_pub_cmd_vel_out_topic)

--- a/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.cpp
+++ b/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.cpp
@@ -1,0 +1,55 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_pub_cmd_vel_out_topic)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+  // msgs are published in the same loop
+  // thus if odom is published cmd_vel_out
+  // should be as well (if enabled)
+  ASSERT_TRUE(wait_for_odom_msgs());
+
+  EXPECT_TRUE(is_publishing_cmd_vel_out());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(100ms);
+
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  sim_sleep_for(100ms);
+
+  EXPECT_TRUE(is_publishing_cmd_vel_out());
+
+  auto cmd_vel_out_msg = get_last_cmd_vel_out();
+  EXPECT_GT(fabs(cmd_vel_out_msg->twist.linear.x), 0);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.cpp
+++ b/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 

--- a/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.test.py
+++ b/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.test.py
+++ b/diff_drive_controller/test/test_diff_drive_pub_cmd_vel_out.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_pub_cmd_vel_out',
+        additional_params={
+            'publish_limited_velocity': True
+        },
+        timeout=20.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.cpp
+++ b/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.cpp
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
+#include "test_common.hpp"
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, test_publish_joint_trajectory_controller_state_topic)

--- a/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.cpp
+++ b/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.cpp
@@ -1,0 +1,60 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_publish_joint_trajectory_controller_state_topic)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+
+  EXPECT_TRUE(is_publishing_joint_trajectory_controller_state());
+
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  sim_sleep_for(100ms);
+
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  sim_sleep_for(500ms);
+
+  EXPECT_TRUE(is_publishing_joint_trajectory_controller_state());
+
+  auto last_state = get_last_wheel_joint_controller_state();
+  // Assuming default config with no speed limiter
+  auto wheel_separation = 1.0;
+  auto wheel_radius = .11;
+  auto expected_vel =
+    (cmd_vel.linear.x - cmd_vel.angular.z * wheel_separation / 2.0) / wheel_radius;
+
+  EXPECT_EQ(last_state->desired.velocities[0], expected_vel);
+  EXPECT_EQ(last_state->desired.velocities[1], expected_vel);
+  EXPECT_EQ(last_state->actual.velocities[0], expected_vel);
+  EXPECT_EQ(last_state->actual.velocities[1], expected_vel);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.cpp
+++ b/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 

--- a/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.test.py
+++ b/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=30.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.test.py
+++ b/diff_drive_controller/test/test_diff_drive_pub_wheel_joint_controller_state.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_pub_wheel_joint_controller_state',
+        additional_params={
+            'publish_wheel_joint_controller_state': True
+        },
+        timeout=30.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=30.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_radius_param.test.py
+++ b/diff_drive_controller/test/test_diff_drive_radius_param.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -26,17 +27,19 @@ def generate_test_description():
         gtest_name='test_diff_drive',
         robot_urdf='diffbot_square_wheels.xacro',
         additional_params={
-            'wheel_radius': 0.11   # Provide the radius, since the bot's wheels are boxes, not cylinders or spheres
+            'wheel_radius': 0.11   # Provide the radius
         },
         timeout=40.0)
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_radius_param.test.py
+++ b/diff_drive_controller/test/test_diff_drive_radius_param.test.py
@@ -1,0 +1,42 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive',
+        robot_urdf='diffbot_square_wheels.xacro',
+        additional_params={
+            'wheel_radius': 0.11   # Provide the radius, since the bot's wheels are boxes, not cylinders or spheres
+        },
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_radius_param_fail.test.py
+++ b/diff_drive_controller/test/test_diff_drive_radius_param_fail.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -26,17 +27,19 @@ def generate_test_description():
         gtest_name='test_diff_drive_fail',
         robot_urdf='diffbot_square_wheels.xacro',
         additional_params={
-            # 'wheel_radius': 0.11   # Don't provide the radius parameter, so the controller should break
+            # 'wheel_radius': 0.11   # Omit the radius parameter so the controller should break
         },
         timeout=40.0)
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_radius_param_fail.test.py
+++ b/diff_drive_controller/test/test_diff_drive_radius_param_fail.test.py
@@ -1,0 +1,42 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_fail',
+        robot_urdf='diffbot_square_wheels.xacro',
+        additional_params={
+            # 'wheel_radius': 0.11   # Don't provide the radius parameter, so the controller should break
+        },
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_radius_sphere.test.py
+++ b/diff_drive_controller/test/test_diff_drive_radius_sphere.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -26,17 +27,19 @@ def generate_test_description():
         gtest_name='test_diff_drive',
         robot_urdf='diffbot_sphere_wheels.xacro',
         additional_params={
-            # 'wheel_radius': 0.11   # Don't provide the radius, since controller should accept cylinders *or* spheres
+            # 'wheel_radius': 0.11   # Controller should accept cylinders *or* spheres
         },
         timeout=40.0)
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_radius_sphere.test.py
+++ b/diff_drive_controller/test/test_diff_drive_radius_sphere.test.py
@@ -1,0 +1,42 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive',
+        robot_urdf='diffbot_sphere_wheels.xacro',
+        additional_params={
+            # 'wheel_radius': 0.11   # Don't provide the radius, since controller should accept cylinders *or* spheres
+        },
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_separation_param.test.py
+++ b/diff_drive_controller/test/test_diff_drive_separation_param.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -26,18 +27,20 @@ def generate_test_description():
         gtest_name='test_diff_drive',
         robot_urdf='diffbot_bad.xacro',
         additional_params={
-            'wheel_radius': 0.11,   #  Provide the radius
+            'wheel_radius': 0.11,   # Provide the radius
             'wheel_separation': 1.0   # Provide the wheel separation
         },
         timeout=40.0)
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_separation_param.test.py
+++ b/diff_drive_controller/test/test_diff_drive_separation_param.test.py
@@ -1,0 +1,43 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive',
+        robot_urdf='diffbot_bad.xacro',
+        additional_params={
+            'wheel_radius': 0.11,   #  Provide the radius
+            'wheel_separation': 1.0   # Provide the wheel separation
+        },
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_timeout.cpp
+++ b/diff_drive_controller/test/test_diff_drive_timeout.cpp
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.hpp"
 
-#include <gtest/gtest.h>
+#include "test_common.hpp"
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, test_timeout)

--- a/diff_drive_controller/test/test_diff_drive_timeout.cpp
+++ b/diff_drive_controller/test/test_diff_drive_timeout.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "test_common.h"
+#include "test_common.hpp"
 
 #include <gtest/gtest.h>
 

--- a/diff_drive_controller/test/test_diff_drive_timeout.cpp
+++ b/diff_drive_controller/test/test_diff_drive_timeout.cpp
@@ -1,0 +1,53 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, test_timeout)
+{
+  // wait for ROS
+  ASSERT_TRUE(wait_for_controller());
+  // zero everything before test
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  // give some time to the controller to react to the command
+  sim_sleep_for(100ms);
+  // get initial odom
+  nav_msgs::msg::Odometry::ConstSharedPtr old_odom = get_last_odom();
+  // send a velocity command of 1 m/s
+  cmd_vel.linear.x = 1.0;
+  publish(cmd_vel);
+  // wait a bit
+  sim_sleep_for(3s);
+
+  nav_msgs::msg::Odometry::ConstSharedPtr new_odom = get_last_odom();
+
+  // check if the robot has stopped after 0.5s,
+  // thus covering less than 0.5s*1.0m.s-1 + some (big) tolerance
+  EXPECT_LT(fabs(new_odom->pose.pose.position.x - old_odom->pose.pose.position.x), 0.8);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_diff_drive_timeout.test.py
+++ b/diff_drive_controller/test/test_diff_drive_timeout.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_diff_drive_timeout.test.py
+++ b/diff_drive_controller/test/test_diff_drive_timeout.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_timeout',
+        additional_params={
+            'cmd_vel_timeout': 500
+        },
+        timeout=20.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_load_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_load_diff_drive_controller.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 PAL Robotics SL.
+// Copyright 2020 PAL Robotics S.L.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ TEST(TestLoadDiffDriveController, load_controller)
 
   robot->init();
 
-  std::shared_ptr<rclcpp::Executor> executor =
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor =
     std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
   controller_manager::ControllerManager cm(robot, executor, "test_controller_manager");

--- a/diff_drive_controller/test/test_skid_steer.test.py
+++ b/diff_drive_controller/test/test_skid_steer.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -31,11 +32,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_skid_steer.test.py
+++ b/diff_drive_controller/test/test_skid_steer.test.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive',
+        exec_name='skidsteerbot',
+        param_yaml='skidsteerbot.yaml',
+        robot_urdf='skidsteerbot.xacro',
+        timeout=40.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=40.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_skid_steer_no_wheels.test.py
+++ b/diff_drive_controller/test/test_skid_steer_no_wheels.test.py
@@ -14,11 +14,12 @@
 import os
 import sys
 import unittest
+
 import launch_testing.asserts
 
 # Import test description for diffbot located in same directory.
 sys.path.append(os.path.dirname(__file__))
-from diffbot_launch_test_common import generate_diffbot_test_description
+from diffbot_launch_test_common import generate_diffbot_test_description # noqa: EI
 
 
 def generate_test_description():
@@ -34,11 +35,13 @@ def generate_test_description():
 
 
 class TestGTestProcessActive(unittest.TestCase):
+
     def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
         proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
 
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):
+
     def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
         launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)

--- a/diff_drive_controller/test/test_skid_steer_no_wheels.test.py
+++ b/diff_drive_controller/test/test_skid_steer_no_wheels.test.py
@@ -1,0 +1,44 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+import launch_testing.asserts
+
+# Import test description for diffbot located in same directory.
+sys.path.append(os.path.dirname(__file__))
+from diffbot_launch_test_common import generate_diffbot_test_description
+
+
+def generate_test_description():
+    return generate_diffbot_test_description(
+        gtest_name='test_diff_drive_fail',
+        exec_name='skidsteerbot',
+        param_yaml='skidsteerbot.yaml',
+        robot_urdf='skidsteerbot.xacro',
+        additional_params={
+            'left_wheel_names': [''],
+        },
+        timeout=20.0)
+
+
+class TestGTestProcessActive(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, diffbot_gtest, diffbot_node):
+        proc_info.assertWaitForShutdown(diffbot_gtest, timeout=20.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    def test_gtest_pass(self, proc_info, diffbot_gtest, diffbot_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=diffbot_gtest)


### PR DESCRIPTION
Hi, in hopes of using this controller for my own project, I recently ported over all the integration tests from the ROS1 repo, as well as porting over missing features like realtime buffer usage for velocity command and urdf parsing. #48  Not sure if this is the way you guys want to go with the launch tests, but I thought it might be of good reference at the least. If I were to do it all over again, I'd probably just rewrite all the gtests in python and avoid the extra complexity of working with gtests on top of launch tests. There aren't too many support on integrating the two together with the current state of launch tests. 

At the very least, I would take a look at the changes I made to diff_drive_controllers.cpp since there were few bugs with the way command velocity messages are currently handled. Also, I caught a few bug with the existing ROS1's diff drive controller in the process as well. 

I did this all a bit haphazardly but I hope it helps!

- stop robot on lifecycle events
- Implement wheel JointControllerState publisher. Port tests
- Implement urdf parsing feature
- Added urdf xacro parameter parsing to launch test. 
- Port over skid steer no wheels test
- Port of skid steer test
- Port over open loop test
- Port allow_multiple_cmd_vel_publishers feature
- Port over odom frme tests
- Port cmd_vel_out tests
- Port test for disabling odom tf
- Port fail test test
- Port multipliers test
- Port command velocity timeout test
- Port over limits test
- Added/ported realtime data structure for storing velocity commands. Bug due to data access race condition was causing tests to fail.
- Fixed a mistake for calculating jerk limit.
- port testing for NaN
- Port test_diff_drive launch test
- make existing unit tests pass