### PR TITLE
Forward Controller using Interfaces (ResourceManager)

### DIFF
--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -59,7 +59,8 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(controller_manager REQUIRED)
-  find_package(test_robot_hardware REQUIRED)
+  find_package(hardware_interface REQUIRED)
+  find_package(ros2_control_test REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 
@@ -70,20 +71,23 @@ if(BUILD_TESTING)
   target_include_directories(test_load_forward_command_controller PRIVATE include)
   ament_target_dependencies(test_load_forward_command_controller
     controller_manager
-    test_robot_hardware
+    hardware_interface
+    ros2_control_test
   )
+  # prevent pluginlib from using boost
+  target_compile_definitions(test_load_forward_command_controller PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
-  ament_add_gtest(
-    test_forward_command_controller
-    test/test_forward_command_controller.cpp
-  )
-  target_include_directories(test_forward_command_controller PRIVATE include)
-  target_link_libraries(test_forward_command_controller
-    forward_command_controller
-  )
-  ament_target_dependencies(test_forward_command_controller
-    test_robot_hardware
-  )
+#   ament_add_gtest(
+#     test_forward_command_controller
+#     test/test_forward_command_controller.cpp
+#   )
+#   target_include_directories(test_forward_command_controller PRIVATE include)
+#   target_link_libraries(test_forward_command_controller
+#     forward_command_controller
+#   )
+#   ament_target_dependencies(test_forward_command_controller
+#     test_robot_hardware
+#   )
 endif()
 
 ament_export_dependencies(

--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -56,15 +56,14 @@ install(
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(controller_manager REQUIRED)
   find_package(hardware_interface REQUIRED)
-  find_package(ros2_control_test REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gtest(
+  ament_add_gmock(
     test_load_forward_command_controller
     test/test_load_forward_command_controller.cpp
   )
@@ -72,22 +71,18 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_load_forward_command_controller
     controller_manager
     hardware_interface
-    ros2_control_test
   )
   # prevent pluginlib from using boost
   target_compile_definitions(test_load_forward_command_controller PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
-#   ament_add_gtest(
-#     test_forward_command_controller
-#     test/test_forward_command_controller.cpp
-#   )
-#   target_include_directories(test_forward_command_controller PRIVATE include)
-#   target_link_libraries(test_forward_command_controller
-#     forward_command_controller
-#   )
-#   ament_target_dependencies(test_forward_command_controller
-#     test_robot_hardware
-#   )
+  ament_add_gmock(
+    test_forward_command_controller
+    test/test_forward_command_controller.cpp
+  )
+  target_include_directories(test_forward_command_controller PRIVATE include)
+  target_link_libraries(test_forward_command_controller
+    forward_command_controller
+  )
 endif()
 
 ament_export_dependencies(

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -74,7 +74,7 @@ public:
 
 protected:
   std::vector<std::string> joint_names_;
-  std::vector<std::string> interfaces_;
+  std::string interface_name_;
 
   realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>> rt_command_ptr_;
   rclcpp::Subscription<CmdType>::SharedPtr joints_command_subscriber_;

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -30,6 +30,7 @@
 namespace forward_command_controller
 {
 using CmdType = std_msgs::msg::Float64MultiArray;
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 /**
  * \brief Forward command controller for a set of joints.
@@ -56,20 +57,16 @@ public:
   controller_interface::InterfaceConfiguration state_interface_configuration() const override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_configure(const rclcpp_lifecycle::State & previous_state) override;
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_activate(const rclcpp_lifecycle::State & previous_state) override;
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
-  controller_interface::return_type
-  update() override;
+  controller_interface::return_type update() override;
 
 protected:
   std::vector<std::string> joint_names_;

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -21,7 +21,6 @@
 
 #include "controller_interface/controller_interface.hpp"
 #include "forward_command_controller/visibility_control.h"
-#include "hardware_interface/loaned_command_interface.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp/subscription.hpp"

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -21,7 +21,7 @@
 
 #include "controller_interface/controller_interface.hpp"
 #include "forward_command_controller/visibility_control.h"
-#include "hardware_interface/joint_handle.hpp"
+#include "hardware_interface/loaned_command_interface.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp/subscription.hpp"
@@ -30,6 +30,7 @@
 
 namespace forward_command_controller
 {
+using CmdType = std_msgs::msg::Float64MultiArray;
 
 /**
  * \brief Forward command controller for a set of joints.
@@ -50,6 +51,12 @@ public:
   ForwardCommandController();
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State & previous_state) override;
 
@@ -66,9 +73,9 @@ public:
   update() override;
 
 protected:
-  using CmdType = std_msgs::msg::Float64MultiArray;
+  std::vector<std::string> joint_names_;
+  std::vector<std::string> interfaces_;
 
-  std::vector<hardware_interface::JointHandle> joint_cmd_handles_;
   realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>> rt_command_ptr_;
   rclcpp::Subscription<CmdType>::SharedPtr joints_command_subscriber_;
 

--- a/forward_command_controller/package.xml
+++ b/forward_command_controller/package.xml
@@ -19,11 +19,10 @@
 
   <build_depend>pluginlib</build_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>controller_manager</test_depend>
-  <test_depend>test_robot_hardware</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -22,9 +22,10 @@
 #include "rclcpp/qos.hpp"
 #include "rclcpp/logging.hpp"
 
+#include "hardware_interface/loaned_command_interface.hpp"
+
 namespace forward_command_controller
 {
-using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 using hardware_interface::LoanedCommandInterface;
 
 ForwardCommandController::ForwardCommandController()
@@ -111,13 +112,6 @@ bool get_ordered_interfaces(
 CallbackReturn ForwardCommandController::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  if (!state_interfaces_.empty()) {
-    RCLCPP_ERROR_STREAM(
-      get_lifecycle_node()->get_logger(),
-      "State interface was not requested by this controller but was provided some.");
-    return CallbackReturn::ERROR;
-  }
-
   //  check if we have all resources defined in the "points" parameter
   //  also verify that we *only* have the resources defined in the "points" parameter
   std::vector<std::reference_wrapper<LoanedCommandInterface>> ordered_interfaces;

--- a/forward_command_controller/test/descriptions.hpp
+++ b/forward_command_controller/test/descriptions.hpp
@@ -1,0 +1,174 @@
+// Copyright 2020 ros2_control Development Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DESCRIPTIONS_HPP_
+#define DESCRIPTIONS_HPP_
+
+#include <string>
+
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/types/hardware_interface_status_values.hpp"
+
+namespace ros2_control_test
+{
+
+const auto urdf_head =
+  R"(
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="MinimalRobot">
+  <joint name="base_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="base_link"/>
+  </joint>
+  <link name="base_link">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="0.1"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint1" type="revolute">
+    <origin rpy="-1.57079632679 0 0" xyz="0 0 0.2"/>
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
+  </joint>
+  <link name="link1">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="0.1"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint2" type="revolute">
+    <origin rpy="1.57079632679 0 0" xyz="0 0 0.9"/>
+    <parent link="link1"/>
+    <child link="link2"/>
+    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
+  </joint>
+  <link name="link2">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="0.1"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="tool_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 1"/>
+    <parent link="link2"/>
+    <child link="tool_link"/>
+  </joint>
+)";
+
+const auto urdf_tail =
+  R"(
+</robot>
+)";
+
+const auto hardware_resources =
+  R"(
+  <ros2_control name="TestActuatorHardware" type="actuator">
+    <hardware>
+      <plugin>test_actuator</plugin>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+  </ros2_control>
+  <ros2_control name="TestSensorHardware" type="sensor">
+    <hardware>
+      <plugin>test_sensor</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <sensor name="sensor1">
+      <state_interface name="velocity"/>
+    </sensor>
+  </ros2_control>
+  <ros2_control name="TestSystemHardware" type="system">
+    <hardware>
+      <plugin>test_system</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <joint name="joint2">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+    </joint>
+    <joint name="joint3">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+    </joint>
+  </ros2_control>
+)";
+
+const auto hardware_resources_missing_keys =
+  R"(
+  <ros2_control name="TestActuatorHardware" type="actuator">
+    <hardware>
+      <plugin>test_actuator</plugin>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <command_interface name="does_not_exist"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="does_not_exist"/>
+    </joint>
+  </ros2_control>
+  <ros2_control name="TestSensorHardware" type="sensor">
+    <hardware>
+      <plugin>test_sensor</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <sensor name="sensor1">
+      <state_interface name="velocity"/>
+      <state_interface name="does_not_exist"/>
+    </sensor>
+  </ros2_control>
+  <ros2_control name="TestSystemHardware" type="system">
+    <hardware>
+      <plugin>test_system</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <joint name="joint2">
+      <command_interface name="velocity"/>
+      <command_interface name="does_not_exist"/>
+      <state_interface name="position"/>
+      <state_interface name="does_not_exist"/>
+    </joint>
+    <joint name="joint3">
+      <command_interface name="velocity"/>
+      <command_interface name="does_not_exist"/>
+      <state_interface name="position"/>
+      <state_interface name="does_not_exist"/>
+    </joint>
+  </ros2_control>
+)";
+
+
+const auto minimal_robot_urdf = std::string(urdf_head) + std::string(hardware_resources) +
+  std::string(urdf_tail);
+
+}  // namespace ros2_control_test
+
+#endif  // DESCRIPTIONS_HPP_

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -300,7 +300,7 @@ TEST_F(ForwardCommandControllerTest, CommandCallbackTest)
   // send a new command
   rclcpp::Node test_node("test_node");
   auto command_pub = test_node.create_publisher<std_msgs::msg::Float64MultiArray>(
-    "commands", rclcpp::SystemDefaultsQoS());
+    std::string(controller_->get_lifecycle_node()->get_name()) + "/commands", rclcpp::SystemDefaultsQoS());
   std_msgs::msg::Float64MultiArray command_msg;
   command_msg.data = {10.0, 20.0, 30.0};
   command_pub->publish(command_msg);

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -25,7 +25,6 @@
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "forward_command_controller/forward_command_controller.hpp"
-#include "hardware_interface/joint_handle.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/node.hpp"

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -22,8 +22,8 @@
 
 #include "gmock/gmock.h"
 
-#include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/loaned_command_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "forward_command_controller/forward_command_controller.hpp"
 #include "hardware_interface/joint_handle.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
@@ -89,7 +89,7 @@ TEST_F(ForwardCommandControllerTest, JointsParameterNotSet)
   SetUpController();
   controller_->lifecycle_node_->declare_parameter("interface_name", "dummy");
 
-  // configure failed, 'joints' paremeter not set
+  // configure failed, 'joints' parameter not set
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 }
 
@@ -97,7 +97,7 @@ TEST_F(ForwardCommandControllerTest, InterfaceParameterNotSet)
 {
   SetUpController();
 
-  // configure failed, 'interface_name' paremeter not set
+  // configure failed, 'interface_name' parameter not set
   controller_->lifecycle_node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>()));
@@ -154,7 +154,7 @@ TEST_F(ForwardCommandControllerTest, ActivateWithWrongJointsNamesFails)
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint4"}));
   controller_->lifecycle_node_->declare_parameter("interface_name", "position");
 
-  // configure failed, 'joint4' not in interfaces
+  // activate failed, 'joint4' is not a valid joint name for the hardware
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 
@@ -164,7 +164,7 @@ TEST_F(ForwardCommandControllerTest, ActivateWithWrongJointsNamesFails)
       rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2"})));
   ASSERT_TRUE(result.successful);
 
-  // configure failed, 'joint1' does not support 'acceleration_command' interface
+  // activate failed, 'acceleration' is not a registered interface for `joint1`
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 }
@@ -178,7 +178,7 @@ TEST_F(ForwardCommandControllerTest, ActivateWithWrongInterfaceNameFails)
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
   controller_->lifecycle_node_->declare_parameter("interface_name", "acceleration");
 
-  // configure failed, 'joint4' not in interfaces
+  // activate failed, 'joint4' not in interfaces
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 }
@@ -192,7 +192,6 @@ TEST_F(ForwardCommandControllerTest, ActivateSuccess)
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
   controller_->lifecycle_node_->declare_parameter("interface_name", "position");
 
-  // configure failed, 'joint4' not in interfaces
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 }
@@ -300,7 +299,8 @@ TEST_F(ForwardCommandControllerTest, CommandCallbackTest)
   // send a new command
   rclcpp::Node test_node("test_node");
   auto command_pub = test_node.create_publisher<std_msgs::msg::Float64MultiArray>(
-    std::string(controller_->get_lifecycle_node()->get_name()) + "/commands", rclcpp::SystemDefaultsQoS());
+    std::string(
+      controller_->get_lifecycle_node()->get_name()) + "/commands", rclcpp::SystemDefaultsQoS());
   std_msgs::msg::Float64MultiArray command_msg;
   command_msg.data = {10.0, 20.0, 30.0};
   command_pub->publish(command_msg);

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -17,11 +17,13 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
-#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/loaned_command_interface.hpp"
 #include "forward_command_controller/forward_command_controller.hpp"
 #include "hardware_interface/joint_handle.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
@@ -32,9 +34,11 @@
 #include "rclcpp/wait_set.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "test_forward_command_controller.hpp"
-#include "test_robot_hardware/test_robot_hardware.hpp"
 
 using CallbackReturn = forward_command_controller::ForwardCommandController::CallbackReturn;
+using hardware_interface::LoanedCommandInterface;
+using testing::SizeIs;
+using testing::IsEmpty;
 
 namespace
 {
@@ -59,10 +63,6 @@ void ForwardCommandControllerTest::TearDownTestCase()
 
 void ForwardCommandControllerTest::SetUp()
 {
-  // initialize robot
-  test_robot_ = std::make_shared<test_robot_hardware::TestRobotHardware>();
-  test_robot_->init();
-
   // initialize controller
   controller_ = std::make_unique<FriendForwardCommandController>();
 }
@@ -74,89 +74,90 @@ void ForwardCommandControllerTest::TearDown()
 
 void ForwardCommandControllerTest::SetUpController()
 {
-  const auto result = controller_->init(test_robot_, "forward_command_controller");
+  const auto result = controller_->init("forward_command_controller");
   ASSERT_EQ(result, controller_interface::return_type::SUCCESS);
+
+  std::vector<LoanedCommandInterface> command_ifs;
+  command_ifs.emplace_back(joint_1_pos_cmd_);
+  command_ifs.emplace_back(joint_2_pos_cmd_);
+  command_ifs.emplace_back(joint_3_pos_cmd_);
+  controller_->assign_interfaces(std::move(command_ifs), {});
 }
 
-void ForwardCommandControllerTest::SetUpHandles()
+TEST_F(ForwardCommandControllerTest, JointsParameterNotSet)
 {
-  // get handles from test_robot_hardware
-  joint1_pos_cmd_handle_ = std::make_shared<hardware_interface::JointHandle>(
-    "joint1",
-    "position_command");
-  joint2_pos_cmd_handle_ = std::make_shared<hardware_interface::JointHandle>(
-    "joint2",
-    "position_command");
-  joint3_pos_cmd_handle_ = std::make_shared<hardware_interface::JointHandle>(
-    "joint3",
-    "position_command");
-
-  ASSERT_EQ(
-    test_robot_->get_joint_handle(
-      *joint1_pos_cmd_handle_), hardware_interface::hardware_interface_ret_t::OK);
-  ASSERT_EQ(
-    test_robot_->get_joint_handle(
-      *joint2_pos_cmd_handle_), hardware_interface::hardware_interface_ret_t::OK);
-  ASSERT_EQ(
-    test_robot_->get_joint_handle(
-      *joint3_pos_cmd_handle_), hardware_interface::hardware_interface_ret_t::OK);
-}
-
-TEST_F(ForwardCommandControllerTest, ConfigureParamsTest)
-{
-  // joint handles not initialized yet
-  ASSERT_TRUE(controller_->joint_cmd_handles_.empty());
-
   SetUpController();
+  controller_->lifecycle_node_->declare_parameter("interface_name", "dummy");
 
   // configure failed, 'joints' paremeter not set
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+}
+
+TEST_F(ForwardCommandControllerTest, InterfaceParameterNotSet)
+{
+  SetUpController();
+
+  // configure failed, 'interface_name' paremeter not set
   controller_->lifecycle_node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>()));
-
-  // configure failed, 'interface_name' paremeter not set
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  controller_->lifecycle_node_->declare_parameter("interface_name", "");
+}
+
+TEST_F(ForwardCommandControllerTest, JointsParameterIsEmpty)
+{
+  SetUpController();
+
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>()));
   controller_->lifecycle_node_->declare_parameter("interface_name", "");
 
   // configure failed, 'joints' is empty
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
-  auto result = controller_->lifecycle_node_->set_parameter(
-    rclcpp::Parameter(
-      "joints",
-      rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2"})));
-  ASSERT_TRUE(result.successful);
+}
+
+TEST_F(ForwardCommandControllerTest, InterfaceParameterEmpty)
+{
+  SetUpController();
+
+  // configure failed, 'interface_name' paremeter not set
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2"}));
+  controller_->lifecycle_node_->declare_parameter("interface_name", "");
 
   // configure failed, 'interface_name' is empty
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
-  result = controller_->lifecycle_node_->set_parameter(
-    rclcpp::Parameter(
-      "interface_name",
-      rclcpp::ParameterValue("position_command")));
-  ASSERT_TRUE(result.successful);
+}
+
+TEST_F(ForwardCommandControllerTest, ConfigureParamsSuccess)
+{
+  SetUpController();
+
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2"}));
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
 
   // configure successful
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
-
-  // joint handles initialized
-  ASSERT_EQ(controller_->joint_cmd_handles_.size(), 2ul);
 }
 
-TEST_F(ForwardCommandControllerTest, ConfigureJointsChecksTest)
+TEST_F(ForwardCommandControllerTest, ActivateWithWrongJointsNamesFails)
 {
-  // joint handles not initialized yet
-  ASSERT_TRUE(controller_->joint_cmd_handles_.empty());
-
   SetUpController();
 
   controller_->lifecycle_node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint4"}));
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
 
-  controller_->lifecycle_node_->declare_parameter("interface_name", "acceleration_command");
+  // configure failed, 'joint4' not in interfaces
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 
-  // configure failed, 'joint4' not in robot_hardware
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
   auto result = controller_->lifecycle_node_->set_parameter(
     rclcpp::Parameter(
       "joints",
@@ -164,43 +165,60 @@ TEST_F(ForwardCommandControllerTest, ConfigureJointsChecksTest)
   ASSERT_TRUE(result.successful);
 
   // configure failed, 'joint1' does not support 'acceleration_command' interface
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
-  result = controller_->lifecycle_node_->set_parameter(
-    rclcpp::Parameter(
-      "interface_name",
-      rclcpp::ParameterValue("position_command")));
-  ASSERT_TRUE(result.successful);
-
-  // configure successful
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+}
 
-  // joint handles initialized
-  ASSERT_EQ(controller_->joint_cmd_handles_.size(), 2ul);
+TEST_F(ForwardCommandControllerTest, ActivateWithWrongInterfaceNameFails)
+{
+  SetUpController();
+
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
+  controller_->lifecycle_node_->declare_parameter("interface_name", "acceleration");
+
+  // configure failed, 'joint4' not in interfaces
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+}
+
+TEST_F(ForwardCommandControllerTest, ActivateSuccess)
+{
+  SetUpController();
+
+  controller_->lifecycle_node_->declare_parameter(
+    "joints",
+    rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
+
+  // configure failed, 'joint4' not in interfaces
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 }
 
 TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
 {
   SetUpController();
-  SetUpHandles();
 
   // configure controller
   controller_->lifecycle_node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position_command");
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful though no command has been send yet
   ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
 
   // check joint commands are still the default ones
-  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 1.1);
-  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 2.1);
-  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 3.1);
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
+  ASSERT_EQ(joint_2_pos_cmd_.get_value(), 2.1);
+  ASSERT_EQ(joint_3_pos_cmd_.get_value(), 3.1);
 
   // send command
-  FriendForwardCommandController::CmdType::SharedPtr command_ptr =
-    std::make_shared<FriendForwardCommandController::CmdType>();
+  auto command_ptr =
+    std::make_shared<forward_command_controller::CmdType>();
   command_ptr->data = {10.0, 20.0, 30.0};
   controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
 
@@ -208,26 +226,25 @@ TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
   ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
 
   // check joint commands have been modified
-  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 10.0);
-  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 20.0);
-  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 30.0);
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);
+  ASSERT_EQ(joint_2_pos_cmd_.get_value(), 20.0);
+  ASSERT_EQ(joint_3_pos_cmd_.get_value(), 30.0);
 }
 
 TEST_F(ForwardCommandControllerTest, WrongCommandCheckTest)
 {
   SetUpController();
-  SetUpHandles();
 
   // configure controller
   controller_->lifecycle_node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position_command");
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // send command with wrong numnber of joints
-  FriendForwardCommandController::CmdType::SharedPtr command_ptr =
-    std::make_shared<FriendForwardCommandController::CmdType>();
+  auto command_ptr =
+    std::make_shared<forward_command_controller::CmdType>();
   command_ptr->data = {10.0, 20.0};
   controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
 
@@ -235,46 +252,44 @@ TEST_F(ForwardCommandControllerTest, WrongCommandCheckTest)
   ASSERT_EQ(controller_->update(), controller_interface::return_type::ERROR);
 
   // check joint commands are still the default ones
-  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 1.1);
-  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 2.1);
-  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 3.1);
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
+  ASSERT_EQ(joint_2_pos_cmd_.get_value(), 2.1);
+  ASSERT_EQ(joint_3_pos_cmd_.get_value(), 3.1);
 }
 
 TEST_F(ForwardCommandControllerTest, NoCommandCheckTest)
 {
   SetUpController();
-  SetUpHandles();
 
   // configure controller
   controller_->lifecycle_node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position_command");
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful, no command received yet
   ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
 
   // check joint commands are still the default ones
-  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 1.1);
-  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 2.1);
-  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 3.1);
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
+  ASSERT_EQ(joint_2_pos_cmd_.get_value(), 2.1);
+  ASSERT_EQ(joint_3_pos_cmd_.get_value(), 3.1);
 }
 
 TEST_F(ForwardCommandControllerTest, CommandCallbackTest)
 {
   SetUpController();
-  SetUpHandles();
 
   controller_->lifecycle_node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position_command");
+  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
 
   // default values
-  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 1.1);
-  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 2.1);
-  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 3.1);
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
+  ASSERT_EQ(joint_2_pos_cmd_.get_value(), 2.1);
+  ASSERT_EQ(joint_3_pos_cmd_.get_value(), 3.1);
 
   auto node_state = controller_->get_lifecycle_node()->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
@@ -300,7 +315,7 @@ TEST_F(ForwardCommandControllerTest, CommandCallbackTest)
   ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
 
   // check command in handle was set
-  ASSERT_EQ(joint1_pos_cmd_handle_->get_value(), 10.0);
-  ASSERT_EQ(joint2_pos_cmd_handle_->get_value(), 20.0);
-  ASSERT_EQ(joint3_pos_cmd_handle_->get_value(), 30.0);
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);
+  ASSERT_EQ(joint_2_pos_cmd_.get_value(), 20.0);
+  ASSERT_EQ(joint_3_pos_cmd_.get_value(), 30.0);
 }

--- a/forward_command_controller/test/test_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_forward_command_controller.hpp
@@ -17,18 +17,26 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 
 #include "forward_command_controller/forward_command_controller.hpp"
-#include "hardware_interface/joint_handle.hpp"
-#include "test_robot_hardware/test_robot_hardware.hpp"
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
 
 // subclassing and friending so we can access member varibles
 class FriendForwardCommandController : public forward_command_controller::ForwardCommandController
 {
-  FRIEND_TEST(ForwardCommandControllerTest, ConfigureParamsTest);
-  FRIEND_TEST(ForwardCommandControllerTest, ConfigureJointsChecksTest);
+  FRIEND_TEST(ForwardCommandControllerTest, JointsParameterNotSet);
+  FRIEND_TEST(ForwardCommandControllerTest, InterfaceParameterNotSet);
+  FRIEND_TEST(ForwardCommandControllerTest, JointsParameterIsEmpty);
+  FRIEND_TEST(ForwardCommandControllerTest, InterfaceParameterEmpty);
+  FRIEND_TEST(ForwardCommandControllerTest, ConfigureParamsSuccess);
+
+  FRIEND_TEST(ForwardCommandControllerTest, ActivateWithWrongJointsNamesFails);
+  FRIEND_TEST(ForwardCommandControllerTest, ActivateWithWrongInterfaceNameFails);
+  FRIEND_TEST(ForwardCommandControllerTest, ActivateSuccess);
   FRIEND_TEST(ForwardCommandControllerTest, CommandSuccessTest);
   FRIEND_TEST(ForwardCommandControllerTest, WrongCommandCheckTest);
   FRIEND_TEST(ForwardCommandControllerTest, NoCommandCheckTest);
@@ -48,12 +56,21 @@ public:
   void SetUpHandles();
 
 protected:
-  std::shared_ptr<test_robot_hardware::TestRobotHardware> test_robot_;
   std::unique_ptr<FriendForwardCommandController> controller_;
 
-  std::shared_ptr<hardware_interface::JointHandle> joint1_pos_cmd_handle_;
-  std::shared_ptr<hardware_interface::JointHandle> joint2_pos_cmd_handle_;
-  std::shared_ptr<hardware_interface::JointHandle> joint3_pos_cmd_handle_;
+  // dummy joint state values used for tests
+  const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
+  std::vector<double> joint_commands_ = {1.1, 2.1, 3.1};
+
+  hardware_interface::CommandInterface joint_1_pos_cmd_{joint_names_[0],
+    hardware_interface::HW_IF_POSITION,
+    &joint_commands_[0]};
+  hardware_interface::CommandInterface joint_2_pos_cmd_{joint_names_[1],
+    hardware_interface::HW_IF_POSITION,
+    &joint_commands_[1]};
+  hardware_interface::CommandInterface joint_3_pos_cmd_{joint_names_[2],
+    hardware_interface::HW_IF_POSITION,
+    &joint_commands_[2]};
 };
 
 #endif  // TEST_FORWARD_COMMAND_CONTROLLER_HPP_

--- a/forward_command_controller/test/test_load_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_load_forward_command_controller.cpp
@@ -16,24 +16,22 @@
 #include <memory>
 
 #include "controller_manager/controller_manager.hpp"
+#include "hardware_interface/resource_manager.hpp"
 #include "rclcpp/executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/utilities.hpp"
-#include "test_robot_hardware/test_robot_hardware.hpp"
+#include "ros2_control_test/descriptions.hpp"
 
 TEST(TestLoadForwardCommandController, load_controller)
 {
   rclcpp::init(0, nullptr);
 
-  std::shared_ptr<test_robot_hardware::TestRobotHardware> robot =
-    std::make_shared<test_robot_hardware::TestRobotHardware>();
-
-  robot->init();
-
   std::shared_ptr<rclcpp::Executor> executor =
     std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
-  controller_manager::ControllerManager cm(robot, executor, "test_controller_manager");
+  controller_manager::ControllerManager cm(
+    std::make_unique<hardware_interface::ResourceManager>(ros2_control_test::minimal_robot_urdf),
+    executor, "test_controller_manager");
 
   ASSERT_NO_THROW(
     cm.load_controller(

--- a/forward_command_controller/test/test_load_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_load_forward_command_controller.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <memory>
 
 #include "controller_manager/controller_manager.hpp"
@@ -20,7 +20,7 @@
 #include "rclcpp/executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/utilities.hpp"
-#include "ros2_control_test/descriptions.hpp"
+#include "descriptions.hpp"
 
 TEST(TestLoadForwardCommandController, load_controller)
 {


### PR DESCRIPTION
This PR implements a simple forward controller which uses `ResourceManager` from ros-control/ros2_control#147 and PositionJoint component from ros-control/ros2_control#147. The controller is use to test the minimal implementation of `ros2_control` with components as described in ros-control/ros2_control#147.

The parameters are now hard-coded since there is one issue with the name of `LifecycleNode` as described in the [comment](https://github.com/ros-controls/ros2_control/pull/147/#issuecomment-702026851) to ros-control/ros2_control#147.