### PR TITLE
Fix JTC segfault

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -186,6 +186,11 @@ protected:
   void preempt_active_goal();
   void set_hold_position();
 
+  // TODO(matthew-reynolds): Race condition if making a copy while another thread is setting
+  RealtimeGoalHandlePtr get_active_goal() const {return rt_active_goal_;}
+  void set_active_goal(const RealtimeGoalHandlePtr & goal) {rt_active_goal_ = goal;}
+  void clear_active_goal() {rt_active_goal_.reset();}
+
   bool reset();
   void halt();
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -149,10 +149,11 @@ protected:
   using FollowJTrajAction = control_msgs::action::FollowJointTrajectory;
   using RealtimeGoalHandle = realtime_tools::RealtimeServerGoalHandle<FollowJTrajAction>;
   using RealtimeGoalHandlePtr = std::shared_ptr<RealtimeGoalHandle>;
+  using RealtimeGoalHandleBuffer = realtime_tools::RealtimeBuffer<RealtimeGoalHandlePtr>;
 
   rclcpp_action::Server<FollowJTrajAction>::SharedPtr action_server_;
   bool allow_partial_joints_goal_ = false;
-  RealtimeGoalHandlePtr rt_active_goal_;     ///< Currently active action goal, if any.
+  RealtimeGoalHandleBuffer rt_active_goal_;     ///< Currently active action goal, if any.
   rclcpp::TimerBase::SharedPtr goal_handle_timer_;
   rclcpp::Duration action_monitor_period_ = rclcpp::Duration(RCUTILS_MS_TO_NS(50));
 
@@ -185,11 +186,6 @@ protected:
 
   void preempt_active_goal();
   void set_hold_position();
-
-  // TODO(matthew-reynolds): Race condition if making a copy while another thread is setting
-  RealtimeGoalHandlePtr get_active_goal() const {return rt_active_goal_;}
-  void set_active_goal(const RealtimeGoalHandlePtr & goal) {rt_active_goal_ = goal;}
-  void clear_active_goal() {rt_active_goal_.reset();}
 
   bool reset();
   void halt();

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -186,7 +186,8 @@ JointTrajectoryController::update()
         }
       }
 
-      if (rt_active_goal_) {
+      const auto active_goal = get_active_goal();
+      if (active_goal) {
         // send feedback
         auto feedback = std::make_shared<FollowJTrajAction::Feedback>();
         feedback->header.stamp = node_->now();
@@ -195,7 +196,7 @@ JointTrajectoryController::update()
         feedback->actual = state_current;
         feedback->desired = state_desired;
         feedback->error = state_error;
-        rt_active_goal_->setFeedback(feedback);
+        active_goal->setFeedback(feedback);
 
         // check abort
         if (abort || outside_goal_tolerance) {
@@ -208,17 +209,16 @@ JointTrajectoryController::update()
             RCLCPP_WARN(node_->get_logger(), "Aborted due to goal tolerance violation");
             result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
           }
-          rt_active_goal_->setAborted(result);
-          rt_active_goal_.reset();
+          active_goal->setAborted(result);
+          clear_active_goal();
         }
-
         // check goal tolerance
-        if (!before_last_point) {
+        else if (!before_last_point) {
           if (!outside_goal_tolerance) {
             auto res = std::make_shared<FollowJTrajAction::Result>();
             res->set__error_code(FollowJTrajAction::Result::SUCCESSFUL);
-            rt_active_goal_->setSucceeded(res);
-            rt_active_goal_.reset();
+            active_goal->setSucceeded(res);
+            clear_active_goal();
 
             RCLCPP_INFO(node_->get_logger(), "Goal reached, success!");
           } else if (default_tolerances_.goal_time_tolerance != 0.0) {
@@ -230,8 +230,8 @@ JointTrajectoryController::update()
             if (difference > default_tolerances_.goal_time_tolerance) {
               auto result = std::make_shared<FollowJTrajAction::Result>();
               result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
-              rt_active_goal_->setAborted(result);
-              rt_active_goal_.reset();
+              active_goal->setAborted(result);
+              clear_active_goal();
               RCLCPP_WARN(
                 node_->get_logger(),
                 "Aborted due goal_time_tolerance exceeding by %f seconds",
@@ -554,7 +554,8 @@ rclcpp_action::CancelResponse JointTrajectoryController::cancel_callback(
   RCLCPP_INFO(node_->get_logger(), "Got request to cancel goal");
 
   // Check that cancel request refers to currently active goal (if any)
-  if (rt_active_goal_ && rt_active_goal_->gh_ == goal_handle) {
+  const auto active_goal = get_active_goal();
+  if (active_goal && active_goal->gh_ == goal_handle) {
     // Controller uptime
     // Enter hold current position mode
     set_hold_position();
@@ -565,10 +566,8 @@ rclcpp_action::CancelResponse JointTrajectoryController::cancel_callback(
 
     // Mark the current goal as canceled
     auto action_res = std::make_shared<FollowJTrajAction::Result>();
-    rt_active_goal_->setCanceled(action_res);
-
-    // Reset current goal
-    rt_active_goal_.reset();
+    active_goal->setCanceled(action_res);
+    clear_active_goal();
   }
   return rclcpp_action::CancelResponse::ACCEPT;
 }
@@ -583,17 +582,18 @@ void JointTrajectoryController::feedback_setup_callback(
       goal_handle->get_goal()->trajectory);
 
     add_new_trajectory_msg(traj_msg);
-
-    RealtimeGoalHandlePtr rt_goal = std::make_shared<RealtimeGoalHandle>(goal_handle);
-    rt_goal->preallocated_feedback_->joint_names = joint_names_;
-    rt_active_goal_ = rt_goal;
-    rt_active_goal_->execute();
   }
+
+  // Update the active goal
+  RealtimeGoalHandlePtr rt_goal = std::make_shared<RealtimeGoalHandle>(goal_handle);
+  rt_goal->preallocated_feedback_->joint_names = joint_names_;
+  set_active_goal(rt_goal);
+  rt_goal->execute();
 
   // Setup goal status checking timer
   goal_handle_timer_ = node_->create_wall_timer(
     action_monitor_period_.to_chrono<std::chrono::seconds>(),
-    std::bind(&RealtimeGoalHandle::runNonRealtime, rt_active_goal_));
+    std::bind(&RealtimeGoalHandle::runNonRealtime, rt_goal));
 }
 
 void JointTrajectoryController::fill_partial_goal(
@@ -782,12 +782,13 @@ void JointTrajectoryController::add_new_trajectory_msg(
 
 void JointTrajectoryController::preempt_active_goal()
 {
-  if (rt_active_goal_) {
+  const auto active_goal = get_active_goal();
+  if (active_goal) {
     auto action_res = std::make_shared<FollowJTrajAction::Result>();
     action_res->set__error_code(FollowJTrajAction::Result::INVALID_GOAL);
     action_res->set__error_string("Current goal cancelled due to new incoming action.");
-    rt_active_goal_->setCanceled(action_res);
-    rt_active_goal_.reset();
+    active_goal->setCanceled(action_res);
+    clear_active_goal();
   }
 }
 


### PR DESCRIPTION
# Purpose
Addresses #132. Fixes a segfault that could occur in regular use of the joint_trajectory_controller, as exposed by the unit tests.

# Summary
There was a race condition in the JTC, where `rt_active_goal_` could be `reset()` in one thread (`joint_trajectory_controller.cpp:568`) but then dereferenced elsewhere. This would cause a segfault.

For example, in `JointTrajectoryController::update()`, we check that `rt_active_goal_` is non-null, and then dereference it a couple lines later. But if we get unlucky with timing, we can reset the shared_ptr in another thread in-between the non-null check and the dereference. We don't currently have the appropriate thread safety mecanisms in place.

By taking a copy of the `rt_active_goal_` shared ptr before checking and using it, we ensure the local copy will never becoming invalid while we're holding it. The `RealtimeBuffer` is required since we need to read and write to the shared ptr concurrently from multiple threads.

# Testing done
:heavy_check_mark: `colcon test --packages-select joint_trajectory_controller --retest-until-fail 100`