### PR TITLE
Fix diff drive twist concurrency issues

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
@@ -37,6 +37,7 @@
 #include "odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/state.hpp"
+#include "realtime_tools/realtime_box.h"
 #include "realtime_tools/realtime_buffer.h"
 #include "realtime_tools/realtime_publisher.h"
 #include "tf2_msgs/msg/tf_message.hpp"
@@ -145,7 +146,7 @@ protected:
     =
     nullptr;
 
-  std::shared_ptr<Twist> received_velocity_msg_ptr_ = nullptr;
+  realtime_tools::RealtimeBox<std::shared_ptr<Twist>> received_velocity_msg_ptr_{nullptr};
 
   std::queue<Twist> previous_commands_;  // last two commands
 

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -42,9 +42,11 @@ class TestableDiffDriveController : public diff_drive_controller::DiffDriveContr
 {
 public:
   using DiffDriveController::DiffDriveController;
-  std::shared_ptr<geometry_msgs::msg::TwistStamped> getLastReceivedTwist() const
+  std::shared_ptr<geometry_msgs::msg::TwistStamped> getLastReceivedTwist()
   {
-    return received_velocity_msg_ptr_;
+    std::shared_ptr<geometry_msgs::msg::TwistStamped> ret;
+    received_velocity_msg_ptr_.get(ret);
+    return ret;
   }
 
   /**


### PR DESCRIPTION
**Concurrency issues**
Before this fix, a twist message could be received and stored one
thread, in the middle of the update() of the controller.

This would be fixed by making a copy of the shared pointer at the
beginning of the update() function, added realtime box to ensure safe
concurrent access to the pointer.

**Don't store limited command as last command**
Before these changes, the limited command overwrote the original
command, which mean that it too much more time to reach the commanded
speed.
We only want this behavior when the command is too old and we replace it
with 0 speed.