### PR TITLE
Bump action-ros-ci to v0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ros-tooling/setup-ros@v0.1
         with:
           required-ros-distributions: foxy
-      - uses: ros-tooling/action-ros-ci@v0.1
+      - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: foxy
           # build all packages listed in the meta package
@@ -46,7 +46,12 @@ jobs:
             velocity_controllers
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/.github/workspace.repos
-          colcon-mixin-name: coverage-gcc
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
# Purpose
Bump `ros-tooling/action-ros-ci` to v0.2

# Summary
Looks like the recent release of `ros-tooling/setup-ros` v0.1.3 pulled in a newer version of `colcon-mixin`, which elevated a warning to an error: https://github.com/ros-tooling/action-ros-ci/issues/525#issuecomment-775990829

This causes `ros-tooling/action-ros-ci` to fail out. The easiest approach is to just switch to the recently-released v0.2 and update our mixin rules according to https://github.com/ros-tooling/action-ros-ci/pull/591

# Testing To Do
 - [ ] CI passes
 - [ ] Code coverage still works