### PR TITLE
Add disable-Boost-flag for tests

### DIFF
--- a/joint_state_controller/CMakeLists.txt
+++ b/joint_state_controller/CMakeLists.txt
@@ -68,6 +68,7 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_load_joint_state_controller
     controller_manager
   )
+  target_compile_definitions(test_load_joint_state_controller PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
   ament_add_gmock(
     test_joint_state_controller

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -97,6 +97,7 @@ if(BUILD_TESTING)
     realtime_tools
     test_robot_hardware
   )
+  target_compile_definitions(test_load_joint_trajectory_controller PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
   ament_add_gtest(
     test_trajectory_actions


### PR DESCRIPTION
This should solve #119

I had the same issues when compiling locally.

EDIT: I also need this for ros-controls/ros2_control_demos#37  - [check here](https://github.com/ros-controls/ros2_control_demos/pull/37/checks?check_run_id=1489680450)