### PR TITLE
Use new joint handles in all controllers

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
@@ -32,9 +32,7 @@
 #include "diff_drive_controller/visibility_control.h"
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "hardware_interface/joint_command_handle.hpp"
 #include "hardware_interface/operation_mode_handle.hpp"
-#include "hardware_interface/robot_hardware.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -43,6 +41,12 @@
 #include "realtime_tools/realtime_publisher.h"
 #include "sensor_msgs/msg/joint_state.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
+
+namespace hardware_interface
+{
+class JointHandle;
+class RobotHardware;
+}  // namespace hardware_interface
 
 namespace diff_drive_controller
 {
@@ -96,8 +100,8 @@ public:
 protected:
   struct WheelHandle
   {
-    const hardware_interface::JointStateHandle * state = nullptr;
-    hardware_interface::JointCommandHandle * command = nullptr;
+    std::shared_ptr<const hardware_interface::JointHandle> state = nullptr;
+    std::shared_ptr<hardware_interface::JointHandle> command = nullptr;
   };
 
   CallbackReturn configure_side(

--- a/joint_state_controller/include/joint_state_controller/joint_state_controller.hpp
+++ b/joint_state_controller/include/joint_state_controller/joint_state_controller.hpp
@@ -16,6 +16,7 @@
 #define JOINT_STATE_CONTROLLER__JOINT_STATE_CONTROLLER_HPP_
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "control_msgs/msg/dynamic_joint_state.hpp"
@@ -27,8 +28,9 @@
 
 namespace hardware_interface
 {
-class JointStateHandle;
+class JointHandle;
 }  // namespace hardware_interface
+
 namespace rclcpp_lifecycle
 {
 class State;
@@ -60,7 +62,12 @@ public:
   on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
 
 protected:
-  std::vector<const hardware_interface::JointStateHandle *> registered_joint_handles_;
+  bool init_joint_data();
+  void init_joint_state_msg();
+  void init_dynamic_joint_state_msg();
+
+protected:
+  std::vector<std::string> joint_names_;
 
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::JointState>>
   joint_state_publisher_;
@@ -69,6 +76,8 @@ protected:
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<control_msgs::msg::DynamicJointState>>
   dynamic_joint_state_publisher_;
   control_msgs::msg::DynamicJointState dynamic_joint_state_msg_;
+
+  std::vector<std::vector<std::shared_ptr<hardware_interface::JointHandle>>> joint_handles_;
 };
 
 }  // namespace joint_state_controller

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -18,9 +18,9 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <vector>
 
-
-#include "hardware_interface/joint_state_handle.hpp"
+#include "hardware_interface/joint_handle.hpp"
 #include "hardware_interface/robot_hardware.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "rclcpp/clock.hpp"
@@ -38,6 +38,9 @@ class State;
 
 namespace joint_state_controller
 {
+static const auto kPositionIndex = 0ul;
+static const auto kVelocityIndex = 1ul;
+static const auto kEffortIndex = 2ul;
 
 JointStateController::JointStateController()
 : controller_interface::ControllerInterface()
@@ -46,38 +49,12 @@ JointStateController::JointStateController()
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 JointStateController::on_configure(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  if (auto sptr = robot_hardware_.lock()) {
-    registered_joint_handles_ = sptr->get_registered_joint_state_handles();
-  } else {
+  if (!init_joint_data()) {
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
   }
 
-  if (registered_joint_handles_.empty()) {
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-  }
-
-  const size_t num_joints = registered_joint_handles_.size();
-
-  // default initialization for joint state message
-  joint_state_msg_.position.resize(num_joints);
-  joint_state_msg_.velocity.resize(num_joints);
-  joint_state_msg_.effort.resize(num_joints);
-
-  // default initialization for dynamic joint state message
-  control_msgs::msg::InterfaceValue default_if_value;
-  default_if_value.interface_names = {"position", "velocity", "effort"};
-  default_if_value.values.resize(
-    default_if_value.interface_names.size(), std::numeric_limits<double>::quiet_NaN());
-
-  // set known joint names
-  joint_state_msg_.name.reserve(num_joints);
-  dynamic_joint_state_msg_.joint_names.reserve(num_joints);
-  for (const auto joint_handle : registered_joint_handles_) {
-    joint_state_msg_.name.push_back(joint_handle->get_name());
-
-    dynamic_joint_state_msg_.joint_names.push_back(joint_handle->get_name());
-    dynamic_joint_state_msg_.interface_values.push_back(default_if_value);
-  }
+  init_joint_state_msg();
+  init_dynamic_joint_state_msg();
 
   joint_state_publisher_ = lifecycle_node_->create_publisher<sensor_msgs::msg::JointState>(
     "joint_states", rclcpp::SystemDefaultsQoS());
@@ -107,6 +84,90 @@ JointStateController::on_deactivate(const rclcpp_lifecycle::State & /*previous_s
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
+bool JointStateController::init_joint_data()
+{
+  if (auto rh_ptr = robot_hardware_.lock()) {
+    joint_names_ = rh_ptr->get_registered_joint_names();
+
+    if (joint_names_.empty()) {
+      return false;
+    }
+
+    // reset any previous joint data
+    joint_handles_.clear();
+
+    for (const auto & joint_name : joint_names_) {
+      // always check for these interfaces, even if they are not supported by the joint
+      std::vector<std::string> interface_names = {"position", "velocity", "effort"};
+      const std::vector<std::string> joint_interface_names =
+        rh_ptr->get_registered_joint_interface_names(joint_name);
+
+      // add the rest of the interfaces
+      // ideally this could be done with std::sort + std::unique, but we rather have
+      // position, velocity and effort in known indexes
+      std::copy_if(
+        joint_interface_names.begin(), joint_interface_names.end(),
+        std::back_inserter(interface_names), [&](const auto & value) {
+          return std::find(
+            interface_names.begin(),
+            interface_names.end(), value) == interface_names.end();
+        });
+
+      std::vector<std::shared_ptr<hardware_interface::JointHandle>> joint_interface_handles;
+      for (const auto & interface_name : interface_names) {
+        /// @todo is there a better way of skipping command interfaces?
+        if (interface_name.find("command") != std::string::npos) {
+          continue;
+        }
+
+        auto joint_handle = std::make_shared<hardware_interface::JointHandle>(
+          joint_name,
+          interface_name);
+        if (rh_ptr->get_joint_handle(*joint_handle) == hardware_interface::return_type::OK) {
+          joint_interface_handles.emplace_back(joint_handle);
+        } else {
+          // leave a nullptr for not supported interfaces
+          joint_interface_handles.emplace_back(nullptr);
+        }
+      }
+      joint_handles_.emplace_back(joint_interface_handles);
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void JointStateController::init_joint_state_msg()
+{
+  const size_t num_joints = joint_handles_.size();
+
+  /// @note joint_state_msg publishes position, velocity and effort for all joints,
+  /// regardless of the joints actually supporting these interfaces
+
+  // default initialization for joint state message
+  joint_state_msg_.name = joint_names_;
+  joint_state_msg_.position.resize(num_joints, std::numeric_limits<double>::quiet_NaN());
+  joint_state_msg_.velocity.resize(num_joints, std::numeric_limits<double>::quiet_NaN());
+  joint_state_msg_.effort.resize(num_joints, std::numeric_limits<double>::quiet_NaN());
+}
+
+void JointStateController::init_dynamic_joint_state_msg()
+{
+  dynamic_joint_state_msg_.joint_names = joint_names_;
+  for (const auto & joint_handle : joint_handles_) {
+    control_msgs::msg::InterfaceValue if_value;
+    for (const auto & joint_interface_handle : joint_handle) {
+      // check joint handle is valid
+      if (joint_interface_handle) {
+        if_value.interface_names.emplace_back(joint_interface_handle->get_interface_name());
+        if_value.values.emplace_back(std::numeric_limits<double>::quiet_NaN());
+      }
+    }
+    dynamic_joint_state_msg_.interface_values.emplace_back(if_value);
+  }
+}
+
 controller_interface::return_type
 JointStateController::update()
 {
@@ -121,17 +182,36 @@ JointStateController::update()
   }
 
   joint_state_msg_.header.stamp = lifecycle_node_->get_clock()->now();
-  size_t i = 0;
-  for (auto joint_state_handle : registered_joint_handles_) {
-    joint_state_msg_.position[i] = joint_state_handle->get_position();
-    joint_state_msg_.velocity[i] = joint_state_handle->get_velocity();
-    joint_state_msg_.effort[i] = joint_state_handle->get_effort();
 
-    dynamic_joint_state_msg_.interface_values[i].values[0] = joint_state_handle->get_position();
-    dynamic_joint_state_msg_.interface_values[i].values[1] = joint_state_handle->get_velocity();
-    dynamic_joint_state_msg_.interface_values[i].values[2] = joint_state_handle->get_effort();
+  // update joint state message and dynamic joint state message
+  for (auto joint_index = 0ul; joint_index < joint_names_.size(); ++joint_index) {
+    auto update_value =
+      [](double & msg_data, const std::shared_ptr<hardware_interface::JointHandle> & joint_handle)
+      {
+        if (joint_handle) {
+          msg_data = joint_handle->get_value();
+        }
+      };
 
-    ++i;
+    // the interface indexes used here are hardcoded, check init_joint_data()
+    update_value(
+      joint_state_msg_.position[joint_index],
+      joint_handles_[joint_index][kPositionIndex]);
+    update_value(
+      joint_state_msg_.velocity[joint_index],
+      joint_handles_[joint_index][kVelocityIndex]);
+    update_value(
+      joint_state_msg_.effort[joint_index],
+      joint_handles_[joint_index][kEffortIndex]);
+
+    auto interface_index = 0ul;
+    for (const auto & joint_interface_handle : joint_handles_[joint_index]) {
+      if (joint_interface_handle) {
+        dynamic_joint_state_msg_.interface_values[joint_index].values[interface_index] =
+          joint_interface_handle->get_value();
+        ++interface_index;
+      }
+    }
   }
 
   // publish

--- a/joint_state_controller/test/test_joint_state_controller.cpp
+++ b/joint_state_controller/test/test_joint_state_controller.cpp
@@ -216,8 +216,8 @@ TEST_F(JointStateControllerTest, JointStatePublishTest)
   const size_t NUM_JOINTS = 3;
   ASSERT_EQ(joint_state_msg.position.size(), NUM_JOINTS);
   ASSERT_EQ(joint_state_msg.position[0], 1.1);
-  ASSERT_EQ(joint_state_msg.position[1], 2.2);
-  ASSERT_EQ(joint_state_msg.position[2], 3.3);
+  ASSERT_EQ(joint_state_msg.position[1], 2.1);
+  ASSERT_EQ(joint_state_msg.position[2], 3.1);
 }
 
 TEST_F(JointStateControllerTest, DynamicJointStatePublishTest)
@@ -255,6 +255,6 @@ TEST_F(JointStateControllerTest, DynamicJointStatePublishTest)
   const size_t NUM_JOINTS = 3;
   ASSERT_EQ(dynamic_joint_state_msg.joint_names.size(), NUM_JOINTS);
   ASSERT_EQ(dynamic_joint_state_msg.interface_values[0].values[0], 1.1);
-  ASSERT_EQ(dynamic_joint_state_msg.interface_values[1].values[0], 2.2);
-  ASSERT_EQ(dynamic_joint_state_msg.interface_values[2].values[0], 3.3);
+  ASSERT_EQ(dynamic_joint_state_msg.interface_values[1].values[0], 2.1);
+  ASSERT_EQ(dynamic_joint_state_msg.interface_values[2].values[0], 3.1);
 }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -24,6 +24,7 @@
 #include "control_msgs/msg/joint_trajectory_controller_state.hpp"
 #include "control_msgs/action/follow_joint_trajectory.hpp"
 #include "controller_interface/controller_interface.hpp"
+#include "hardware_interface/joint_handle.hpp"
 #include "hardware_interface/operation_mode_handle.hpp"
 #include "joint_trajectory_controller/tolerances.hpp"
 #include "joint_trajectory_controller/visibility_control.h"
@@ -44,8 +45,6 @@
 
 namespace hardware_interface
 {
-class JointCommandHandle;
-class JointStateHandle;
 class RobotHardware;
 }  // namespace hardware_interface
 namespace rclcpp_action
@@ -111,8 +110,9 @@ protected:
   std::vector<std::string> joint_names_;
   std::vector<std::string> write_op_names_;
 
-  std::vector<hardware_interface::JointCommandHandle *> registered_joint_cmd_handles_;
-  std::vector<const hardware_interface::JointStateHandle *> registered_joint_state_handles_;
+  std::vector<hardware_interface::JointHandle> joint_position_command_handles_;
+  std::vector<hardware_interface::JointHandle> joint_position_state_handles_;
+  std::vector<hardware_interface::JointHandle> joint_velocity_state_handles_;
   std::vector<hardware_interface::OperationModeHandle *> registered_operation_mode_handles_;
 
   // TODO(karsten1987): eventually activate and deactive subscriber directly when its supported


### PR DESCRIPTION
Refactor joint_state_controller, joint_trajectory_controller and diff_drive_controller to use the new joint handles.

Depends on https://github.com/ros-controls/ros2_control/pull/125 and https://github.com/ros-controls/ros2_control/pull/136.

Closes #89.