### PR TITLE
Diff drive parameter fixes

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.hpp
@@ -19,6 +19,8 @@
 #ifndef DIFF_DRIVE_CONTROLLER__SPEED_LIMITER_HPP_
 #define DIFF_DRIVE_CONTROLLER__SPEED_LIMITER_HPP_
 
+#include <math.h>
+
 namespace diff_drive_controller
 {
 class SpeedLimiter
@@ -39,8 +41,8 @@ public:
   SpeedLimiter(
     bool has_velocity_limits = false, bool has_acceleration_limits = false,
     bool has_jerk_limits = false,
-    double min_velocity = 0.0, double max_velocity = 0.0, double min_acceleration = 0.0,
-    double max_acceleration = 0.0, double min_jerk = 0.0, double max_jerk = 0.0);
+    double min_velocity = NAN, double max_velocity = NAN, double min_acceleration = NAN,
+    double max_acceleration = NAN, double min_jerk = NAN, double max_jerk = NAN);
 
   /**
    * \brief Limit the velocity and acceleration

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -84,7 +84,7 @@ DiffDriveController::init(const std::string & controller_name)
     node->declare_parameter<bool>("open_loop", odom_params_.open_loop);
     node->declare_parameter<bool>("enable_odom_tf", odom_params_.enable_odom_tf);
 
-    node->declare_parameter<int>("cmd_vel_timeout", cmd_vel_timeout_.count());
+    node->declare_parameter<double>("cmd_vel_timeout", cmd_vel_timeout_.count() / 1000.0);
     node->declare_parameter<bool>("publish_limited_velocity", publish_limited_velocity_);
     node->declare_parameter<int>("velocity_rolling_window_size", 10);
     node->declare_parameter<bool>("use_stamped_vel", use_stamped_vel_);
@@ -330,7 +330,8 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
   odom_params_.enable_odom_tf = node_->get_parameter("enable_odom_tf").as_bool();
 
   cmd_vel_timeout_ =
-    std::chrono::milliseconds{node_->get_parameter("cmd_vel_timeout").as_int()};
+    std::chrono::milliseconds{static_cast<int>(node_->get_parameter("cmd_vel_timeout").as_double() *
+    1000.0)};
   publish_limited_velocity_ = node_->get_parameter("publish_limited_velocity").as_bool();
   use_stamped_vel_ = node_->get_parameter("use_stamped_vel").as_bool();
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -92,22 +92,22 @@ DiffDriveController::init(const std::string & controller_name)
     node->declare_parameter<bool>("linear.x.has_velocity_limits", false);
     node->declare_parameter<bool>("linear.x.has_acceleration_limits", false);
     node->declare_parameter<bool>("linear.x.has_jerk_limits", false);
-    node->declare_parameter<double>("linear.x.max_velocity", 0.0);
-    node->declare_parameter<double>("linear.x.min_velocity", 0.0);
-    node->declare_parameter<double>("linear.x.max_acceleration", 0.0);
-    node->declare_parameter<double>("linear.x.min_acceleration", 0.0);
-    node->declare_parameter<double>("linear.x.max_jerk", 0.0);
-    node->declare_parameter<double>("linear.x.min_jerk", 0.0);
+    node->declare_parameter<double>("linear.x.max_velocity", NAN);
+    node->declare_parameter<double>("linear.x.min_velocity", NAN);
+    node->declare_parameter<double>("linear.x.max_acceleration", NAN);
+    node->declare_parameter<double>("linear.x.min_acceleration", NAN);
+    node->declare_parameter<double>("linear.x.max_jerk", NAN);
+    node->declare_parameter<double>("linear.x.min_jerk", NAN);
 
     node->declare_parameter<bool>("angular.z.has_velocity_limits", false);
     node->declare_parameter<bool>("angular.z.has_acceleration_limits", false);
     node->declare_parameter<bool>("angular.z.has_jerk_limits", false);
-    node->declare_parameter<double>("angular.z.max_velocity", 0.0);
-    node->declare_parameter<double>("angular.z.min_velocity", 0.0);
-    node->declare_parameter<double>("angular.z.max_acceleration", 0.0);
-    node->declare_parameter<double>("angular.z.min_acceleration", 0.0);
-    node->declare_parameter<double>("angular.z.max_jerk", 0.0);
-    node->declare_parameter<double>("angular.z.min_jerk", 0.0);
+    node->declare_parameter<double>("angular.z.max_velocity", NAN);
+    node->declare_parameter<double>("angular.z.min_velocity", NAN);
+    node->declare_parameter<double>("angular.z.max_acceleration", NAN);
+    node->declare_parameter<double>("angular.z.min_acceleration", NAN);
+    node->declare_parameter<double>("angular.z.max_jerk", NAN);
+    node->declare_parameter<double>("angular.z.min_jerk", NAN);
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;
@@ -334,27 +334,35 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
   publish_limited_velocity_ = node_->get_parameter("publish_limited_velocity").as_bool();
   use_stamped_vel_ = node_->get_parameter("use_stamped_vel").as_bool();
 
-  limiter_linear_ = SpeedLimiter(
-    node_->get_parameter("linear.x.has_velocity_limits").as_bool(),
-    node_->get_parameter("linear.x.has_acceleration_limits").as_bool(),
-    node_->get_parameter("linear.x.has_jerk_limits").as_bool(),
-    node_->get_parameter("linear.x.min_velocity").as_double(),
-    node_->get_parameter("linear.x.max_velocity").as_double(),
-    node_->get_parameter("linear.x.min_acceleration").as_double(),
-    node_->get_parameter("linear.x.max_acceleration").as_double(),
-    node_->get_parameter("linear.x.min_jerk").as_double(),
-    node_->get_parameter("linear.x.max_jerk").as_double());
+  try {
+    limiter_linear_ = SpeedLimiter(
+      node_->get_parameter("linear.x.has_velocity_limits").as_bool(),
+      node_->get_parameter("linear.x.has_acceleration_limits").as_bool(),
+      node_->get_parameter("linear.x.has_jerk_limits").as_bool(),
+      node_->get_parameter("linear.x.min_velocity").as_double(),
+      node_->get_parameter("linear.x.max_velocity").as_double(),
+      node_->get_parameter("linear.x.min_acceleration").as_double(),
+      node_->get_parameter("linear.x.max_acceleration").as_double(),
+      node_->get_parameter("linear.x.min_jerk").as_double(),
+      node_->get_parameter("linear.x.max_jerk").as_double());
+  } catch (const std::runtime_error & e) {
+    RCLCPP_ERROR(node_->get_logger(), "Error configuring linear speed limiter: %s", e.what());
+  }
 
-  limiter_angular_ = SpeedLimiter(
-    node_->get_parameter("angular.z.has_velocity_limits").as_bool(),
-    node_->get_parameter("angular.z.has_acceleration_limits").as_bool(),
-    node_->get_parameter("angular.z.has_jerk_limits").as_bool(),
-    node_->get_parameter("angular.z.min_velocity").as_double(),
-    node_->get_parameter("angular.z.max_velocity").as_double(),
-    node_->get_parameter("angular.z.min_acceleration").as_double(),
-    node_->get_parameter("angular.z.max_acceleration").as_double(),
-    node_->get_parameter("angular.z.min_jerk").as_double(),
-    node_->get_parameter("angular.z.max_jerk").as_double());
+  try {
+    limiter_angular_ = SpeedLimiter(
+      node_->get_parameter("angular.z.has_velocity_limits").as_bool(),
+      node_->get_parameter("angular.z.has_acceleration_limits").as_bool(),
+      node_->get_parameter("angular.z.has_jerk_limits").as_bool(),
+      node_->get_parameter("angular.z.min_velocity").as_double(),
+      node_->get_parameter("angular.z.max_velocity").as_double(),
+      node_->get_parameter("angular.z.min_acceleration").as_double(),
+      node_->get_parameter("angular.z.max_acceleration").as_double(),
+      node_->get_parameter("angular.z.min_jerk").as_double(),
+      node_->get_parameter("angular.z.max_jerk").as_double());
+  } catch (const std::runtime_error & e) {
+    RCLCPP_ERROR(node_->get_logger(), "Error configuring angular speed limiter: %s", e.what());
+  }
 
 
   if (!reset()) {

--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <algorithm>
+#include <stdexcept>
 
 #include "diff_drive_controller/speed_limiter.hpp"
 #include "rcppmath/clamp.hpp"
@@ -37,6 +38,32 @@ SpeedLimiter::SpeedLimiter(
   min_jerk_(min_jerk),
   max_jerk_(max_jerk)
 {
+  // Check if limits are valid, max must be specified, min defaults to -max if unspecified
+  if (has_velocity_limits_) {
+    if (std::isnan(max_velocity_)) {
+      throw std::runtime_error("Cannot apply velocity limits if max_velocity is not specified");
+    }
+    if (std::isnan(min_velocity_)) {
+      min_velocity_ = -max_velocity_;
+    }
+  }
+  if (has_acceleration_limits_) {
+    if (std::isnan(max_acceleration_)) {
+      throw std::runtime_error(
+              "Cannot apply acceleration limits if max_acceleration is not specified");
+    }
+    if (std::isnan(min_acceleration_)) {
+      min_acceleration_ = -max_acceleration_;
+    }
+  }
+  if (has_jerk_limits_) {
+    if (std::isnan(max_jerk_)) {
+      throw std::runtime_error("Cannot apply jerk limits if max_jerk is not specified");
+    }
+    if (std::isnan(min_jerk_)) {
+      min_jerk_ = -max_jerk_;
+    }
+  }
 }
 
 double SpeedLimiter::limit(double & v, double v0, double v1, double dt)


### PR DESCRIPTION
-  Recover old speed limiter behavior, if unspecified min defaults to -max
- Change cmd_vel_timeout to seconds (double) as ROS1 instead of ms(int) 