### PR TITLE
Setup codecov github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/.github/workspace.repos
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: codecov/codecov-action@v1.0.14
+        with:
+          file: ros_ws/lcov/total_coverage.info
+          flags: unittests
+          name: codecov-umbrella
       - uses: actions/upload-artifact@v1
         with:
           name: colcon-logs-${{ matrix.os }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  precision: 2
+  round: down
+  range: "35...100"
+  status:
+    project:
+      default:
+        informational: true
+    patch: off
+fixes:
+  - "ros_ws/src/ros2_controllers/::"
+comment:
+  layout: "diff, flags, files"
+  behavior: default


### PR DESCRIPTION
Similar to https://github.com/ros-controls/ros2_control/pull/206. Main customizations:
* Make the test informational for now
* Keep only diff table and files in the PR comment
* Remove patch verification