### PR TITLE
Remove lifecycle node controllers

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -124,7 +124,7 @@ DiffDriveController::init(
 
 controller_interface::return_type DiffDriveController::update()
 {
-  auto logger = lifecycle_node_->get_logger();
+  auto logger = node_->get_logger();
   if (lifecycle_node_->get_current_state().id() == State::PRIMARY_STATE_INACTIVE) {
     if (!is_halted) {
       halt();
@@ -133,7 +133,7 @@ controller_interface::return_type DiffDriveController::update()
     return controller_interface::return_type::SUCCESS;
   }
 
-  const auto current_time = lifecycle_node_->get_clock()->now();
+  const auto current_time = node_->get_clock()->now();
   double & linear_command = received_velocity_msg_ptr_->twist.linear.x;
   double & angular_command = received_velocity_msg_ptr_->twist.angular.z;
 
@@ -255,7 +255,7 @@ controller_interface::return_type DiffDriveController::update()
 
 CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &)
 {
-  auto logger = lifecycle_node_->get_logger();
+  auto logger = node_->get_logger();
 
   // update parameters
   left_wheel_names_ = lifecycle_node_->get_parameter("left_wheel_names").as_string_array();
@@ -399,7 +399,7 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
       const std::shared_ptr<Twist> msg) -> void {
       if (!subscriber_is_active_) {
         RCLCPP_WARN(
-          lifecycle_node_->get_logger(),
+          node_->get_logger(),
           "Can't accept new commands. subscriber is inactive");
         return;
       }
@@ -448,7 +448,7 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
   odometry_transform_message.transforms.front().header.frame_id = odom_params_.odom_frame_id;
   odometry_transform_message.transforms.front().child_frame_id = odom_params_.base_frame_id;
 
-  previous_update_timestamp_ = lifecycle_node_->get_clock()->now();
+  previous_update_timestamp_ = node_->get_clock()->now();
   set_op_mode(hardware_interface::OperationMode::INACTIVE);
   return CallbackReturn::SUCCESS;
 }
@@ -465,7 +465,7 @@ CallbackReturn DiffDriveController::on_activate(const rclcpp_lifecycle::State &)
   }
 
   RCLCPP_INFO(
-    lifecycle_node_->get_logger(), "Lifecycle subscriber and publisher are currently active.");
+    node_->get_logger(), "Lifecycle subscriber and publisher are currently active.");
   return CallbackReturn::SUCCESS;
 }
 
@@ -549,7 +549,7 @@ CallbackReturn DiffDriveController::configure_side(
   std::vector<WheelHandle> & registered_handles,
   hardware_interface::RobotHardware & robot_hardware)
 {
-  auto logger = lifecycle_node_->get_logger();
+  auto logger = node_->get_logger();
 
   if (wheel_names.empty()) {
     std::stringstream ss;

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -38,7 +38,7 @@ CallbackReturn ForwardCommandController::on_configure(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
   rclcpp::Parameter joints_param, interface_param;
-  if (!lifecycle_node_->get_parameter("joints", joint_names_)) {
+  if (!node_->get_parameter("joints", joint_names_)) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(), "'joints' parameter not set");
     return CallbackReturn::ERROR;
   }
@@ -48,7 +48,7 @@ CallbackReturn ForwardCommandController::on_configure(
     return CallbackReturn::ERROR;
   }
 
-  if (!lifecycle_node_->get_parameter("interface_name", interface_name_)) {
+  if (!node_->get_parameter("interface_name", interface_name_)) {
     RCLCPP_ERROR_STREAM(get_node()->get_logger(), "'interface_name' parameter not set");
     return CallbackReturn::ERROR;
   }
@@ -58,7 +58,7 @@ CallbackReturn ForwardCommandController::on_configure(
     return CallbackReturn::ERROR;
   }
 
-  joints_command_subscriber_ = lifecycle_node_->create_subscription<CmdType>(
+  joints_command_subscriber_ = node_->create_subscription<CmdType>(
     "~/commands", rclcpp::SystemDefaultsQoS(),
     [this](const CmdType::SharedPtr msg)
     {

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -39,22 +39,22 @@ CallbackReturn ForwardCommandController::on_configure(
 {
   rclcpp::Parameter joints_param, interface_param;
   if (!lifecycle_node_->get_parameter("joints", joint_names_)) {
-    RCLCPP_ERROR_STREAM(get_lifecycle_node()->get_logger(), "'joints' parameter not set");
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(), "'joints' parameter not set");
     return CallbackReturn::ERROR;
   }
 
   if (joint_names_.empty()) {
-    RCLCPP_ERROR_STREAM(get_lifecycle_node()->get_logger(), "'joints' parameter was empty");
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(), "'joints' parameter was empty");
     return CallbackReturn::ERROR;
   }
 
   if (!lifecycle_node_->get_parameter("interface_name", interface_name_)) {
-    RCLCPP_ERROR_STREAM(get_lifecycle_node()->get_logger(), "'interface_name' parameter not set");
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(), "'interface_name' parameter not set");
     return CallbackReturn::ERROR;
   }
 
   if (interface_name_.empty()) {
-    RCLCPP_ERROR_STREAM(get_lifecycle_node()->get_logger(), "'interface_name' parameter was empty");
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(), "'interface_name' parameter was empty");
     return CallbackReturn::ERROR;
   }
 
@@ -65,7 +65,7 @@ CallbackReturn ForwardCommandController::on_configure(
       rt_command_ptr_.writeFromNonRT(msg);
     });
 
-  RCLCPP_INFO_STREAM(get_lifecycle_node()->get_logger(), "configure successful");
+  RCLCPP_INFO_STREAM(get_node()->get_logger(), "configure successful");
   return CallbackReturn::SUCCESS;
 }
 
@@ -120,7 +120,7 @@ CallbackReturn ForwardCommandController::on_activate(
       ordered_interfaces) || command_interfaces_.size() != ordered_interfaces.size())
   {
     RCLCPP_ERROR(
-      lifecycle_node_->get_logger(),
+      node_->get_logger(),
       "Expected %u position command interfaces, got %u",
       joint_names_.size(), ordered_interfaces.size());
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
@@ -146,8 +146,8 @@ controller_interface::return_type ForwardCommandController::update()
 
   if ((*joint_commands)->data.size() != command_interfaces_.size()) {
     RCLCPP_ERROR_STREAM_THROTTLE(
-      get_lifecycle_node()->get_logger(),
-      *lifecycle_node_->get_clock(), 1000,
+      get_node()->get_logger(),
+      *node_->get_clock(), 1000,
       "command size (" << (*joint_commands)->data.size() <<
         ") does not match number of interfaces (" <<
         command_interfaces_.size() << ")");

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -86,7 +86,7 @@ void ForwardCommandControllerTest::SetUpController()
 TEST_F(ForwardCommandControllerTest, JointsParameterNotSet)
 {
   SetUpController();
-  controller_->lifecycle_node_->declare_parameter("interface_name", "dummy");
+  controller_->node_->declare_parameter("interface_name", "dummy");
 
   // configure failed, 'joints' parameter not set
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
@@ -97,21 +97,21 @@ TEST_F(ForwardCommandControllerTest, InterfaceParameterNotSet)
   SetUpController();
 
   // configure failed, 'interface_name' parameter not set
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>()));
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
-  controller_->lifecycle_node_->declare_parameter("interface_name", "");
+  controller_->node_->declare_parameter("interface_name", "");
 }
 
 TEST_F(ForwardCommandControllerTest, JointsParameterIsEmpty)
 {
   SetUpController();
 
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>()));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "");
+  controller_->node_->declare_parameter("interface_name", "");
 
   // configure failed, 'joints' is empty
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
@@ -122,10 +122,10 @@ TEST_F(ForwardCommandControllerTest, InterfaceParameterEmpty)
   SetUpController();
 
   // configure failed, 'interface_name' paremeter not set
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "");
+  controller_->node_->declare_parameter("interface_name", "");
 
   // configure failed, 'interface_name' is empty
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
@@ -135,10 +135,10 @@ TEST_F(ForwardCommandControllerTest, ConfigureParamsSuccess)
 {
   SetUpController();
 
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
+  controller_->node_->declare_parameter("interface_name", "position");
 
   // configure successful
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
@@ -148,16 +148,16 @@ TEST_F(ForwardCommandControllerTest, ActivateWithWrongJointsNamesFails)
 {
   SetUpController();
 
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint4"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
+  controller_->node_->declare_parameter("interface_name", "position");
 
   // activate failed, 'joint4' is not a valid joint name for the hardware
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 
-  auto result = controller_->lifecycle_node_->set_parameter(
+  auto result = controller_->node_->set_parameter(
     rclcpp::Parameter(
       "joints",
       rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2"})));
@@ -172,10 +172,10 @@ TEST_F(ForwardCommandControllerTest, ActivateWithWrongInterfaceNameFails)
 {
   SetUpController();
 
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "acceleration");
+  controller_->node_->declare_parameter("interface_name", "acceleration");
 
   // activate failed, 'joint4' not in interfaces
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
@@ -186,10 +186,10 @@ TEST_F(ForwardCommandControllerTest, ActivateSuccess)
 {
   SetUpController();
 
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
+  controller_->node_->declare_parameter("interface_name", "position");
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
@@ -200,10 +200,10 @@ TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
   SetUpController();
 
   // configure controller
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
+  controller_->node_->declare_parameter("interface_name", "position");
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful though no command has been send yet
@@ -234,10 +234,10 @@ TEST_F(ForwardCommandControllerTest, WrongCommandCheckTest)
   SetUpController();
 
   // configure controller
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
+  controller_->node_->declare_parameter("interface_name", "position");
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // send command with wrong numnber of joints
@@ -260,10 +260,10 @@ TEST_F(ForwardCommandControllerTest, NoCommandCheckTest)
   SetUpController();
 
   // configure controller
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
+  controller_->node_->declare_parameter("interface_name", "position");
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful, no command received yet
@@ -279,27 +279,27 @@ TEST_F(ForwardCommandControllerTest, CommandCallbackTest)
 {
   SetUpController();
 
-  controller_->lifecycle_node_->declare_parameter(
+  controller_->node_->declare_parameter(
     "joints",
     rclcpp::ParameterValue(std::vector<std::string>{"joint1", "joint2", "joint3"}));
-  controller_->lifecycle_node_->declare_parameter("interface_name", "position");
+  controller_->node_->declare_parameter("interface_name", "position");
 
   // default values
   ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
   ASSERT_EQ(joint_2_pos_cmd_.get_value(), 2.1);
   ASSERT_EQ(joint_3_pos_cmd_.get_value(), 3.1);
 
-  auto node_state = controller_->get_lifecycle_node()->configure();
+  auto node_state = controller_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = controller_->get_lifecycle_node()->activate();
+  node_state = controller_->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   // send a new command
   rclcpp::Node test_node("test_node");
   auto command_pub = test_node.create_publisher<std_msgs::msg::Float64MultiArray>(
     std::string(
-      controller_->get_lifecycle_node()->get_name()) + "/commands", rclcpp::SystemDefaultsQoS());
+      controller_->get_node()->get_name()) + "/commands", rclcpp::SystemDefaultsQoS());
   std_msgs::msg::Float64MultiArray command_msg;
   command_msg.data = {10.0, 20.0, 30.0};
   command_pub->publish(command_msg);
@@ -308,7 +308,7 @@ TEST_F(ForwardCommandControllerTest, CommandCallbackTest)
   ASSERT_EQ(wait_for(controller_->joints_command_subscriber_), rclcpp::WaitResultKind::Ready);
 
   // process callbacks
-  rclcpp::spin_some(controller_->get_lifecycle_node()->get_node_base_interface());
+  rclcpp::spin_some(controller_->get_node()->get_node_base_interface());
 
   // update successful
   ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);

--- a/joint_state_controller/include/joint_state_controller/joint_state_controller.hpp
+++ b/joint_state_controller/include/joint_state_controller/joint_state_controller.hpp
@@ -67,14 +67,14 @@ protected:
   //  For the JointState message,
   //  we store the name of joints with compatible interfaces
   std::vector<std::string> joint_names_;
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::JointState>>
+  std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::JointState>>
   joint_state_publisher_;
   sensor_msgs::msg::JointState joint_state_msg_;
 
   //  For the DynamicJointState format, we use a map to buffer values in for easier lookup
   //  This allows to preserve whatever order or names/interfaces were initialized.
   std::unordered_map<std::string, std::unordered_map<std::string, double>> name_if_value_mapping_;
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<control_msgs::msg::DynamicJointState>>
+  std::shared_ptr<rclcpp::Publisher<control_msgs::msg::DynamicJointState>>
   dynamic_joint_state_publisher_;
   control_msgs::msg::DynamicJointState dynamic_joint_state_msg_;
 };

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -23,7 +23,6 @@
 
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/qos_event.hpp"

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -66,15 +66,12 @@ const
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 JointStateController::on_configure(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  if (!node_.get()) {
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-  }
   try {
-    joint_state_publisher_ = node_->create_publisher<sensor_msgs::msg::JointState>(
+    joint_state_publisher_ = get_node()->create_publisher<sensor_msgs::msg::JointState>(
       "joint_states", rclcpp::SystemDefaultsQoS());
 
     dynamic_joint_state_publisher_ =
-      node_->create_publisher<control_msgs::msg::DynamicJointState>(
+      get_node()->create_publisher<control_msgs::msg::DynamicJointState>(
       "dynamic_joint_states", rclcpp::SystemDefaultsQoS());
   } catch (...) {
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -66,6 +66,9 @@ const
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 JointStateController::on_configure(const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  if (!node_.get()) {
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
   try {
     joint_state_publisher_ = node_->create_publisher<sensor_msgs::msg::JointState>(
       "joint_states", rclcpp::SystemDefaultsQoS());

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -67,9 +67,6 @@ const
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 JointStateController::on_configure(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  if (!node_.get()) {
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-  }
   try {
     joint_state_publisher_ = node_->create_publisher<sensor_msgs::msg::JointState>(
       "joint_states", rclcpp::SystemDefaultsQoS());
@@ -188,12 +185,6 @@ double get_value(
 controller_interface::return_type
 JointStateController::update()
 {
-  if (lifecycle_state_.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
-    RCLCPP_WARN_ONCE(
-      get_node()->get_logger(), "JointStateController is not activated");
-    return controller_interface::return_type::ERROR;
-  }
-
   for (const auto & state_interface : state_interfaces_) {
     name_if_value_mapping_[state_interface.get_name()][state_interface.get_interface_name()] =
       state_interface.get_value();

--- a/joint_state_controller/test/test_joint_state_controller.cpp
+++ b/joint_state_controller/test/test_joint_state_controller.cpp
@@ -191,13 +191,13 @@ TEST_F(JointStateControllerTest, UpdateTest)
 {
   SetUpStateController();
 
-  auto node_state = state_controller_->get_lifecycle_node()->configure();
+  auto node_state = state_controller_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
   // publishers not activated yet
   ASSERT_EQ(state_controller_->update(), controller_interface::return_type::ERROR);
 
-  node_state = state_controller_->get_lifecycle_node()->activate();
+  node_state = state_controller_->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   ASSERT_EQ(state_controller_->update(), controller_interface::return_type::SUCCESS);
@@ -207,10 +207,10 @@ TEST_F(JointStateControllerTest, JointStatePublishTest)
 {
   SetUpStateController();
 
-  auto node_state = state_controller_->get_lifecycle_node()->configure();
+  auto node_state = state_controller_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = state_controller_->get_lifecycle_node()->activate();
+  node_state = state_controller_->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   rclcpp::Node test_node("test_node");
@@ -247,10 +247,10 @@ TEST_F(JointStateControllerTest, DynamicJointStatePublishTest)
 {
   SetUpStateController();
 
-  auto node_state = state_controller_->get_lifecycle_node()->configure();
+  auto node_state = state_controller_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = state_controller_->get_lifecycle_node()->activate();
+  node_state = state_controller_->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   rclcpp::Node test_node("test_node");

--- a/joint_state_controller/test/test_joint_state_controller.cpp
+++ b/joint_state_controller/test/test_joint_state_controller.cpp
@@ -117,6 +117,7 @@ TEST_F(JointStateControllerTest, ConfigureErrorTest)
   // configure failed
   ASSERT_EQ(state_controller_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
 
+  SetUpStateController();
   // check state remains unchanged
 
   // joint state still not initialized
@@ -192,14 +193,8 @@ TEST_F(JointStateControllerTest, UpdateTest)
   SetUpStateController();
 
   auto node_state = state_controller_->configure();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
-
-  // publishers not activated yet
-  ASSERT_EQ(state_controller_->update(), controller_interface::return_type::ERROR);
-
   node_state = state_controller_->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
-
   ASSERT_EQ(state_controller_->update(), controller_interface::return_type::SUCCESS);
 }
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -140,7 +140,7 @@ protected:
   using ControllerStateMsg = control_msgs::msg::JointTrajectoryControllerState;
   using StatePublisher = realtime_tools::RealtimePublisher<ControllerStateMsg>;
   using StatePublisherPtr = std::unique_ptr<StatePublisher>;
-  rclcpp_lifecycle::LifecyclePublisher<ControllerStateMsg>::SharedPtr publisher_;
+  rclcpp::Publisher<ControllerStateMsg>::SharedPtr publisher_;
   StatePublisherPtr state_publisher_;
 
   rclcpp::Duration state_publisher_period_ = rclcpp::Duration(RCUTILS_MS_TO_NS(20));

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -96,7 +96,7 @@ struct SegmentTolerances
  * \return Trajectory segment tolerances.
  */
 SegmentTolerances get_segment_tolerances(
-  const rclcpp_lifecycle::LifecycleNode & node,
+  const rclcpp::Node & node,
   const std::vector<std::string> & joint_names)
 {
   const auto n_joints = joint_names.size();

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -74,7 +74,7 @@ protected:
 
     SetUpAndActivateTrajectoryController(true, parameters);
 
-    executor_->add_node(traj_lifecycle_node_->get_node_base_interface());
+    executor_->add_node(traj_node_->get_node_base_interface());
 
     SetUpActionClient();
 

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -67,10 +67,10 @@ TEST_F(TestTrajectoryController, configuration) {
   SetUpTrajectoryController();
 
   rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(traj_controller_->get_lifecycle_node()->get_node_base_interface());
+  executor.add_node(traj_controller_->get_node()->get_node_base_interface());
   const auto future_handle_ = std::async(std::launch::async, spin, &executor);
 
-  const auto state = traj_controller_->get_lifecycle_node()->configure();
+  const auto state = traj_controller_->configure();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 
   // send msg
@@ -99,14 +99,14 @@ TEST_F(TestTrajectoryController, configuration) {
 //     FAIL();
 //   }
 //
-//   auto traj_lifecycle_node = traj_controller->get_lifecycle_node();
+//   auto traj_node = traj_controller->get_node();
 //   rclcpp::executors::MultiThreadedExecutor executor;
-//   executor.add_node(traj_lifecycle_node->get_node_base_interface());
+//   executor.add_node(traj_node->get_node_base_interface());
 //
-//   auto state = traj_lifecycle_node->configure();
+//   auto state = traj_controller_->configure();
 //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 //
-//   state = traj_lifecycle_node->activate();
+//   state = traj_node->activate();
 //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
 //
 //   // wait for the subscriber and publisher to completely setup
@@ -141,14 +141,14 @@ TEST_F(TestTrajectoryController, configuration) {
 //     FAIL();
 //   }
 //
-//   auto traj_lifecycle_node = traj_controller->get_lifecycle_node();
+//   auto traj_node = traj_controller->get_node();
 //   rclcpp::executors::MultiThreadedExecutor executor;
-//   executor.add_node(traj_lifecycle_node->get_node_base_interface());
+//   executor.add_node(traj_node->get_node_base_interface());
 //
-//   auto state = traj_lifecycle_node->configure();
+//   auto state = traj_controller_->configure();
 //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 //
-//   state = traj_lifecycle_node->activate();
+//   state = traj_node->activate();
 //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
 //
 //   // wait for the subscriber and publisher to completely setup
@@ -176,7 +176,7 @@ TEST_F(TestTrajectoryController, configuration) {
 //   // deactivated
 //   // wait so controller process the second point when deactivated
 //   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-//   state = traj_lifecycle_node->deactivate();
+//   state = traj_controller_->deactivate();
 //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 //   resource_manager_->read();
 //   traj_controller->update();
@@ -190,7 +190,7 @@ TEST_F(TestTrajectoryController, configuration) {
 //   // reactivated
 //   // wait so controller process the third point when reactivated
 //   std::this_thread::sleep_for(std::chrono::milliseconds(3000));
-//   state = traj_lifecycle_node->activate();
+//   state = traj_node->activate();
 //   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
 //   resource_manager_->read();
 //   traj_controller->update();
@@ -207,9 +207,9 @@ TEST_F(TestTrajectoryController, configuration) {
 TEST_F(TestTrajectoryController, cleanup) {
   SetUpAndActivateTrajectoryController();
 
-  auto traj_lifecycle_node = traj_controller_->get_lifecycle_node();
+  auto traj_node = traj_controller_->get_node();
   rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(traj_lifecycle_node->get_node_base_interface());
+  executor.add_node(traj_node->get_node_base_interface());
 
   // send msg
   builtin_interfaces::msg::Duration time_from_start;
@@ -220,11 +220,11 @@ TEST_F(TestTrajectoryController, cleanup) {
   traj_controller_->wait_for_trajectory(executor);
   traj_controller_->update();
 
-  auto state = traj_lifecycle_node->deactivate();
+  auto state = traj_controller_->deactivate();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
   traj_controller_->update();
 
-  state = traj_lifecycle_node->cleanup();
+  state = traj_controller_->cleanup();
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
   // update for 0.25 seconds
   const auto start_time = rclcpp::Clock().now();
@@ -240,19 +240,19 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   SetUpTrajectoryController(false);
 
   // This block is replacing the way parameters are set via launch
-  auto traj_lifecycle_node = traj_controller_->get_lifecycle_node();
+  auto traj_node = traj_controller_->get_node();
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
   const rclcpp::Parameter joint_parameters("joints", joint_names_);
-  traj_lifecycle_node->set_parameter(joint_parameters);
-  traj_lifecycle_node->configure();
-  auto state = traj_lifecycle_node->get_current_state();
+  traj_node->set_parameter(joint_parameters);
+  traj_controller_->configure();
+  auto state = traj_controller_->get_current_state();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
 
   ActivateTrajectoryController();
   rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(traj_lifecycle_node->get_node_base_interface());
+  executor.add_node(traj_node->get_node_base_interface());
 
-  state = traj_lifecycle_node->get_current_state();
+  state = traj_controller_->get_current_state();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
   EXPECT_EQ(INITIAL_POS_JOINT1, joint_pos_[0]);
   EXPECT_EQ(INITIAL_POS_JOINT2, joint_pos_[1]);
@@ -278,7 +278,7 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   std::this_thread::sleep_for(FIRST_POINT_TIME);
   traj_controller_->update();
   // deactivated
-  state = traj_lifecycle_node->deactivate();
+  state = traj_controller_->deactivate();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 
   const auto allowed_delta = 0.05;
@@ -288,7 +288,7 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   EXPECT_NEAR(5.5, joint_pos_[2], allowed_delta);
 
   // cleanup
-  state = traj_lifecycle_node->cleanup();
+  state = traj_controller_->cleanup();
 
   // update loop receives a new msg and updates accordingly
   traj_controller_->update();
@@ -302,7 +302,7 @@ TEST_F(TestTrajectoryController, correct_initialization_using_parameters) {
   EXPECT_NEAR(INITIAL_POS_JOINT2, joint_pos_[1], allowed_delta);
   EXPECT_NEAR(INITIAL_POS_JOINT3, joint_pos_[2], allowed_delta);
 
-  state = traj_lifecycle_node->configure();
+  state = traj_controller_->configure();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
   executor.cancel();
 }
@@ -355,7 +355,7 @@ void TestTrajectoryController::test_state_publish_rate_target(int target_msg_cou
   const int qos_level = 10;
   int echo_received_counter = 0;
   rclcpp::Subscription<JointTrajectoryControllerState>::SharedPtr subs =
-    traj_lifecycle_node_->create_subscription<JointTrajectoryControllerState>(
+    traj_node_->create_subscription<JointTrajectoryControllerState>(
     "/state",
     qos_level,
     [&](JointTrajectoryControllerState::UniquePtr msg) {
@@ -617,7 +617,7 @@ TEST_F(TestTrajectoryController, test_trajectory_replace) {
   //  Check that we reached end of points_old trajectory
   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
 
-  RCLCPP_INFO(traj_lifecycle_node_->get_logger(), "Sending new trajectory");
+  RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory");
   publish(time_from_start, points_partial_new);
   // Replaced trajectory is a mix of previous and current goal
   expected_desired.positions[0] = points_partial_new[0][0];
@@ -647,7 +647,7 @@ TEST_F(TestTrajectoryController, test_ignore_old_trajectory) {
   //  Check that we reached end of points_old[0] trajectory
   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
 
-  RCLCPP_INFO(traj_lifecycle_node_->get_logger(), "Sending new trajectory in the past");
+  RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory in the past");
   //  New trajectory will end before current time
   rclcpp::Time new_traj_start = rclcpp::Clock().now() - delay - std::chrono::milliseconds(100);
   expected_actual.positions = {points_old[1].begin(), points_old[1].end()};
@@ -673,7 +673,7 @@ TEST_F(TestTrajectoryController, test_ignore_partial_old_trajectory) {
   //  Check that we reached end of points_old[0]trajectory
   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
 
-  RCLCPP_INFO(traj_lifecycle_node_->get_logger(), "Sending new trajectory partially in the past");
+  RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory partially in the past");
   //  New trajectory first point is in the past, second is in the future
   rclcpp::Time new_traj_start = rclcpp::Clock().now() - delay - std::chrono::milliseconds(100);
   expected_actual.positions = {points_new[1].begin(), points_new[1].end()};
@@ -685,20 +685,20 @@ TEST_F(TestTrajectoryController, test_ignore_partial_old_trajectory) {
 
 TEST_F(TestTrajectoryController, test_execute_partial_traj_in_future) {
   SetUpTrajectoryController();
-  auto traj_lifecycle_node = traj_controller_->get_lifecycle_node();
+  auto traj_node = traj_controller_->get_node();
   RCLCPP_WARN(
-    traj_lifecycle_node->get_logger(),
+    traj_node->get_logger(),
     "Test disabled until current_trajectory is taken into account when adding a new trajectory.");
   // https://github.com/ros-controls/ros_controllers/blob/melodic-devel/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h#L149
   return;
 
   rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(traj_lifecycle_node->get_node_base_interface());
+  executor.add_node(traj_node->get_node_base_interface());
   subscribeToState();
   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
-  traj_lifecycle_node->set_parameter(partial_joints_parameters);
-  traj_lifecycle_node->configure();
-  traj_lifecycle_node->activate();
+  traj_node->set_parameter(partial_joints_parameters);
+  traj_controller_->configure();
+  traj_controller_->activate();
 
   std::vector<std::vector<double>> full_traj {{{2., 3., 4.}, {4., 6., 8.}}};
   std::vector<std::vector<double>> partial_traj {{{-1., -2.}, {-2., -4, }}};
@@ -716,7 +716,7 @@ TEST_F(TestTrajectoryController, test_execute_partial_traj_in_future) {
 
 
   // Send partial trajectory starting after full trajecotry is complete
-  RCLCPP_INFO(traj_lifecycle_node->get_logger(), "Sending new trajectory in the future");
+  RCLCPP_INFO(traj_node->get_logger(), "Sending new trajectory in the future");
   publish(points_delay, partial_traj, rclcpp::Clock().now() + delay * 2);
   // Wait until the end start and end of partial traj
 

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -115,19 +115,19 @@ protected:
   {
     SetUpTrajectoryController(use_local_parameters);
 
-    traj_lifecycle_node_ = traj_controller_->get_lifecycle_node();
+    traj_node_ = traj_controller_->get_node();
     for (const auto & param : parameters) {
-      traj_lifecycle_node_->set_parameter(param);
+      traj_node_->set_parameter(param);
     }
     if (executor) {
-      executor->add_node(traj_lifecycle_node_->get_node_base_interface());
+      executor->add_node(traj_node_->get_node_base_interface());
     }
 
     // ignore velocity tolerances for this test since they arent commited in test_robot->write()
     rclcpp::Parameter stopped_velocity_parameters("constraints.stopped_velocity_tolerance", 0.0);
-    traj_lifecycle_node_->set_parameter(stopped_velocity_parameters);
+    traj_node_->set_parameter(stopped_velocity_parameters);
 
-    traj_controller_->get_lifecycle_node()->configure();
+    traj_controller_->configure();
     ActivateTrajectoryController();
   }
 
@@ -165,7 +165,7 @@ protected:
     cmd_interfaces[2].set_value(INITIAL_POS_JOINT3);
 
     traj_controller_->assign_interfaces(std::move(cmd_interfaces), std::move(state_interfaces));
-    traj_controller_->get_lifecycle_node()->activate();
+    traj_controller_->activate();
   }
 
   static void TearDownTestCase()
@@ -175,7 +175,7 @@ protected:
 
   void subscribeToState()
   {
-    auto traj_lifecycle_node = traj_controller_->get_lifecycle_node();
+    auto traj_lifecycle_node = traj_controller_->get_node();
     traj_lifecycle_node->set_parameter(
       rclcpp::Parameter(
         "state_publish_rate",
@@ -300,7 +300,7 @@ protected:
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr trajectory_publisher_;
 
   std::shared_ptr<TestableJointTrajectoryController> traj_controller_;
-  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> traj_lifecycle_node_;
+  std::shared_ptr<rclcpp::Node> traj_node_;
   rclcpp::Subscription<control_msgs::msg::JointTrajectoryControllerState>::SharedPtr
     state_subscriber_;
   mutable std::mutex state_mutex_;


### PR DESCRIPTION
Summary of changes:

- Replace `LifecyclePublisher`s with regular `Publisher`s, unfortunately now controllers could publish while deactivated.
- Refactor the calls to `get_lifecycle_node`

The `LifecyclePublisher` above made me notice that there are no LifecycleSubscribers or LifecycleServices. Is it because they have yet to be implemented, or because a `LifecycleNode` stops serving callbacks if it's not active?  I could not find mention to this.