### PR TITLE
Multi interface Forward Controller

### DIFF
--- a/effort_controllers/src/joint_group_effort_controller.cpp
+++ b/effort_controllers/src/joint_group_effort_controller.cpp
@@ -25,7 +25,6 @@ namespace effort_controllers
 JointGroupEffortController::JointGroupEffortController()
 : forward_command_controller::ForwardCommandController()
 {
-  logger_name_ = "joint effort controller";
   interface_name_ = hardware_interface::HW_IF_EFFORT;
 }
 

--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -22,7 +22,9 @@ find_package(std_msgs REQUIRED)
 
 add_library(forward_command_controller
   SHARED
+  src/forward_controllers_base.cpp
   src/forward_command_controller.cpp
+  src/multi_interface_forward_command_controller.cpp
 )
 target_include_directories(forward_command_controller PRIVATE include)
 ament_target_dependencies(forward_command_controller
@@ -77,6 +79,18 @@ if(BUILD_TESTING)
   target_include_directories(test_forward_command_controller PRIVATE include)
   target_link_libraries(test_forward_command_controller
     forward_command_controller
+  )
+
+  ament_add_gmock(
+    test_load_multi_interface_forward_command_controller
+    test/test_load_multi_interface_forward_command_controller.cpp
+  )
+  target_include_directories(test_load_multi_interface_forward_command_controller PRIVATE include)
+  ament_target_dependencies(
+    test_load_multi_interface_forward_command_controller
+    controller_manager
+    hardware_interface
+    ros2_control_test_assets
   )
 endif()
 

--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -92,6 +92,15 @@ if(BUILD_TESTING)
     hardware_interface
     ros2_control_test_assets
   )
+
+  ament_add_gmock(
+    test_multi_interface_forward_command_controller
+    test/test_multi_interface_forward_command_controller.cpp
+  )
+  target_include_directories(test_multi_interface_forward_command_controller PRIVATE include)
+  target_link_libraries(test_multi_interface_forward_command_controller
+    forward_command_controller
+  )
 endif()
 
 ament_export_dependencies(

--- a/forward_command_controller/forward_command_plugin.xml
+++ b/forward_command_controller/forward_command_plugin.xml
@@ -4,4 +4,10 @@
     The forward command controller commands a group of joints in a given interface
   </description>
   </class>
+  <class name="forward_command_controller/MultiInterfaceForwardCommandController"
+         type="forward_command_controller::MultiInterfaceForwardCommandController" base_class_type="controller_interface::ControllerInterface">
+    <description>
+      MultiInterfaceForwardController ros2_control controller.
+    </description>
+  </class>
 </library>

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -23,8 +23,6 @@
 
 namespace forward_command_controller
 {
-using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
-
 /**
  * \brief Forward command controller for a set of joints.
  *
@@ -44,7 +42,7 @@ public:
 
 protected:
   void declare_parameters() override;
-  CallbackReturn read_parameters() override;
+  controller_interface::CallbackReturn read_parameters() override;
 
   std::vector<std::string> joint_names_;
   std::string interface_name_;

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.hpp
@@ -78,6 +78,8 @@ protected:
   std::vector<std::string> joint_names_;
   std::string interface_name_;
 
+  std::vector<std::string> command_interface_types_;
+
   realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>> rt_command_ptr_;
   rclcpp::Subscription<CmdType>::SharedPtr joints_command_subscriber_;
 

--- a/forward_command_controller/include/forward_command_controller/forward_controllers_base.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_controllers_base.hpp
@@ -1,0 +1,104 @@
+// Copyright 2021 Stogl Robotics Consulting UG (haftungsbescrhänkt)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORWARD_COMMAND_CONTROLLER__FORWARD_CONTROLLERS_BASE_HPP_
+#define FORWARD_COMMAND_CONTROLLER__FORWARD_CONTROLLERS_BASE_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "controller_interface/controller_interface.hpp"
+#include "forward_command_controller/visibility_control.h"
+#include "rclcpp/subscription.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+#include "realtime_tools/realtime_buffer.h"
+#include "std_msgs/msg/float64_multi_array.hpp"
+
+namespace forward_command_controller
+{
+using CmdType = std_msgs::msg::Float64MultiArray;
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+/**
+ * \brief Forward command controller for a set of joints and interfaces.
+ *
+ * This class forwards the command signal down to a set of joints or interfaces.
+ *
+ * Subscribes to:
+ * - \b commands (std_msgs::msg::Float64MultiArray) : The commands to apply.
+ */
+class ForwardControllersBase : public controller_interface::ControllerInterface
+{
+public:
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  ForwardControllersBase();
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  ~ForwardControllersBase() = default;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  CallbackReturn on_init() override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+  FORWARD_COMMAND_CONTROLLER_PUBLIC
+  controller_interface::return_type update(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+protected:
+  /**
+   * Derived controllers have to declare parameters in this method.
+   * Error handling does not have to be done. It is done in `on_init`-method of this class.
+   */
+  virtual void declare_parameters() = 0;
+
+  /**
+   * Derived controllers have to read parameters in this method and set `command_interface_types_`
+   * variable. The variable is then used to propagate the command interface configuration to
+   * controller manager. The method is called from `on_configure`-method of this class.
+   *
+   * It is expected that error handling of exceptions is done.
+   *
+   * \returns CallbackReturn::SUCCESS if parameters are successfully read and their values are
+   * allowed, CallbackReturn::ERROR otherwise.
+   */
+  virtual CallbackReturn read_parameters() = 0;
+
+  std::vector<std::string> joint_names_;
+  std::string interface_name_;
+
+  std::vector<std::string> command_interface_types_;
+
+  realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>> rt_command_ptr_;
+  rclcpp::Subscription<CmdType>::SharedPtr joints_command_subscriber_;
+};
+
+}  // namespace forward_command_controller
+
+#endif  // FORWARD_COMMAND_CONTROLLER__FORWARD_CONTROLLERS_BASE_HPP_

--- a/forward_command_controller/include/forward_command_controller/forward_controllers_base.hpp
+++ b/forward_command_controller/include/forward_command_controller/forward_controllers_base.hpp
@@ -30,7 +30,6 @@
 namespace forward_command_controller
 {
 using CmdType = std_msgs::msg::Float64MultiArray;
-using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 /**
  * \brief Forward command controller for a set of joints and interfaces.
@@ -56,16 +55,19 @@ public:
   controller_interface::InterfaceConfiguration state_interface_configuration() const override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
-  CallbackReturn on_init() override;
+  controller_interface::CallbackReturn on_init() override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
-  CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
+  controller_interface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & previous_state) override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
-  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+  controller_interface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State & previous_state) override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
-  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+  controller_interface::CallbackReturn on_deactivate(
+    const rclcpp_lifecycle::State & previous_state) override;
 
   FORWARD_COMMAND_CONTROLLER_PUBLIC
   controller_interface::return_type update(
@@ -85,10 +87,10 @@ protected:
    *
    * It is expected that error handling of exceptions is done.
    *
-   * \returns CallbackReturn::SUCCESS if parameters are successfully read and their values are
-   * allowed, CallbackReturn::ERROR otherwise.
+   * \returns controller_interface::CallbackReturn::SUCCESS if parameters are successfully read and their values are
+   * allowed, controller_interface::CallbackReturn::ERROR otherwise.
    */
-  virtual CallbackReturn read_parameters() = 0;
+  virtual controller_interface::CallbackReturn read_parameters() = 0;
 
   std::vector<std::string> joint_names_;
   std::string interface_name_;

--- a/forward_command_controller/include/forward_command_controller/multi_interface_forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/multi_interface_forward_command_controller.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 PAL Robotics S.L.
+// Copyright 2021 Stogl Robotics Consulting UG (haftungsbescrhänkt)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FORWARD_COMMAND_CONTROLLER__FORWARD_COMMAND_CONTROLLER_HPP_
-#define FORWARD_COMMAND_CONTROLLER__FORWARD_COMMAND_CONTROLLER_HPP_
+#ifndef FORWARD_COMMAND_CONTROLLER__MULTI_INTERFACE_FORWARD_COMMAND_CONTROLLER_HPP_
+#define FORWARD_COMMAND_CONTROLLER__MULTI_INTERFACE_FORWARD_COMMAND_CONTROLLER_HPP_
 
 #include <string>
 #include <vector>
@@ -26,30 +26,31 @@ namespace forward_command_controller
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 /**
- * \brief Forward command controller for a set of joints.
+ * \brief Multi interface forward command controller for a set of interfaces.
  *
- * This class forwards the command signal down to a set of joints on the specified interface.
+ * This class forwards the command signal down to a set of interfaces on the specified joint.
  *
- * \param joints Names of the joints to control.
- * \param interface_name Name of the interface to command.
+ * \param joint Name of the joint to control.
+ * \param interface_names Names of the interfaces to command.
  *
  * Subscribes to:
  * - \b commands (std_msgs::msg::Float64MultiArray) : The commands to apply.
  */
-class ForwardCommandController : public ForwardControllersBase
+class MultiInterfaceForwardCommandController
+: public forward_command_controller::ForwardControllersBase
 {
 public:
   FORWARD_COMMAND_CONTROLLER_PUBLIC
-  ForwardCommandController();
+  MultiInterfaceForwardCommandController();
 
 protected:
   void declare_parameters() override;
   CallbackReturn read_parameters() override;
 
-  std::vector<std::string> joint_names_;
-  std::string interface_name_;
+  std::string joint_name_;
+  std::vector<std::string> interface_names_;
 };
 
 }  // namespace forward_command_controller
 
-#endif  // FORWARD_COMMAND_CONTROLLER__FORWARD_COMMAND_CONTROLLER_HPP_
+#endif  // FORWARD_COMMAND_CONTROLLER__MULTI_INTERFACE_FORWARD_COMMAND_CONTROLLER_HPP_

--- a/forward_command_controller/include/forward_command_controller/multi_interface_forward_command_controller.hpp
+++ b/forward_command_controller/include/forward_command_controller/multi_interface_forward_command_controller.hpp
@@ -23,8 +23,6 @@
 
 namespace forward_command_controller
 {
-using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
-
 /**
  * \brief Multi interface forward command controller for a set of interfaces.
  *
@@ -45,7 +43,7 @@ public:
 
 protected:
   void declare_parameters() override;
-  CallbackReturn read_parameters() override;
+  controller_interface::CallbackReturn read_parameters() override;
 
   std::string joint_name_;
   std::vector<std::string> interface_names_;

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -24,45 +24,24 @@
 #include "rclcpp/logging.hpp"
 #include "rclcpp/qos.hpp"
 
-#include "hardware_interface/loaned_command_interface.hpp"
-
 namespace forward_command_controller
 {
-using hardware_interface::LoanedCommandInterface;
+ForwardCommandController::ForwardCommandController() : ForwardControllersBase() {}
 
-ForwardCommandController::ForwardCommandController()
-: controller_interface::ControllerInterface(),
-  rt_command_ptr_(nullptr),
-  joints_command_subscriber_(nullptr)
+void ForwardCommandController::declare_parameters()
 {
+  get_node()->declare_parameter<std::vector<std::string>>("joints", std::vector<std::string>());
+  get_node()->declare_parameter<std::string>("interface_name", "");
 }
 
-controller_interface::CallbackReturn ForwardCommandController::on_init()
-{
-  try
-  {
-    auto_declare<std::vector<std::string>>("joints", std::vector<std::string>());
-
-    auto_declare<std::string>("interface_name", "");
-  }
-  catch (const std::exception & e)
-  {
-    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
-    return controller_interface::CallbackReturn::ERROR;
-  }
-
-  return controller_interface::CallbackReturn::SUCCESS;
-}
-
-controller_interface::CallbackReturn ForwardCommandController::on_configure(
-  const rclcpp_lifecycle::State & /*previous_state*/)
+CallbackReturn ForwardCommandController::read_parameters()
 {
   joint_names_ = get_node()->get_parameter("joints").as_string_array();
 
   if (joint_names_.empty())
   {
     RCLCPP_ERROR(get_node()->get_logger(), "'joints' parameter was empty");
-    return controller_interface::CallbackReturn::ERROR;
+    return CallbackReturn::ERROR;
   }
 
   // Specialized, child controllers set interfaces before calling configure function.
@@ -74,99 +53,15 @@ controller_interface::CallbackReturn ForwardCommandController::on_configure(
   if (interface_name_.empty())
   {
     RCLCPP_ERROR(get_node()->get_logger(), "'interface_name' parameter was empty");
-    return controller_interface::CallbackReturn::ERROR;
+    return CallbackReturn::ERROR;
   }
 
-  for (const auto & joint : joint_names_) {
+  for (const auto & joint : joint_names_)
+  {
     command_interface_types_.push_back(joint + "/" + interface_name_);
   }
 
-  joints_command_subscriber_ = get_node()->create_subscription<CmdType>(
-    "~/commands", rclcpp::SystemDefaultsQoS(),
-    [this](const CmdType::SharedPtr msg) { rt_command_ptr_.writeFromNonRT(msg); });
-
-  RCLCPP_INFO(get_node()->get_logger(), "configure successful");
-  return controller_interface::CallbackReturn::SUCCESS;
-}
-
-controller_interface::InterfaceConfiguration
-ForwardCommandController::command_interface_configuration() const
-{
-  controller_interface::InterfaceConfiguration command_interfaces_config;
-  command_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
-
-  for (const auto & command_interface : command_interface_types_)
-  {
-    command_interfaces_config.names.push_back(command_interface);
-  }
-
-  return command_interfaces_config;
-}
-
-controller_interface::InterfaceConfiguration
-ForwardCommandController::state_interface_configuration() const
-{
-  return controller_interface::InterfaceConfiguration{
-    controller_interface::interface_configuration_type::NONE};
-}
-
-controller_interface::CallbackReturn ForwardCommandController::on_activate(
-  const rclcpp_lifecycle::State & /*previous_state*/)
-{
-  //  check if we have all resources defined in the "points" parameter
-  //  also verify that we *only* have the resources defined in the "points" parameter
-  std::vector<std::reference_wrapper<LoanedCommandInterface>> ordered_interfaces;
-  if (
-    !controller_interface::get_ordered_interfaces(
-      command_interfaces_, joint_names_, interface_name_, ordered_interfaces) ||
-    command_interfaces_.size() != ordered_interfaces.size())
-  {
-    RCLCPP_ERROR(
-      get_node()->get_logger(), "Expected %zu position command interfaces, got %zu",
-      joint_names_.size(), ordered_interfaces.size());
-    return controller_interface::CallbackReturn::ERROR;
-  }
-
-  // reset command buffer if a command came through callback when controller was inactive
-  rt_command_ptr_.reset();
-
-  return controller_interface::CallbackReturn::SUCCESS;
-}
-
-controller_interface::CallbackReturn ForwardCommandController::on_deactivate(
-  const rclcpp_lifecycle::State & /*previous_state*/)
-{
-  // reset command buffer
-  rt_command_ptr_.reset();
-  return controller_interface::CallbackReturn::SUCCESS;
-}
-
-controller_interface::return_type ForwardCommandController::update(
-  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
-{
-  auto joint_commands = rt_command_ptr_.readFromRT();
-
-  // no command received yet
-  if (!joint_commands || !(*joint_commands))
-  {
-    return controller_interface::return_type::OK;
-  }
-
-  if ((*joint_commands)->data.size() != command_interfaces_.size())
-  {
-    RCLCPP_ERROR_THROTTLE(
-      get_node()->get_logger(), *get_node()->get_clock(), 1000,
-      "command size (%zu) does not match number of interfaces (%zu)",
-      (*joint_commands)->data.size(), command_interfaces_.size());
-    return controller_interface::return_type::ERROR;
-  }
-
-  for (size_t index = 0; index < command_interfaces_.size(); ++index)
-  {
-    command_interfaces_[index].set_value((*joint_commands)->data[index]);
-  }
-
-  return controller_interface::return_type::OK;
+  return CallbackReturn::SUCCESS;
 }
 
 }  // namespace forward_command_controller

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -77,6 +77,10 @@ controller_interface::CallbackReturn ForwardCommandController::on_configure(
     return controller_interface::CallbackReturn::ERROR;
   }
 
+  for (const auto & joint : joint_names_) {
+    command_interface_types_.push_back(joint + "/" + interface_name_);
+  }
+
   joints_command_subscriber_ = get_node()->create_subscription<CmdType>(
     "~/commands", rclcpp::SystemDefaultsQoS(),
     [this](const CmdType::SharedPtr msg) { rt_command_ptr_.writeFromNonRT(msg); });
@@ -91,9 +95,9 @@ ForwardCommandController::command_interface_configuration() const
   controller_interface::InterfaceConfiguration command_interfaces_config;
   command_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
 
-  for (const auto & joint : joint_names_)
+  for (const auto & command_interface : command_interface_types_)
   {
-    command_interfaces_config.names.push_back(joint + "/" + interface_name_);
+    command_interfaces_config.names.push_back(command_interface);
   }
 
   return command_interfaces_config;

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -20,7 +20,6 @@
 #include <utility>
 #include <vector>
 
-#include "controller_interface/helpers.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/qos.hpp"
 

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -33,14 +33,14 @@ void ForwardCommandController::declare_parameters()
   get_node()->declare_parameter<std::string>("interface_name", "");
 }
 
-CallbackReturn ForwardCommandController::read_parameters()
+controller_interface::CallbackReturn ForwardCommandController::read_parameters()
 {
   joint_names_ = get_node()->get_parameter("joints").as_string_array();
 
   if (joint_names_.empty())
   {
     RCLCPP_ERROR(get_node()->get_logger(), "'joints' parameter was empty");
-    return CallbackReturn::ERROR;
+    return controller_interface::CallbackReturn::ERROR;
   }
 
   // Specialized, child controllers set interfaces before calling configure function.
@@ -52,7 +52,7 @@ CallbackReturn ForwardCommandController::read_parameters()
   if (interface_name_.empty())
   {
     RCLCPP_ERROR(get_node()->get_logger(), "'interface_name' parameter was empty");
-    return CallbackReturn::ERROR;
+    return controller_interface::CallbackReturn::ERROR;
   }
 
   for (const auto & joint : joint_names_)
@@ -60,7 +60,7 @@ CallbackReturn ForwardCommandController::read_parameters()
     command_interface_types_.push_back(joint + "/" + interface_name_);
   }
 
-  return CallbackReturn::SUCCESS;
+  return controller_interface::CallbackReturn::SUCCESS;
 }
 
 }  // namespace forward_command_controller

--- a/forward_command_controller/src/forward_controllers_base.cpp
+++ b/forward_command_controller/src/forward_controllers_base.cpp
@@ -1,0 +1,147 @@
+// Copyright 2021 Stogl Robotics Consulting UG (haftungsbescrhänkt)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "forward_command_controller/forward_controllers_base.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "controller_interface/helpers.hpp"
+#include "hardware_interface/loaned_command_interface.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/qos.hpp"
+
+namespace forward_command_controller
+{
+ForwardControllersBase::ForwardControllersBase()
+: controller_interface::ControllerInterface(),
+  rt_command_ptr_(nullptr),
+  joints_command_subscriber_(nullptr)
+{
+}
+
+CallbackReturn ForwardControllersBase::on_init()
+{
+  try
+  {
+    declare_parameters();
+  }
+  catch (const std::exception & e)
+  {
+    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
+    return CallbackReturn::ERROR;
+  }
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn ForwardControllersBase::on_configure(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  auto ret = this->read_parameters();
+  if (ret != CallbackReturn::SUCCESS)
+  {
+    return ret;
+  }
+
+  joints_command_subscriber_ = node_->create_subscription<CmdType>(
+    "~/commands", rclcpp::SystemDefaultsQoS(),
+    [this](const CmdType::SharedPtr msg) { rt_command_ptr_.writeFromNonRT(msg); });
+
+  RCLCPP_INFO(get_node()->get_logger(), "configure successful");
+  return CallbackReturn::SUCCESS;
+}
+
+controller_interface::InterfaceConfiguration
+ForwardControllersBase::command_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration command_interfaces_config;
+  command_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  command_interfaces_config.names = command_interface_types_;
+
+  return command_interfaces_config;
+}
+
+controller_interface::InterfaceConfiguration ForwardControllersBase::state_interface_configuration()
+  const
+{
+  return controller_interface::InterfaceConfiguration{
+    controller_interface::interface_configuration_type::NONE};
+}
+
+CallbackReturn ForwardControllersBase::on_activate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  //  check if we have all resources defined in the "points" parameter
+  //  also verify that we *only* have the resources defined in the "points" parameter
+  // ATTENTION(destogl): Shouldn't we use ordered interface all the time?
+  std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
+    ordered_interfaces;
+  if (
+    !controller_interface::get_ordered_interfaces(
+      command_interfaces_, command_interface_types_, std::string(""), ordered_interfaces) ||
+    command_interfaces_.size() != ordered_interfaces.size())
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(), "Expected %zu position command interfaces, got %zu", joint_names_.size(),
+      ordered_interfaces.size());
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+
+  // reset command buffer if a command came through callback when controller was inactive
+  rt_command_ptr_ = realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn ForwardControllersBase::on_deactivate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  // reset command buffer
+  rt_command_ptr_ = realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);
+  return CallbackReturn::SUCCESS;
+}
+
+controller_interface::return_type ForwardControllersBase::update(
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  auto joint_commands = rt_command_ptr_.readFromRT();
+
+  // no command received yet
+  if (!joint_commands || !(*joint_commands))
+  {
+    return controller_interface::return_type::OK;
+  }
+
+  if ((*joint_commands)->data.size() != command_interfaces_.size())
+  {
+    RCLCPP_ERROR_THROTTLE(
+      get_node()->get_logger(), *node_->get_clock(), 1000,
+      "command size (%zu) does not match number of interfaces (%zu)",
+      (*joint_commands)->data.size(), command_interfaces_.size());
+    return controller_interface::return_type::ERROR;
+  }
+
+  for (auto index = 0ul; index < command_interfaces_.size(); ++index)
+  {
+    command_interfaces_[index].set_value((*joint_commands)->data[index]);
+  }
+
+  return controller_interface::return_type::OK;
+}
+
+}  // namespace forward_command_controller

--- a/forward_command_controller/src/forward_controllers_base.cpp
+++ b/forward_command_controller/src/forward_controllers_base.cpp
@@ -94,17 +94,18 @@ CallbackReturn ForwardControllersBase::on_activate(
   if (
     !controller_interface::get_ordered_interfaces(
       command_interfaces_, command_interface_types_, std::string(""), ordered_interfaces) ||
-    command_interfaces_.size() != ordered_interfaces.size())
+    command_interface_types_.size() != ordered_interfaces.size())
   {
     RCLCPP_ERROR(
-      node_->get_logger(), "Expected %zu position command interfaces, got %zu", joint_names_.size(),
-      ordered_interfaces.size());
+      node_->get_logger(), "Expected %zu command interfaces, got %zu",
+      command_interface_types_.size(), ordered_interfaces.size());
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
   }
 
   // reset command buffer if a command came through callback when controller was inactive
   rt_command_ptr_ = realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);
 
+  RCLCPP_INFO(get_node()->get_logger(), "activate successful");
   return CallbackReturn::SUCCESS;
 }
 

--- a/forward_command_controller/src/multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/src/multi_interface_forward_command_controller.cpp
@@ -1,0 +1,64 @@
+// Copyright 2021 Stogl Robotics Consulting UG (haftungsbescrhänkt)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "forward_command_controller/multi_interface_forward_command_controller.hpp"
+
+#include <string>
+#include <vector>
+
+namespace forward_command_controller
+{
+MultiInterfaceForwardCommandController::MultiInterfaceForwardCommandController()
+: ForwardControllersBase()
+{
+}
+
+void MultiInterfaceForwardCommandController::declare_parameters()
+{
+  get_node()->declare_parameter<std::string>("joint", joint_name_);
+  get_node()->declare_parameter<std::vector<std::string>>("interface_names", interface_names_);
+}
+
+CallbackReturn MultiInterfaceForwardCommandController::read_parameters()
+{
+  joint_name_ = get_node()->get_parameter("joint").as_string();
+  interface_names_ = get_node()->get_parameter("interface_names").as_string_array();
+
+  if (joint_name_.empty())
+  {
+    RCLCPP_ERROR(get_node()->get_logger(), "'joint' parameter is empty");
+    return CallbackReturn::ERROR;
+  }
+
+  if (interface_names_.empty())
+  {
+    RCLCPP_ERROR(get_node()->get_logger(), "'interfaces' parameter is empty");
+    return CallbackReturn::ERROR;
+  }
+
+  for (const auto & interface : interface_names_)
+  {
+    command_interface_types_.push_back(joint_name_ + "/" + interface);
+  }
+
+  return CallbackReturn::SUCCESS;
+}
+
+}  // namespace forward_command_controller
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(
+  forward_command_controller::MultiInterfaceForwardCommandController,
+  controller_interface::ControllerInterface)

--- a/forward_command_controller/src/multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/src/multi_interface_forward_command_controller.cpp
@@ -30,7 +30,7 @@ void MultiInterfaceForwardCommandController::declare_parameters()
   get_node()->declare_parameter<std::vector<std::string>>("interface_names", interface_names_);
 }
 
-CallbackReturn MultiInterfaceForwardCommandController::read_parameters()
+controller_interface::CallbackReturn MultiInterfaceForwardCommandController::read_parameters()
 {
   joint_name_ = get_node()->get_parameter("joint").as_string();
   interface_names_ = get_node()->get_parameter("interface_names").as_string_array();
@@ -38,13 +38,13 @@ CallbackReturn MultiInterfaceForwardCommandController::read_parameters()
   if (joint_name_.empty())
   {
     RCLCPP_ERROR(get_node()->get_logger(), "'joint' parameter is empty");
-    return CallbackReturn::ERROR;
+    return controller_interface::CallbackReturn::ERROR;
   }
 
   if (interface_names_.empty())
   {
     RCLCPP_ERROR(get_node()->get_logger(), "'interfaces' parameter is empty");
-    return CallbackReturn::ERROR;
+    return controller_interface::CallbackReturn::ERROR;
   }
 
   for (const auto & interface : interface_names_)
@@ -52,7 +52,7 @@ CallbackReturn MultiInterfaceForwardCommandController::read_parameters()
     command_interface_types_.push_back(joint_name_ + "/" + interface);
   }
 
-  return CallbackReturn::SUCCESS;
+  return controller_interface::CallbackReturn::SUCCESS;
 }
 
 }  // namespace forward_command_controller

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -33,7 +33,6 @@
 #include "rclcpp/wait_set.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 
-using CallbackReturn = controller_interface::CallbackReturn;
 using hardware_interface::LoanedCommandInterface;
 
 namespace
@@ -77,7 +76,9 @@ TEST_F(ForwardCommandControllerTest, JointsParameterNotSet)
   controller_->get_node()->set_parameter({"interface_name", ""});
 
   // configure failed, 'joints' parameter not set
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::ERROR);
 }
 
 TEST_F(ForwardCommandControllerTest, InterfaceParameterNotSet)
@@ -86,7 +87,9 @@ TEST_F(ForwardCommandControllerTest, InterfaceParameterNotSet)
   controller_->get_node()->set_parameter({"joints", std::vector<std::string>()});
 
   // configure failed, 'interface_name' parameter not set
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::ERROR);
 }
 
 TEST_F(ForwardCommandControllerTest, JointsParameterIsEmpty)
@@ -97,7 +100,9 @@ TEST_F(ForwardCommandControllerTest, JointsParameterIsEmpty)
   controller_->get_node()->set_parameter({"interface_name", ""});
 
   // configure failed, 'joints' is empty
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::ERROR);
 }
 
 TEST_F(ForwardCommandControllerTest, InterfaceParameterEmpty)
@@ -107,7 +112,9 @@ TEST_F(ForwardCommandControllerTest, InterfaceParameterEmpty)
   controller_->get_node()->set_parameter({"interface_name", ""});
 
   // configure failed, 'interface_name' is empty
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::ERROR);
 }
 
 TEST_F(ForwardCommandControllerTest, ConfigureParamsSuccess)
@@ -118,7 +125,9 @@ TEST_F(ForwardCommandControllerTest, ConfigureParamsSuccess)
   controller_->get_node()->set_parameter({"interface_name", "position"});
 
   // configure successful
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::SUCCESS);
 }
 
 TEST_F(ForwardCommandControllerTest, ActivateWithWrongJointsNamesFails)
@@ -129,8 +138,12 @@ TEST_F(ForwardCommandControllerTest, ActivateWithWrongJointsNamesFails)
   controller_->get_node()->set_parameter({"interface_name", "position"});
 
   // activate failed, 'joint4' is not a valid joint name for the hardware
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    controller_->on_activate(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::ERROR);
 }
 
 TEST_F(ForwardCommandControllerTest, ActivateWithWrongInterfaceNameFails)
@@ -141,8 +154,12 @@ TEST_F(ForwardCommandControllerTest, ActivateWithWrongInterfaceNameFails)
   controller_->get_node()->set_parameter({"interface_name", "acceleration"});
 
   // activate failed, 'acceleration' is not a registered interface for `joint1`
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    controller_->on_activate(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::ERROR);
 }
 
 TEST_F(ForwardCommandControllerTest, ActivateSuccess)
@@ -153,8 +170,12 @@ TEST_F(ForwardCommandControllerTest, ActivateSuccess)
   controller_->get_node()->set_parameter({"interface_name", "position"});
 
   // activate successful
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    controller_->on_activate(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::SUCCESS);
 }
 
 TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
@@ -164,7 +185,9 @@ TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
   // configure controller
   controller_->get_node()->set_parameter({"joints", joint_names_});
   controller_->get_node()->set_parameter({"interface_name", "position"});
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::SUCCESS);
 
   // update successful though no command has been send yet
   ASSERT_EQ(
@@ -200,7 +223,9 @@ TEST_F(ForwardCommandControllerTest, WrongCommandCheckTest)
   controller_->get_node()->set_parameter({"joints", joint_names_});
   controller_->get_node()->set_parameter({"interface_name", "position"});
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::SUCCESS);
 
   // send command with wrong number of joints
   auto command_ptr = std::make_shared<forward_command_controller::CmdType>();
@@ -225,7 +250,9 @@ TEST_F(ForwardCommandControllerTest, NoCommandCheckTest)
   // configure controller
   controller_->get_node()->set_parameter({"joints", joint_names_});
   controller_->get_node()->set_parameter({"interface_name", "position"});
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    controller_->on_configure(rclcpp_lifecycle::State()),
+    controller_interface::CallbackReturn::SUCCESS);
 
   // update successful, no command received yet
   ASSERT_EQ(

--- a/forward_command_controller/test/test_load_multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_load_multi_interface_forward_command_controller.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2021, PickNik, Inc.
+// Copyright (c) 2021, Stogl Robotics Consulting UG (haftungsbeschränkt) (template)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <memory>
+
+#include "controller_manager/controller_manager.hpp"
+#include "hardware_interface/resource_manager.hpp"
+#include "rclcpp/executor.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
+#include "ros2_control_test_assets/descriptions.hpp"
+
+TEST(TestLoadMultiInterfaceForwardController, load_controller)
+{
+  rclcpp::init(0, nullptr);
+
+  std::shared_ptr<rclcpp::Executor> executor =
+    std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+  controller_manager::ControllerManager cm(
+    std::make_unique<hardware_interface::ResourceManager>(
+      ros2_control_test_assets::minimal_robot_urdf),
+    executor, "test_controller_manager");
+
+  ASSERT_NO_THROW(cm.load_controller(
+    "test_forward_command_controller",
+    "forward_command_controller/MultiInterfaceForwardCommandController"));
+}

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
@@ -1,0 +1,373 @@
+// Copyright (c) 2021, PickNik, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+/// \authors: Jack Center, Denis Stogl
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gmock/gmock.h"
+
+#include "test_multi_interface_forward_command_controller.hpp"
+
+#include "forward_command_controller/multi_interface_forward_command_controller.hpp"
+#include "hardware_interface/loaned_command_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/subscription.hpp"
+#include "rclcpp/utilities.hpp"
+#include "rclcpp/wait_set.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+using CallbackReturn =
+  forward_command_controller::MultiInterfaceForwardCommandController::CallbackReturn;
+using hardware_interface::LoanedCommandInterface;
+
+namespace
+{
+rclcpp::WaitResultKind wait_for(rclcpp::SubscriptionBase::SharedPtr subscription)
+{
+  rclcpp::WaitSet wait_set;
+  wait_set.add_subscription(subscription);
+  const auto timeout = std::chrono::seconds(10);
+  return wait_set.wait(timeout).kind();
+}
+}  // namespace
+
+void MultiInterfaceForwardCommandControllerTest::SetUpTestCase() { rclcpp::init(0, nullptr); }
+
+void MultiInterfaceForwardCommandControllerTest::TearDownTestCase() { rclcpp::shutdown(); }
+
+void MultiInterfaceForwardCommandControllerTest::SetUp()
+{
+  // initialize controller
+  controller_ = std::make_unique<FriendMultiInterfaceForwardCommandController>();
+}
+
+void MultiInterfaceForwardCommandControllerTest::TearDown() { controller_.reset(nullptr); }
+
+void MultiInterfaceForwardCommandControllerTest::SetUpController()
+{
+  const auto result = controller_->init("multi_interface_forward_command_controller");
+  ASSERT_EQ(result, controller_interface::return_type::OK);
+
+  std::vector<LoanedCommandInterface> command_ifs;
+  command_ifs.emplace_back(joint_1_pos_cmd_);
+  command_ifs.emplace_back(joint_1_vel_cmd_);
+  command_ifs.emplace_back(joint_1_eff_cmd_);
+  controller_->assign_interfaces(std::move(command_ifs), {});
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, JointsParameterNotSet)
+{
+  SetUpController();
+  controller_->get_node()->set_parameter({"interface_names", std::vector<std::string>()});
+
+  // configure failed, 'joint' parameter not set
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, InterfaceParameterNotSet)
+{
+  SetUpController();
+  controller_->get_node()->set_parameter({"joint", ""});
+
+  // configure failed, 'interface_names' parameter not set
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, JointsParameterIsEmpty)
+{
+  SetUpController();
+
+  controller_->get_node()->set_parameter({"joint", ""});
+  controller_->get_node()->set_parameter({"interface_names", std::vector<std::string>()});
+
+  // configure failed, 'joint' is empty
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, InterfaceParameterEmpty)
+{
+  SetUpController();
+  controller_->get_node()->set_parameter({"joint", "joint1"});
+  controller_->get_node()->set_parameter({"interface_names", std::vector<std::string>()});
+
+  // configure failed, 'interface_name' is empty
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, ConfigureParamsSuccess)
+{
+  SetUpController();
+
+  controller_->get_node()->set_parameter({"joint", "joint1"});
+  controller_->get_node()->set_parameter(
+    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+
+  // configure successful
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateWithWrongJointsNamesFails)
+{
+  SetUpController();
+
+  controller_->get_node()->set_parameter({"joint", "joint2"});
+  controller_->get_node()->set_parameter(
+    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+
+  // activate failed, 'joint2' is not a valid joint name for the hardware
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateWithWrongInterfaceNameFails)
+{
+  SetUpController();
+
+  controller_->get_node()->set_parameter({"joint", "joint1"});
+  controller_->get_node()->set_parameter(
+    {"interface_names", std::vector<std::string>{"position", "velocity", "acceleration"}});
+
+  // activate failed, 'acceleration' is not a registered interface for `joint1`
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateSuccess)
+{
+  SetUpController();
+
+  controller_->get_node()->set_parameter({"joint", "joint1"});
+  controller_->get_node()->set_parameter(
+    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // check joint commands are the default ones
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
+  ASSERT_EQ(joint_1_vel_cmd_.get_value(), 2.1);
+  ASSERT_EQ(joint_1_eff_cmd_.get_value(), 3.1);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, CommandSuccessTest)
+{
+  SetUpController();
+
+  // configure controller
+  controller_->get_node()->set_parameter({"joint", "joint1"});
+  controller_->get_node()->set_parameter(
+    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // send command
+  auto command_ptr = std::make_shared<forward_command_controller::CmdType>();
+  command_ptr->data = {10.0, 20.0, 30.0};
+  controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
+
+  // update successful, command received
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0.1), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // check command in handle was set
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);
+  ASSERT_EQ(joint_1_vel_cmd_.get_value(), 20.0);
+  ASSERT_EQ(joint_1_eff_cmd_.get_value(), 30.0);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, NoCommandCheckTest)
+{
+  SetUpController();
+
+  // configure controller
+  controller_->get_node()->set_parameter({"joint", "joint1"});
+  controller_->get_node()->set_parameter(
+    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // update successful, no command received yet
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // check joint commands are still the default ones
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
+  ASSERT_EQ(joint_1_vel_cmd_.get_value(), 2.1);
+  ASSERT_EQ(joint_1_eff_cmd_.get_value(), 3.1);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, WrongCommandCheckTest)
+{
+  SetUpController();
+
+  // configure controller
+  controller_->get_node()->set_parameter({"joint", "joint1"});
+  controller_->get_node()->set_parameter(
+    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // send command with wrong number of joints
+  auto command_ptr = std::make_shared<forward_command_controller::CmdType>();
+  command_ptr->data = {10.0, 20.0};
+  controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
+
+  // update failed, command size does not match number of joints
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::ERROR);
+
+  // check joint commands are still the default ones
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
+  ASSERT_EQ(joint_1_vel_cmd_.get_value(), 2.1);
+  ASSERT_EQ(joint_1_eff_cmd_.get_value(), 3.1);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, CommandCallbackTest)
+{
+  SetUpController();
+
+  controller_->get_node()->set_parameter({"joint", "joint1"});
+  controller_->get_node()->set_parameter(
+    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  auto node_state = controller_->configure();
+  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  node_state = controller_->activate();
+  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  // send a new command
+  rclcpp::Node test_node("test_node");
+  auto command_pub = test_node.create_publisher<std_msgs::msg::Float64MultiArray>(
+    std::string(controller_->get_node()->get_name()) + "/commands", rclcpp::SystemDefaultsQoS());
+  std_msgs::msg::Float64MultiArray command_msg;
+  command_msg.data = {10.0, 20.0, 30.0};
+  command_pub->publish(command_msg);
+
+  // wait for command message to be passed
+  ASSERT_EQ(wait_for(controller_->joints_command_subscriber_), rclcpp::WaitResultKind::Ready);
+
+  // process callbacks
+  rclcpp::spin_some(controller_->get_node()->get_node_base_interface());
+
+  // update successful
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // check command in handle was set
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);
+  ASSERT_EQ(joint_1_vel_cmd_.get_value(), 20.0);
+  ASSERT_EQ(joint_1_eff_cmd_.get_value(), 30.0);
+}
+
+TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
+{
+  SetUpController();
+
+  controller_->get_node()->set_parameter({"joint", "joint1"});
+  controller_->get_node()->set_parameter(
+    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  // send command
+  auto command_ptr = std::make_shared<forward_command_controller::CmdType>();
+  command_ptr->data = {10.0, 20.0, 30.0};
+  controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
+
+  // update successful, command received
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0.1), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // check command in handle was set
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);
+  ASSERT_EQ(joint_1_vel_cmd_.get_value(), 20.0);
+  ASSERT_EQ(joint_1_eff_cmd_.get_value(), 30.0);
+
+  auto node_state = controller_->deactivate();
+  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // command ptr should be reset (nullptr) after deactivation - same check as in `update`
+  ASSERT_FALSE(
+    controller_->rt_command_ptr_.readFromNonRT() &&
+    *(controller_->rt_command_ptr_.readFromNonRT()));
+  ASSERT_FALSE(
+    controller_->rt_command_ptr_.readFromRT() && *(controller_->rt_command_ptr_.readFromRT()));
+
+  // Controller is inactive but let's put some data into buffer (simulate callback when inactive)
+  auto command_msg = std::make_shared<std_msgs::msg::Float64MultiArray>();
+  command_msg->data = {5.5, 6.6, 7.7};
+  controller_->rt_command_ptr_.writeFromNonRT(command_msg);
+
+  // command ptr should be available and message should be there - same check as in `update`
+  ASSERT_TRUE(
+    controller_->rt_command_ptr_.readFromNonRT() &&
+    *(controller_->rt_command_ptr_.readFromNonRT()));
+  ASSERT_TRUE(
+    controller_->rt_command_ptr_.readFromRT() && *(controller_->rt_command_ptr_.readFromRT()));
+
+  // Now activate again
+  node_state = controller_->activate();
+  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  // command ptr should be reset (nullptr) after activation - same check as in `update`
+  ASSERT_FALSE(
+    controller_->rt_command_ptr_.readFromNonRT() &&
+    *(controller_->rt_command_ptr_.readFromNonRT()));
+  ASSERT_FALSE(
+    controller_->rt_command_ptr_.readFromRT() && *(controller_->rt_command_ptr_.readFromRT()));
+
+  // update successful
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // values should not change
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);
+  ASSERT_EQ(joint_1_vel_cmd_.get_value(), 20.0);
+  ASSERT_EQ(joint_1_eff_cmd_.get_value(), 30.0);
+
+  // set commands again
+  controller_->rt_command_ptr_.writeFromNonRT(command_msg);
+
+  // update successful
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // check command in handle was set
+  ASSERT_EQ(joint_1_pos_cmd_.get_value(), 5.5);
+  ASSERT_EQ(joint_1_vel_cmd_.get_value(), 6.6);
+  ASSERT_EQ(joint_1_eff_cmd_.get_value(), 7.7);
+}

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2021, PickNik, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+/// \authors: Jack Center, Denis Stogl
+
+#ifndef TEST_MULTI_INTERFACE_FORWARD_COMMAND_CONTROLLER_HPP_
+#define TEST_MULTI_INTERFACE_FORWARD_COMMAND_CONTROLLER_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gmock/gmock.h"
+
+#include "forward_command_controller/multi_interface_forward_command_controller.hpp"
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+using hardware_interface::CommandInterface;
+using hardware_interface::HW_IF_EFFORT;
+using hardware_interface::HW_IF_POSITION;
+using hardware_interface::HW_IF_VELOCITY;
+
+// subclassing and friending so we can access member variables
+class FriendMultiInterfaceForwardCommandController
+: public forward_command_controller::MultiInterfaceForwardCommandController
+{
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, JointsParameterNotSet);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, InterfaceParameterNotSet);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, JointsParameterIsEmpty);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, InterfaceParameterEmpty);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, ConfigureParamsSuccess);
+
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, ActivateWithWrongJointsNamesFails);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, ActivateWithWrongInterfaceNameFails);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, ActivateSuccess);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, CommandSuccessTest);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, WrongCommandCheckTest);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, NoCommandCheckTest);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, CommandCallbackTest);
+  FRIEND_TEST(MultiInterfaceForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess);
+};
+
+class MultiInterfaceForwardCommandControllerTest : public ::testing::Test
+{
+public:
+  static void SetUpTestCase();
+  static void TearDownTestCase();
+
+  void SetUp();
+  void TearDown();
+
+  void SetUpController();
+  void SetUpHandles();
+
+protected:
+  std::unique_ptr<FriendMultiInterfaceForwardCommandController> controller_;
+
+  // dummy joint state value used for tests
+  const std::string joint_name_ = "joint1";
+
+  double pos_cmd_ = 1.1;
+  double vel_cmd_ = 2.1;
+  double eff_cmd_ = 3.1;
+
+  CommandInterface joint_1_pos_cmd_{joint_name_, HW_IF_POSITION, &pos_cmd_};
+  CommandInterface joint_1_vel_cmd_{joint_name_, HW_IF_VELOCITY, &vel_cmd_};
+  CommandInterface joint_1_eff_cmd_{joint_name_, HW_IF_EFFORT, &eff_cmd_};
+};
+
+#endif  // TEST_MULTI_INTERFACE_FORWARD_COMMAND_CONTROLLER_HPP_

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
@@ -61,8 +61,8 @@ public:
   void SetUp();
   void TearDown();
 
-  void SetUpController();
-  void SetUpHandles();
+  void SetUpController(bool set_params_and_activate = false);
+  void SetParametersAndActivateController();
 
 protected:
   std::unique_ptr<FriendMultiInterfaceForwardCommandController> controller_;

--- a/position_controllers/src/joint_group_position_controller.cpp
+++ b/position_controllers/src/joint_group_position_controller.cpp
@@ -25,7 +25,6 @@ namespace position_controllers
 JointGroupPositionController::JointGroupPositionController()
 : forward_command_controller::ForwardCommandController()
 {
-  logger_name_ = "joint position controller";
   interface_name_ = hardware_interface::HW_IF_POSITION;
 }
 

--- a/velocity_controllers/src/joint_group_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_group_velocity_controller.cpp
@@ -25,7 +25,6 @@ namespace velocity_controllers
 JointGroupVelocityController::JointGroupVelocityController()
 : forward_command_controller::ForwardCommandController()
 {
-  logger_name_ = "joint velocity controller";
   interface_name_ = hardware_interface::HW_IF_VELOCITY;
 }
 


### PR DESCRIPTION
A proposal for forward controller enabling multiple interfaces defined by a parameter. 

Difference to classical `ForwardCommandController` is in input parameters, i.e., joint-interface combinations, for example:

`ForwardCommandController` parameters:
``` yaml
joints:
  - joint1
  - ...
  - joint7
interface: position
```

`MultiInterfaceForwardController` parameters:
``` yaml
joint: joint1
interfaces:
  - position
  - velocity
  - emergency_stop
```