### PR TITLE
forward_command_controller

### DIFF
--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.5)
+project(forward_command_controller)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(controller_interface REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(realtime_tools REQUIRED)
+
+add_library(forward_command_controller
+  SHARED
+  src/forward_command_controller.cpp
+)
+target_include_directories(forward_command_controller PRIVATE include)
+ament_target_dependencies(forward_command_controller
+  builtin_interfaces
+  controller_interface
+  pluginlib
+  rclcpp_lifecycle
+  rcutils
+)
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(forward_command_controller PRIVATE "FORWARD_COMMAND_CONTROLLER_BUILDING_DLL")
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS
+  forward_command_controller
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_dependencies(
+  controller_interface
+  hardware_interface
+  rclcpp
+  rclcpp_lifecycle
+)
+ament_export_include_directories(
+  include
+)
+ament_export_libraries(
+  forward_command_controller
+)
+ament_package()

--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -28,6 +28,7 @@ target_include_directories(forward_command_controller PRIVATE include)
 ament_target_dependencies(forward_command_controller
   builtin_interfaces
   controller_interface
+  hardware_interface
   pluginlib
   rclcpp_lifecycle
   rcutils
@@ -59,6 +60,8 @@ if(BUILD_TESTING)
   find_package(controller_manager REQUIRED)
   find_package(test_robot_hardware REQUIRED)
 
+  ament_lint_auto_find_test_dependencies()
+
   ament_add_gtest(
     test_load_forward_command_controller
     test/test_load_forward_command_controller.cpp
@@ -69,7 +72,17 @@ if(BUILD_TESTING)
     test_robot_hardware
   )
 
-  ament_lint_auto_find_test_dependencies()
+  ament_add_gtest(
+    test_forward_command_controller
+    test/test_forward_command_controller.cpp
+  )
+  target_include_directories(test_forward_command_controller PRIVATE include)
+  target_link_libraries(test_forward_command_controller
+    forward_command_controller
+  )
+  ament_target_dependencies(test_forward_command_controller
+    test_robot_hardware
+  )
 endif()
 
 ament_export_dependencies(

--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(realtime_tools REQUIRED)
+find_package(std_msgs REQUIRED)
 
 add_library(forward_command_controller
   SHARED
@@ -30,6 +31,8 @@ ament_target_dependencies(forward_command_controller
   pluginlib
   rclcpp_lifecycle
   rcutils
+  realtime_tools
+  std_msgs
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -59,6 +62,8 @@ ament_export_dependencies(
   hardware_interface
   rclcpp
   rclcpp_lifecycle
+  realtime_tools
+  std_msgs
 )
 ament_export_include_directories(
   include

--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -38,6 +38,8 @@ ament_target_dependencies(forward_command_controller
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(forward_command_controller PRIVATE "FORWARD_COMMAND_CONTROLLER_BUILDING_DLL")
 
+pluginlib_export_plugin_description_file(controller_interface forward_command_plugin.xml)
+
 install(
   DIRECTORY include/
   DESTINATION include
@@ -52,7 +54,20 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+  find_package(controller_manager REQUIRED)
+  find_package(test_robot_hardware REQUIRED)
+
+  ament_add_gtest(
+    test_load_forward_command_controller
+    test/test_load_forward_command_controller.cpp
+  )
+  target_include_directories(test_load_forward_command_controller PRIVATE include)
+  ament_target_dependencies(test_load_forward_command_controller
+    controller_manager
+    test_robot_hardware
+  )
 
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/forward_command_controller/forward_command_plugin.xml
+++ b/forward_command_controller/forward_command_plugin.xml
@@ -1,0 +1,7 @@
+<library path="forward_command_controller">
+  <class name="forward_command_controller/ForwardCommandController" type="forward_command_controller::ForwardCommandController" base_class_type="controller_interface::ControllerInterface">
+  <description>
+    The forward command controller commands a group of joints in a given interface
+  </description>
+  </class>
+</library>

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -31,8 +31,6 @@ namespace forward_command_controller
 {
 class ForwardCommandController : public controller_interface::ControllerInterface
 {
-  using CmdType = std_msgs::msg::Float64MultiArray;
-
 public:
   FORWARD_COMMAND_CONTROLLER_PUBLIC
   ForwardCommandController();
@@ -54,6 +52,8 @@ public:
   update() override;
 
 protected:
+  using CmdType = std_msgs::msg::Float64MultiArray;
+
   std::vector<hardware_interface::JointHandle> joint_handles_;
   realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>> rt_command_ptr_;
   rclcpp::Subscription<CmdType>::SharedPtr joints_command_subscriber_;

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -54,7 +54,7 @@ public:
 protected:
   using CmdType = std_msgs::msg::Float64MultiArray;
 
-  std::vector<hardware_interface::JointHandle> joint_handles_;
+  std::vector<hardware_interface::JointHandle> joint_cmd_handles_;
   realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>> rt_command_ptr_;
   rclcpp::Subscription<CmdType>::SharedPtr joints_command_subscriber_;
 };

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -1,0 +1,53 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORWARD_COMMAND_CONTROLLER__FORWARD_COMMAND_CONTROLLER_HPP_
+#define FORWARD_COMMAND_CONTROLLER__FORWARD_COMMAND_CONTROLLER_HPP_
+
+#include "controller_interface/controller_interface.hpp"
+#include "forward_command_controller/visibility_control.h"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+
+namespace forward_command_controller
+{
+
+class ForwardCommandController : public controller_interface::ControllerInterface
+{
+public:
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  ForwardCommandController();
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  controller_interface::return_type
+  update() override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State & previous_state) override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+protected:
+};
+
+}  // namespace forward_command_controller
+
+#endif  // FORWARD_COMMAND_CONTROLLER__FORWARD_COMMAND_CONTROLLER_HPP_

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -30,6 +30,19 @@
 
 namespace forward_command_controller
 {
+
+/**
+ * \brief Forward command controller for a set of joints.
+ *
+ * This class forwards the command signal down to a set of joints
+ * on the specified interface.
+ *
+ * \param joints Names of the joints to control.
+ * \param interface_name Name of the interface to command.
+ *
+ * Subscribes to:
+ * - \b commands (std_msgs::msg::Float64MultiArray) : The commands to apply.
+ */
 class ForwardCommandController : public controller_interface::ControllerInterface
 {
 public:

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -16,6 +16,7 @@
 #define FORWARD_COMMAND_CONTROLLER__FORWARD_COMMAND_CONTROLLER_HPP_
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "controller_interface/controller_interface.hpp"
@@ -57,6 +58,8 @@ protected:
   std::vector<hardware_interface::JointHandle> joint_cmd_handles_;
   realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>> rt_command_ptr_;
   rclcpp::Subscription<CmdType>::SharedPtr joints_command_subscriber_;
+
+  std::string logger_name_;
 };
 
 }  // namespace forward_command_controller

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -15,23 +15,27 @@
 #ifndef FORWARD_COMMAND_CONTROLLER__FORWARD_COMMAND_CONTROLLER_HPP_
 #define FORWARD_COMMAND_CONTROLLER__FORWARD_COMMAND_CONTROLLER_HPP_
 
+#include <memory>
+#include <vector>
+
 #include "controller_interface/controller_interface.hpp"
 #include "forward_command_controller/visibility_control.h"
+#include "hardware_interface/joint_handle.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
+#include "rclcpp/subscription.hpp"
+#include "realtime_tools/realtime_buffer.h"
+#include "std_msgs/msg/float64_multi_array.hpp"
 
 namespace forward_command_controller
 {
-
 class ForwardCommandController : public controller_interface::ControllerInterface
 {
+  using CmdType = std_msgs::msg::Float64MultiArray;
+
 public:
   FORWARD_COMMAND_CONTROLLER_PUBLIC
   ForwardCommandController();
-
-  FORWARD_COMMAND_CONTROLLER_PUBLIC
-  controller_interface::return_type
-  update() override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
@@ -45,7 +49,14 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
 
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  controller_interface::return_type
+  update() override;
+
 protected:
+  std::vector<hardware_interface::JointHandle> joint_handles_;
+  realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>> rt_command_ptr_;
+  rclcpp::Subscription<CmdType>::SharedPtr joints_command_subscriber_;
 };
 
 }  // namespace forward_command_controller

--- a/forward_command_controller/include/forward_command_controller/visibility_control.h
+++ b/forward_command_controller/include/forward_command_controller/visibility_control.h
@@ -1,0 +1,56 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This header must be included by all rclcpp headers which declare symbols
+ * which are defined in the rclcpp library. When not building the rclcpp
+ * library, i.e. when using the headers in other package's code, the contents
+ * of this header change the visibility of certain symbols which the rclcpp
+ * library cannot have, but the consuming code must have inorder to link.
+ */
+
+#ifndef FORWARD_COMMAND_CONTROLLER__VISIBILITY_CONTROL_H_
+#define FORWARD_COMMAND_CONTROLLER__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define FORWARD_COMMAND_CONTROLLER_EXPORT __attribute__ ((dllexport))
+    #define FORWARD_COMMAND_CONTROLLER_IMPORT __attribute__ ((dllimport))
+  #else
+    #define FORWARD_COMMAND_CONTROLLER_EXPORT __declspec(dllexport)
+    #define FORWARD_COMMAND_CONTROLLER_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef FORWARD_COMMAND_CONTROLLER_BUILDING_DLL
+    #define FORWARD_COMMAND_CONTROLLER_PUBLIC FORWARD_COMMAND_CONTROLLER_EXPORT
+  #else
+    #define FORWARD_COMMAND_CONTROLLER_PUBLIC FORWARD_COMMAND_CONTROLLER_IMPORT
+  #endif
+  #define FORWARD_COMMAND_CONTROLLER_PUBLIC_TYPE FORWARD_COMMAND_CONTROLLER_PUBLIC
+  #define FORWARD_COMMAND_CONTROLLER_LOCAL
+#else
+  #define FORWARD_COMMAND_CONTROLLER_EXPORT __attribute__ ((visibility("default")))
+  #define FORWARD_COMMAND_CONTROLLER_IMPORT
+  #if __GNUC__ >= 4
+    #define FORWARD_COMMAND_CONTROLLER_PUBLIC __attribute__ ((visibility("default")))
+    #define FORWARD_COMMAND_CONTROLLER_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define FORWARD_COMMAND_CONTROLLER_PUBLIC
+    #define FORWARD_COMMAND_CONTROLLER_LOCAL
+  #endif
+  #define FORWARD_COMMAND_CONTROLLER_PUBLIC_TYPE
+#endif
+
+#endif  // FORWARD_COMMAND_CONTROLLER__VISIBILITY_CONTROL_H_

--- a/forward_command_controller/package.xml
+++ b/forward_command_controller/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>forward_command_controller</name>
+  <version>0.0.0</version>
+  <description>Generic controller for forwarding commands.</description>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="jordan.palacios@pal-robotics.com">Jordan Palacios</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>controller_interface</depend>
+  <depend>hardware_interface</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>realtime_tools</depend>
+
+  <build_depend>pluginlib</build_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/forward_command_controller/package.xml
+++ b/forward_command_controller/package.xml
@@ -22,6 +22,8 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>controller_manager</test_depend>
+  <test_depend>test_robot_hardware</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/forward_command_controller/package.xml
+++ b/forward_command_controller/package.xml
@@ -15,6 +15,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>realtime_tools</depend>
+  <depend>std_msgs</depend>
 
   <build_depend>pluginlib</build_depend>
 

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -137,9 +137,10 @@ controller_interface::return_type ForwardCommandController::update()
 
   const auto joint_num = (*joint_commands)->data.size();
   if (joint_num != joint_cmd_handles_.size()) {
-    RCLCPP_ERROR_STREAM(
+    RCLCPP_ERROR_STREAM_THROTTLE(
       rclcpp::get_logger(
-        logger_name_), "command size does not match number of joints");
+        logger_name_),
+      *lifecycle_node_->get_clock(), 1000, "command size does not match number of joints");
     return controller_interface::return_type::ERROR;
   }
 

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -12,35 +12,94 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <utility>
+
 #include "forward_command_controller/forward_command_controller.hpp"
 
 namespace forward_command_controller
 {
+using CallbackReturn = ForwardCommandController::CallbackReturn;
 
 ForwardCommandController::ForwardCommandController()
-: controller_interface::ControllerInterface()
+: controller_interface::ControllerInterface(),
+  joint_handles_(),
+  rt_command_ptr_(nullptr),
+  joints_command_subscriber_(nullptr)
 {}
 
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-ForwardCommandController::on_configure(const rclcpp_lifecycle::State & /*previous_state*/)
+CallbackReturn ForwardCommandController::on_configure(
+  const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  /// @todo add logging messages with reported error cause
+
+  rclcpp::Parameter joints_param, interface_param;
+  if (!lifecycle_node_->get_parameter("joints", joints_param) ||
+    !lifecycle_node_->get_parameter("interface_name", interface_param))
+  {
+    return CallbackReturn::ERROR;
+  }
+
+  auto joint_names = joints_param.as_string_array();
+  if (joint_names.empty()) {
+    return CallbackReturn::ERROR;
+  }
+
+  auto interface_name = interface_param.as_string();
+  if (interface_name.empty()) {
+    return CallbackReturn::ERROR;
+  }
+
+  if (auto rh_ptr = robot_hardware_.lock()) {
+    const auto registered_joints = rh_ptr->get_registered_joint_names();
+
+    // check all requested joints are present
+    for (const auto & joint_name : joint_names) {
+      if (std::find(
+          registered_joints.cbegin(), registered_joints.cend(),
+          joint_name) == registered_joints.cend())
+      {
+        return CallbackReturn::ERROR;
+      }
+    }
+
+    // get joint handles
+    for (const auto & joint_name : joint_names) {
+      hardware_interface::JointHandle joint_handle(joint_name, interface_name);
+      if (rh_ptr->get_joint_handle(joint_handle) ==
+        hardware_interface::hardware_interface_ret_t::ERROR)
+      {
+        return CallbackReturn::ERROR;
+      }
+      joint_handles_.push_back(std::move(joint_handle));
+    }
+  } else {
+    return CallbackReturn::ERROR;
+  }
+
+  joints_command_subscriber_ = lifecycle_node_->create_subscription<CmdType>(
+    "commands", rclcpp::SystemDefaultsQoS(),
+    [this](const CmdType::SharedPtr msg)
+    {
+      rt_command_ptr_.writeFromNonRT(msg);
+    });
+
+  return CallbackReturn::SUCCESS;
 }
 
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-ForwardCommandController::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+CallbackReturn ForwardCommandController::on_activate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  return CallbackReturn::SUCCESS;
 }
 
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-ForwardCommandController::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+CallbackReturn ForwardCommandController::on_deactivate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  return CallbackReturn::SUCCESS;
 }
 
-controller_interface::return_type
-ForwardCommandController::update()
+controller_interface::return_type ForwardCommandController::update()
 {
   return controller_interface::return_type::ERROR;
 }

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -102,7 +102,24 @@ CallbackReturn ForwardCommandController::on_deactivate(
 
 controller_interface::return_type ForwardCommandController::update()
 {
-  return controller_interface::return_type::ERROR;
+  /// @todo add logging messages with reported error cause
+
+  auto joint_commands = rt_command_ptr_.readFromRT();
+
+  if (!joint_commands) {
+    return controller_interface::return_type::ERROR;
+  }
+
+  const auto joint_num = (*joint_commands)->data.size();
+  if (joint_num != joint_handles_.size()) {
+    return controller_interface::return_type::ERROR;
+  }
+
+  for (auto index = 0ul; index < joint_num; ++index) {
+    joint_handles_[index].set_value((*joint_commands)->data[index]);
+  }
+
+  return controller_interface::return_type::SUCCESS;
 }
 
 }  // namespace forward_command_controller

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <string>
 #include <utility>
 
 #include "forward_command_controller/forward_command_controller.hpp"
@@ -32,7 +33,8 @@ ForwardCommandController::ForwardCommandController()
 : controller_interface::ControllerInterface(),
   joint_cmd_handles_(),
   rt_command_ptr_(nullptr),
-  joints_command_subscriber_(nullptr)
+  joints_command_subscriber_(nullptr),
+  logger_name_(kFCCLoggerName)
 {}
 
 CallbackReturn ForwardCommandController::on_configure(
@@ -40,23 +42,23 @@ CallbackReturn ForwardCommandController::on_configure(
 {
   rclcpp::Parameter joints_param, interface_param;
   if (!lifecycle_node_->get_parameter("joints", joints_param)) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger(kFCCLoggerName), "'joints' parameter not set");
+    RCLCPP_ERROR_STREAM(rclcpp::get_logger(logger_name_), "'joints' parameter not set");
     return CallbackReturn::ERROR;
   }
   if (!lifecycle_node_->get_parameter("interface_name", interface_param)) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger(kFCCLoggerName), "'interface_name' parameter not set");
+    RCLCPP_ERROR_STREAM(rclcpp::get_logger(logger_name_), "'interface_name' parameter not set");
     return CallbackReturn::ERROR;
   }
 
   auto joint_names = joints_param.as_string_array();
   if (joint_names.empty()) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger(kFCCLoggerName), "'joints' is empty");
+    RCLCPP_ERROR_STREAM(rclcpp::get_logger(logger_name_), "'joints' is empty");
     return CallbackReturn::ERROR;
   }
 
   auto interface_name = interface_param.as_string();
   if (interface_name.empty()) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger(kFCCLoggerName), "'interface_name' is empty");
+    RCLCPP_ERROR_STREAM(rclcpp::get_logger(logger_name_), "'interface_name' is empty");
     return CallbackReturn::ERROR;
   }
 
@@ -71,7 +73,7 @@ CallbackReturn ForwardCommandController::on_configure(
       {
         RCLCPP_ERROR_STREAM(
           rclcpp::get_logger(
-            kFCCLoggerName), "joint '" << joint_name << "' not registered");
+            logger_name_), "joint '" << joint_name << "' not registered");
         return CallbackReturn::ERROR;
       }
     }
@@ -87,7 +89,7 @@ CallbackReturn ForwardCommandController::on_configure(
 
         RCLCPP_ERROR_STREAM(
           rclcpp::get_logger(
-            kFCCLoggerName), "could not get handle for joint '" << joint_name << "'");
+            logger_name_), "could not get handle for joint '" << joint_name << "'");
         return CallbackReturn::ERROR;
       }
       joint_cmd_handles_.emplace_back(std::move(joint_handle));
@@ -95,7 +97,7 @@ CallbackReturn ForwardCommandController::on_configure(
   } else {
     RCLCPP_ERROR_STREAM(
       rclcpp::get_logger(
-        kFCCLoggerName), "could not lock pointer to robot_hardware");
+        logger_name_), "could not lock pointer to robot_hardware");
     return CallbackReturn::ERROR;
   }
 
@@ -108,7 +110,7 @@ CallbackReturn ForwardCommandController::on_configure(
 
   RCLCPP_INFO_STREAM(
     rclcpp::get_logger(
-      kFCCLoggerName), "configure successful");
+      logger_name_), "configure successful");
   return CallbackReturn::SUCCESS;
 }
 
@@ -137,7 +139,7 @@ controller_interface::return_type ForwardCommandController::update()
   if (joint_num != joint_cmd_handles_.size()) {
     RCLCPP_ERROR_STREAM(
       rclcpp::get_logger(
-        kFCCLoggerName), "command size does not match number of joints");
+        logger_name_), "command size does not match number of joints");
     return controller_interface::return_type::ERROR;
   }
 

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -1,0 +1,53 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "forward_command_controller/forward_command_controller.hpp"
+
+namespace forward_command_controller
+{
+
+ForwardCommandController::ForwardCommandController()
+: controller_interface::ControllerInterface()
+{}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+ForwardCommandController::on_configure(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+ForwardCommandController::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+ForwardCommandController::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::return_type
+ForwardCommandController::update()
+{
+  return controller_interface::return_type::ERROR;
+}
+
+}  // namespace forward_command_controller
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(
+  forward_command_controller::ForwardCommandController, controller_interface::ControllerInterface)

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include "forward_command_controller/forward_command_controller.hpp"
+#include "rclcpp/qos.hpp"
 
 namespace forward_command_controller
 {

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -30,7 +30,7 @@ using CallbackReturn = ForwardCommandController::CallbackReturn;
 
 ForwardCommandController::ForwardCommandController()
 : controller_interface::ControllerInterface(),
-  joint_handles_(),
+  joint_cmd_handles_(),
   rt_command_ptr_(nullptr),
   joints_command_subscriber_(nullptr)
 {}
@@ -83,14 +83,14 @@ CallbackReturn ForwardCommandController::on_configure(
         hardware_interface::hardware_interface_ret_t::ERROR)
       {
         // uppon error, clear any previously requested handles
-        joint_handles_.clear();
+        joint_cmd_handles_.clear();
 
         RCLCPP_ERROR_STREAM(
           rclcpp::get_logger(
             kFCCLoggerName), "could not get handle for joint '" << joint_name << "'");
         return CallbackReturn::ERROR;
       }
-      joint_handles_.push_back(std::move(joint_handle));
+      joint_cmd_handles_.emplace_back(std::move(joint_handle));
     }
   } else {
     RCLCPP_ERROR_STREAM(
@@ -134,7 +134,7 @@ controller_interface::return_type ForwardCommandController::update()
   }
 
   const auto joint_num = (*joint_commands)->data.size();
-  if (joint_num != joint_handles_.size()) {
+  if (joint_num != joint_cmd_handles_.size()) {
     RCLCPP_ERROR_STREAM(
       rclcpp::get_logger(
         kFCCLoggerName), "command size does not match number of joints");
@@ -142,7 +142,7 @@ controller_interface::return_type ForwardCommandController::update()
   }
 
   for (auto index = 0ul; index < joint_num; ++index) {
-    joint_handles_[index].set_value((*joint_commands)->data[index]);
+    joint_cmd_handles_[index].set_value((*joint_commands)->data[index]);
   }
 
   return controller_interface::return_type::SUCCESS;

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -20,11 +20,6 @@
 #include "rclcpp/qos.hpp"
 #include "rclcpp/logging.hpp"
 
-namespace
-{
-constexpr auto kFCCLoggerName = "forward command controller";
-}
-
 namespace forward_command_controller
 {
 using CallbackReturn = ForwardCommandController::CallbackReturn;
@@ -34,7 +29,7 @@ ForwardCommandController::ForwardCommandController()
   joint_cmd_handles_(),
   rt_command_ptr_(nullptr),
   joints_command_subscriber_(nullptr),
-  logger_name_(kFCCLoggerName)
+  logger_name_("forward command controller")
 {}
 
 CallbackReturn ForwardCommandController::on_configure(

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -224,3 +224,24 @@ TEST_F(ForwardCommandControllerTest, WrongCommandCheckTest)
   ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 2.1);
   ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 3.1);
 }
+
+TEST_F(ForwardCommandControllerTest, NoCommandCheckTest)
+{
+  SetUpController();
+  SetUpHandles();
+
+  // configure controller
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position_command");
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // update successful, no command received yet
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+
+  // check joint commands are still the default ones
+  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 1.1);
+  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 2.1);
+  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 3.1);
+}

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -1,0 +1,226 @@
+// Copyright 2020 PAL Robotics SL.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "forward_command_controller/forward_command_controller.hpp"
+#include "hardware_interface/joint_handle.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "rclcpp/utilities.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+#include "test_forward_command_controller.hpp"
+#include "test_robot_hardware/test_robot_hardware.hpp"
+
+using CallbackReturn = forward_command_controller::ForwardCommandController::CallbackReturn;
+
+void ForwardCommandControllerTest::SetUpTestCase()
+{
+  rclcpp::init(0, nullptr);
+}
+
+void ForwardCommandControllerTest::TearDownTestCase()
+{
+  rclcpp::shutdown();
+}
+
+void ForwardCommandControllerTest::SetUp()
+{
+  // initialize robot
+  test_robot_ = std::make_shared<test_robot_hardware::TestRobotHardware>();
+  test_robot_->init();
+
+  // initialize controller
+  controller_ = std::make_unique<FriendForwardCommandController>();
+}
+
+void ForwardCommandControllerTest::TearDown()
+{
+  controller_.reset(nullptr);
+}
+
+void ForwardCommandControllerTest::SetUpController()
+{
+  const auto result = controller_->init(test_robot_, "forward_command_controller");
+  ASSERT_EQ(result, controller_interface::return_type::SUCCESS);
+}
+
+void ForwardCommandControllerTest::SetUpHandles()
+{
+  // get handles from test_robot_hardware
+  joint1_pos_cmd_handle_ = std::make_shared<hardware_interface::JointHandle>(
+    "joint1",
+    "position_command");
+  joint2_pos_cmd_handle_ = std::make_shared<hardware_interface::JointHandle>(
+    "joint2",
+    "position_command");
+  joint3_pos_cmd_handle_ = std::make_shared<hardware_interface::JointHandle>(
+    "joint3",
+    "position_command");
+
+  ASSERT_EQ(
+    test_robot_->get_joint_handle(
+      *joint1_pos_cmd_handle_), hardware_interface::hardware_interface_ret_t::OK);
+  ASSERT_EQ(
+    test_robot_->get_joint_handle(
+      *joint2_pos_cmd_handle_), hardware_interface::hardware_interface_ret_t::OK);
+  ASSERT_EQ(
+    test_robot_->get_joint_handle(
+      *joint3_pos_cmd_handle_), hardware_interface::hardware_interface_ret_t::OK);
+}
+
+TEST_F(ForwardCommandControllerTest, ConfigureParamsTest)
+{
+  // joint handles not initialized yet
+  ASSERT_TRUE(controller_->joint_handles_.empty());
+
+  SetUpController();
+
+  // configure failed, 'joints' paremeter not set
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>()));
+
+  // configure failed, 'interface_name' paremeter not set
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  controller_->lifecycle_node_->declare_parameter("interface_name", "");
+
+  // configure failed, 'joints' is empty
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  auto result = controller_->lifecycle_node_->set_parameter(
+    rclcpp::Parameter(
+      "joints",
+      rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2"})));
+  ASSERT_TRUE(result.successful);
+
+  // configure failed, 'interface_name' is empty
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  result = controller_->lifecycle_node_->set_parameter(
+    rclcpp::Parameter(
+      "interface_name",
+      rclcpp::ParameterValue("position_command")));
+  ASSERT_TRUE(result.successful);
+
+  // configure successful
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // joint handles initialized
+  ASSERT_EQ(controller_->joint_handles_.size(), 2ul);
+}
+
+TEST_F(ForwardCommandControllerTest, ConfigureJointsChecksTest)
+{
+  // joint handles not initialized yet
+  ASSERT_TRUE(controller_->joint_handles_.empty());
+
+  SetUpController();
+
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint4"}));
+
+  controller_->lifecycle_node_->declare_parameter("interface_name", "acceleration_command");
+
+  // configure failed, 'joint4' not in robot_hardware
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  auto result = controller_->lifecycle_node_->set_parameter(
+    rclcpp::Parameter(
+      "joints",
+      rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2"})));
+  ASSERT_TRUE(result.successful);
+
+  // configure failed, 'joint1' does not support 'acceleration_command' interface
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  result = controller_->lifecycle_node_->set_parameter(
+    rclcpp::Parameter(
+      "interface_name",
+      rclcpp::ParameterValue("position_command")));
+  ASSERT_TRUE(result.successful);
+
+  // configure successful
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // joint handles initialized
+  ASSERT_EQ(controller_->joint_handles_.size(), 2ul);
+}
+
+TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
+{
+  SetUpController();
+  SetUpHandles();
+
+  // configure controller
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position_command");
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // update successful though no command has been send yet
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+
+  // check joint commands are still the default ones
+  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 1.1);
+  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 2.1);
+  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 3.1);
+
+  // send command
+  FriendForwardCommandController::CmdType::SharedPtr command_ptr =
+    std::make_shared<FriendForwardCommandController::CmdType>();
+  command_ptr->data = {10.0, 20.0, 30.0};
+  controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
+
+  // update successful, command received
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+
+  // check joint commands have been modified
+  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 10.0);
+  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 20.0);
+  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 30.0);
+}
+
+TEST_F(ForwardCommandControllerTest, WrongCommandCheckTest)
+{
+  SetUpController();
+  SetUpHandles();
+
+  // configure controller
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position_command");
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // send command with wrong numnber of joints
+  FriendForwardCommandController::CmdType::SharedPtr command_ptr =
+    std::make_shared<FriendForwardCommandController::CmdType>();
+  command_ptr->data = {10.0, 20.0};
+  controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
+
+  // update failed, command size does not match number of joints
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::ERROR);
+
+  // check joint commands are still the default ones
+  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 1.1);
+  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 2.1);
+  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 3.1);
+}

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -90,7 +90,7 @@ void ForwardCommandControllerTest::SetUpHandles()
 TEST_F(ForwardCommandControllerTest, ConfigureParamsTest)
 {
   // joint handles not initialized yet
-  ASSERT_TRUE(controller_->joint_handles_.empty());
+  ASSERT_TRUE(controller_->joint_cmd_handles_.empty());
 
   SetUpController();
 
@@ -124,13 +124,13 @@ TEST_F(ForwardCommandControllerTest, ConfigureParamsTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // joint handles initialized
-  ASSERT_EQ(controller_->joint_handles_.size(), 2ul);
+  ASSERT_EQ(controller_->joint_cmd_handles_.size(), 2ul);
 }
 
 TEST_F(ForwardCommandControllerTest, ConfigureJointsChecksTest)
 {
   // joint handles not initialized yet
-  ASSERT_TRUE(controller_->joint_handles_.empty());
+  ASSERT_TRUE(controller_->joint_cmd_handles_.empty());
 
   SetUpController();
 
@@ -160,7 +160,7 @@ TEST_F(ForwardCommandControllerTest, ConfigureJointsChecksTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // joint handles initialized
-  ASSERT_EQ(controller_->joint_handles_.size(), 2ul);
+  ASSERT_EQ(controller_->joint_cmd_handles_.size(), 2ul);
 }
 
 TEST_F(ForwardCommandControllerTest, CommandSuccessTest)

--- a/forward_command_controller/test/test_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_forward_command_controller.hpp
@@ -32,6 +32,7 @@ class FriendForwardCommandController : public forward_command_controller::Forwar
   FRIEND_TEST(ForwardCommandControllerTest, CommandSuccessTest);
   FRIEND_TEST(ForwardCommandControllerTest, WrongCommandCheckTest);
   FRIEND_TEST(ForwardCommandControllerTest, NoCommandCheckTest);
+  FRIEND_TEST(ForwardCommandControllerTest, CommandCallbackTest);
 };
 
 class ForwardCommandControllerTest : public ::testing::Test

--- a/forward_command_controller/test/test_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_forward_command_controller.hpp
@@ -1,0 +1,57 @@
+// Copyright 2020 PAL Robotics SL.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_FORWARD_COMMAND_CONTROLLER_HPP_
+#define TEST_FORWARD_COMMAND_CONTROLLER_HPP_
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "forward_command_controller/forward_command_controller.hpp"
+#include "hardware_interface/joint_handle.hpp"
+#include "test_robot_hardware/test_robot_hardware.hpp"
+
+// subclassing and friending so we can access member varibles
+class FriendForwardCommandController : public forward_command_controller::ForwardCommandController
+{
+  FRIEND_TEST(ForwardCommandControllerTest, ConfigureParamsTest);
+  FRIEND_TEST(ForwardCommandControllerTest, ConfigureJointsChecksTest);
+  FRIEND_TEST(ForwardCommandControllerTest, CommandSuccessTest);
+  FRIEND_TEST(ForwardCommandControllerTest, WrongCommandCheckTest);
+};
+
+class ForwardCommandControllerTest : public ::testing::Test
+{
+public:
+  static void SetUpTestCase();
+  static void TearDownTestCase();
+
+  void SetUp();
+  void TearDown();
+
+  void SetUpController();
+  void SetUpHandles();
+
+protected:
+  std::shared_ptr<test_robot_hardware::TestRobotHardware> test_robot_;
+  std::unique_ptr<FriendForwardCommandController> controller_;
+
+  std::shared_ptr<hardware_interface::JointHandle> joint1_pos_cmd_handle_;
+  std::shared_ptr<hardware_interface::JointHandle> joint2_pos_cmd_handle_;
+  std::shared_ptr<hardware_interface::JointHandle> joint3_pos_cmd_handle_;
+};
+
+#endif  // TEST_FORWARD_COMMAND_CONTROLLER_HPP_

--- a/forward_command_controller/test/test_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_forward_command_controller.hpp
@@ -31,6 +31,7 @@ class FriendForwardCommandController : public forward_command_controller::Forwar
   FRIEND_TEST(ForwardCommandControllerTest, ConfigureJointsChecksTest);
   FRIEND_TEST(ForwardCommandControllerTest, CommandSuccessTest);
   FRIEND_TEST(ForwardCommandControllerTest, WrongCommandCheckTest);
+  FRIEND_TEST(ForwardCommandControllerTest, NoCommandCheckTest);
 };
 
 class ForwardCommandControllerTest : public ::testing::Test

--- a/forward_command_controller/test/test_load_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_load_forward_command_controller.cpp
@@ -1,0 +1,42 @@
+// Copyright 2020 PAL Robotics SL.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "controller_manager/controller_manager.hpp"
+#include "rclcpp/executor.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
+#include "test_robot_hardware/test_robot_hardware.hpp"
+
+TEST(TestLoadForwardCommandController, load_controller)
+{
+  rclcpp::init(0, nullptr);
+
+  std::shared_ptr<test_robot_hardware::TestRobotHardware> robot =
+    std::make_shared<test_robot_hardware::TestRobotHardware>();
+
+  robot->init();
+
+  std::shared_ptr<rclcpp::Executor> executor =
+    std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+  controller_manager::ControllerManager cm(robot, executor, "test_controller_manager");
+
+  ASSERT_NO_THROW(
+    cm.load_controller(
+      "test_forward_command_controller",
+      "forward_command_controller/ForwardCommandController"));
+}


### PR DESCRIPTION
Port of forward_command_controller from ROS1.

Depends https://github.com/ros-controls/ros2_controllers/pull/90.

Closes #78.