### PR TITLE
Migrate from deprecated controller_interface::return_type::SUCCESS -> OK

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -54,7 +54,7 @@ DiffDriveController::init(const std::string & controller_name)
 {
   // initialize lifecycle node
   auto ret = ControllerInterface::init(controller_name);
-  if (ret != controller_interface::return_type::SUCCESS) {
+  if (ret != controller_interface::return_type::OK) {
     return ret;
   }
 
@@ -113,7 +113,7 @@ DiffDriveController::init(const std::string & controller_name)
     return controller_interface::return_type::ERROR;
   }
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 InterfaceConfiguration DiffDriveController::command_interface_configuration() const
@@ -149,7 +149,7 @@ controller_interface::return_type DiffDriveController::update()
       halt();
       is_halted = true;
     }
-    return controller_interface::return_type::SUCCESS;
+    return controller_interface::return_type::OK;
   }
 
   const auto current_time = node_->get_clock()->now();
@@ -271,7 +271,7 @@ controller_interface::return_type DiffDriveController::update()
     registered_right_wheel_handles_[index].velocity.get().set_value(velocity_right);
   }
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &)

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -171,7 +171,7 @@ protected:
 TEST_F(TestDiffDriveController, configure_fails_without_parameters)
 {
   const auto ret = controller_->init(controller_name);
-  ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 }
@@ -179,7 +179,7 @@ TEST_F(TestDiffDriveController, configure_fails_without_parameters)
 TEST_F(TestDiffDriveController, configure_fails_with_only_left_or_only_right_side_defined)
 {
   const auto ret = controller_->init(controller_name);
-  ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
     rclcpp::Parameter(
@@ -207,7 +207,7 @@ TEST_F(TestDiffDriveController, configure_fails_with_only_left_or_only_right_sid
 TEST_F(TestDiffDriveController, configure_fails_with_mismatching_wheel_side_size)
 {
   const auto ret = controller_->init(controller_name);
-  ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
     rclcpp::Parameter(
@@ -227,7 +227,7 @@ TEST_F(TestDiffDriveController, configure_fails_with_mismatching_wheel_side_size
 TEST_F(TestDiffDriveController, configure_succeeds_when_wheels_are_specified)
 {
   const auto ret = controller_->init(controller_name);
-  ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
     rclcpp::Parameter(
@@ -251,7 +251,7 @@ TEST_F(TestDiffDriveController, configure_succeeds_when_wheels_are_specified)
 TEST_F(TestDiffDriveController, activate_fails_without_resources_assigned)
 {
   const auto ret = controller_->init(controller_name);
-  ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
     rclcpp::Parameter(
@@ -270,7 +270,7 @@ TEST_F(TestDiffDriveController, activate_fails_without_resources_assigned)
 TEST_F(TestDiffDriveController, activate_succeeds_with_resources_assigned)
 {
   const auto ret = controller_->init(controller_name);
-  ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
     rclcpp::Parameter(
@@ -290,7 +290,7 @@ TEST_F(TestDiffDriveController, activate_succeeds_with_resources_assigned)
 TEST_F(TestDiffDriveController, cleanup)
 {
   const auto ret = controller_->init(controller_name);
-  ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
     rclcpp::Parameter(
@@ -320,11 +320,11 @@ TEST_F(TestDiffDriveController, cleanup)
   publish(linear, angular);
   controller_->wait_for_twist(executor);
 
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   state = controller_->deactivate();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   state = controller_->cleanup();
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
@@ -339,7 +339,7 @@ TEST_F(TestDiffDriveController, cleanup)
 TEST_F(TestDiffDriveController, correct_initialization_using_parameters)
 {
   const auto ret = controller_->init(controller_name);
-  ASSERT_EQ(ret, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
     rclcpp::Parameter(
@@ -372,7 +372,7 @@ TEST_F(TestDiffDriveController, correct_initialization_using_parameters)
   // wait for msg is be published to the system
   ASSERT_TRUE(controller_->wait_for_twist(executor));
 
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
   EXPECT_EQ(1.0, left_wheel_vel_cmd_.get_value());
   EXPECT_EQ(1.0, right_wheel_vel_cmd_.get_value());
 
@@ -381,7 +381,7 @@ TEST_F(TestDiffDriveController, correct_initialization_using_parameters)
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
   state = controller_->deactivate();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   EXPECT_EQ(0.0, left_wheel_vel_cmd_.get_value()) << "Wheels are halted on deactivate()";
   EXPECT_EQ(0.0, right_wheel_vel_cmd_.get_value()) << "Wheels are halted on deactivate()";

--- a/effort_controllers/src/joint_group_effort_controller.cpp
+++ b/effort_controllers/src/joint_group_effort_controller.cpp
@@ -35,7 +35,7 @@ JointGroupEffortController::init(
   const std::string & controller_name)
 {
   auto ret = ForwardCommandController::init(controller_name);
-  if (ret != controller_interface::return_type::SUCCESS) {
+  if (ret != controller_interface::return_type::OK) {
     return ret;
   }
 
@@ -47,7 +47,7 @@ JointGroupEffortController::init(
     return controller_interface::return_type::ERROR;
   }
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 CallbackReturn JointGroupEffortController::on_deactivate(

--- a/effort_controllers/test/test_joint_group_effort_controller.cpp
+++ b/effort_controllers/test/test_joint_group_effort_controller.cpp
@@ -64,7 +64,7 @@ void JointGroupEffortControllerTest::TearDown()
 void JointGroupEffortControllerTest::SetUpController()
 {
   const auto result = controller_->init("group_effort_controller");
-  ASSERT_EQ(result, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
   command_ifs.emplace_back(joint_1_cmd_);
@@ -123,7 +123,7 @@ TEST_F(JointGroupEffortControllerTest, CommandSuccessTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful though no command has been send yet
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands are still the default ones
   ASSERT_EQ(joint_1_cmd_.get_value(), 1.1);
@@ -137,7 +137,7 @@ TEST_F(JointGroupEffortControllerTest, CommandSuccessTest)
   controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
 
   // update successful, command received
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands have been modified
   ASSERT_EQ(joint_1_cmd_.get_value(), 10.0);
@@ -173,7 +173,7 @@ TEST_F(JointGroupEffortControllerTest, NoCommandCheckTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful, no command received yet
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands are still the default ones
   ASSERT_EQ(joint_1_cmd_.get_value(), 1.1);
@@ -213,7 +213,7 @@ TEST_F(JointGroupEffortControllerTest, CommandCallbackTest)
   rclcpp::spin_some(controller_->get_node()->get_node_base_interface());
 
   // update successful
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check command in handle was set
   ASSERT_EQ(joint_1_cmd_.get_value(), 10.0);

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -38,7 +38,7 @@ controller_interface::return_type
 ForwardCommandController::init(const std::string & controller_name)
 {
   auto ret = ControllerInterface::init(controller_name);
-  if (ret != controller_interface::return_type::SUCCESS) {
+  if (ret != controller_interface::return_type::OK) {
     return ret;
   }
 
@@ -52,7 +52,7 @@ ForwardCommandController::init(const std::string & controller_name)
     return controller_interface::return_type::ERROR;
   }
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 CallbackReturn ForwardCommandController::on_configure(
@@ -158,7 +158,7 @@ controller_interface::return_type ForwardCommandController::update()
 
   // no command received yet
   if (!joint_commands || !(*joint_commands)) {
-    return controller_interface::return_type::SUCCESS;
+    return controller_interface::return_type::OK;
   }
 
   if ((*joint_commands)->data.size() != command_interfaces_.size()) {
@@ -175,7 +175,7 @@ controller_interface::return_type ForwardCommandController::update()
     command_interfaces_[index].set_value((*joint_commands)->data[index]);
   }
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 }  // namespace forward_command_controller

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -72,7 +72,7 @@ void ForwardCommandControllerTest::TearDown()
 void ForwardCommandControllerTest::SetUpController()
 {
   const auto result = controller_->init("forward_command_controller");
-  ASSERT_EQ(result, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
   command_ifs.emplace_back(joint_1_pos_cmd_);
@@ -187,7 +187,7 @@ TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful though no command has been send yet
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands are still the default ones
   ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
@@ -201,7 +201,7 @@ TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
   controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
 
   // update successful, command received
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands have been modified
   ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);
@@ -244,7 +244,7 @@ TEST_F(ForwardCommandControllerTest, NoCommandCheckTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful, no command received yet
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands are still the default ones
   ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
@@ -286,7 +286,7 @@ TEST_F(ForwardCommandControllerTest, CommandCallbackTest)
   rclcpp::spin_some(controller_->get_node()->get_node_base_interface());
 
   // update successful
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check command in handle was set
   ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -226,7 +226,7 @@ JointStateBroadcaster::update()
   joint_state_publisher_->publish(joint_state_msg_);
   dynamic_joint_state_publisher_->publish(dynamic_joint_state_msg_);
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 }  // namespace joint_state_broadcaster

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -82,7 +82,7 @@ void JointStateBroadcasterTest::TearDown()
 void JointStateBroadcasterTest::SetUpStateBroadcaster()
 {
   const auto result = state_broadcaster_->init("joint_state_broadcaster");
-  ASSERT_EQ(result, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedStateInterface> state_ifs;
   state_ifs.emplace_back(joint_1_pos_state_);
@@ -195,7 +195,7 @@ TEST_F(JointStateBroadcasterTest, UpdateTest)
   auto node_state = state_broadcaster_->configure();
   node_state = state_broadcaster_->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
-  ASSERT_EQ(state_broadcaster_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(state_broadcaster_->update(), controller_interface::return_type::OK);
 }
 
 TEST_F(JointStateBroadcasterTest, JointStatePublishTest)
@@ -217,7 +217,7 @@ TEST_F(JointStateBroadcasterTest, JointStatePublishTest)
     10,
     subs_callback);
 
-  ASSERT_EQ(state_broadcaster_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(state_broadcaster_->update(), controller_interface::return_type::OK);
 
   // wait for message to be passed
   ASSERT_EQ(wait_for(subscription), rclcpp::WaitResultKind::Ready);
@@ -257,7 +257,7 @@ TEST_F(JointStateBroadcasterTest, DynamicJointStatePublishTest)
     10,
     subs_callback);
 
-  ASSERT_EQ(state_broadcaster_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(state_broadcaster_->update(), controller_interface::return_type::OK);
 
   // wait for message to be passed
   ASSERT_EQ(wait_for(subscription), rclcpp::WaitResultKind::Ready);

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -58,7 +58,7 @@ JointTrajectoryController::init(const std::string & controller_name)
 {
   // initialize lifecycle node
   const auto ret = ControllerInterface::init(controller_name);
-  if (ret != controller_interface::return_type::SUCCESS) {
+  if (ret != controller_interface::return_type::OK) {
     return ret;
   }
 
@@ -70,7 +70,7 @@ JointTrajectoryController::init(const std::string & controller_name)
   node_->declare_parameter<double>("constraints.stopped_velocity_tolerance", 0.01);
   node_->declare_parameter<double>("constraints.goal_time", 0.0);
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 controller_interface::InterfaceConfiguration JointTrajectoryController::
@@ -106,7 +106,7 @@ JointTrajectoryController::update()
       halt();
       is_halted = true;
     }
-    return controller_interface::return_type::SUCCESS;
+    return controller_interface::return_type::OK;
   }
 
   auto resize_joint_trajectory_point =
@@ -247,7 +247,7 @@ JointTrajectoryController::update()
   }
 
   publish_state(state_desired, state_current, state_error);
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -95,7 +95,7 @@ TEST_F(TestTrajectoryController, configuration) {
 //   auto traj_controller = std::make_shared<ros_controllers::JointTrajectoryController>(
 //     joint_names_, op_mode_);
 //   auto ret = traj_controller->init(test_robot_, controller_name_);
-//   if (ret != controller_interface::return_type::SUCCESS) {
+//   if (ret != controller_interface::return_type::OK) {
 //     FAIL();
 //   }
 //
@@ -137,7 +137,7 @@ TEST_F(TestTrajectoryController, configuration) {
 //   auto traj_controller = std::make_shared<ros_controllers::JointTrajectoryController>(
 //     joint_names_, op_mode_);
 //   auto ret = traj_controller->init(test_robot_, controller_name_);
-//   if (ret != controller_interface::return_type::SUCCESS) {
+//   if (ret != controller_interface::return_type::OK) {
 //     FAIL();
 //   }
 //

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -103,7 +103,7 @@ protected:
       traj_controller_->set_joint_names(joint_names_);
     }
     auto ret = traj_controller_->init(controller_name_);
-    if (ret != controller_interface::return_type::SUCCESS) {
+    if (ret != controller_interface::return_type::OK) {
       FAIL();
     }
   }

--- a/position_controllers/src/joint_group_position_controller.cpp
+++ b/position_controllers/src/joint_group_position_controller.cpp
@@ -34,7 +34,7 @@ controller_interface::return_type
 JointGroupPositionController::init(const std::string & controller_name)
 {
   auto ret = ForwardCommandController::init(controller_name);
-  if (ret != controller_interface::return_type::SUCCESS) {
+  if (ret != controller_interface::return_type::OK) {
     return ret;
   }
 
@@ -46,7 +46,7 @@ JointGroupPositionController::init(const std::string & controller_name)
     return controller_interface::return_type::ERROR;
   }
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 }  // namespace position_controllers
 

--- a/position_controllers/test/test_joint_group_position_controller.cpp
+++ b/position_controllers/test/test_joint_group_position_controller.cpp
@@ -64,7 +64,7 @@ void JointGroupPositionControllerTest::TearDown()
 void JointGroupPositionControllerTest::SetUpController()
 {
   const auto result = controller_->init("test_joint_group_position_controller");
-  ASSERT_EQ(result, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
   command_ifs.emplace_back(joint_1_pos_cmd_);
@@ -123,7 +123,7 @@ TEST_F(JointGroupPositionControllerTest, CommandSuccessTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful though no command has been send yet
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands are still the default ones
   ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
@@ -137,7 +137,7 @@ TEST_F(JointGroupPositionControllerTest, CommandSuccessTest)
   controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
 
   // update successful, command received
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands have been modified
   ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);
@@ -173,7 +173,7 @@ TEST_F(JointGroupPositionControllerTest, NoCommandCheckTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful, no command received yet
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands are still the default ones
   ASSERT_EQ(joint_1_pos_cmd_.get_value(), 1.1);
@@ -213,7 +213,7 @@ TEST_F(JointGroupPositionControllerTest, CommandCallbackTest)
   rclcpp::spin_some(controller_->get_node()->get_node_base_interface());
 
   // update successful
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check command in handle was set
   ASSERT_EQ(joint_1_pos_cmd_.get_value(), 10.0);

--- a/velocity_controllers/src/joint_group_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_group_velocity_controller.cpp
@@ -35,7 +35,7 @@ JointGroupVelocityController::init(
   const std::string & controller_name)
 {
   auto ret = ForwardCommandController::init(controller_name);
-  if (ret != controller_interface::return_type::SUCCESS) {
+  if (ret != controller_interface::return_type::OK) {
     return ret;
   }
 
@@ -47,7 +47,7 @@ JointGroupVelocityController::init(
     return controller_interface::return_type::ERROR;
   }
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 CallbackReturn JointGroupVelocityController::on_deactivate(

--- a/velocity_controllers/test/test_joint_group_velocity_controller.cpp
+++ b/velocity_controllers/test/test_joint_group_velocity_controller.cpp
@@ -64,7 +64,7 @@ void JointGroupVelocityControllerTest::TearDown()
 void JointGroupVelocityControllerTest::SetUpController()
 {
   const auto result = controller_->init("group_velocity_controller");
-  ASSERT_EQ(result, controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
   command_ifs.emplace_back(joint_1_cmd_);
@@ -123,7 +123,7 @@ TEST_F(JointGroupVelocityControllerTest, CommandSuccessTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful though no command has been send yet
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands are still the default ones
   ASSERT_EQ(joint_1_cmd_.get_value(), 1.1);
@@ -137,7 +137,7 @@ TEST_F(JointGroupVelocityControllerTest, CommandSuccessTest)
   controller_->rt_command_ptr_.writeFromNonRT(command_ptr);
 
   // update successful, command received
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands have been modified
   ASSERT_EQ(joint_1_cmd_.get_value(), 10.0);
@@ -173,7 +173,7 @@ TEST_F(JointGroupVelocityControllerTest, NoCommandCheckTest)
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   // update successful, no command received yet
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check joint commands are still the default ones
   ASSERT_EQ(joint_1_cmd_.get_value(), 1.1);
@@ -213,7 +213,7 @@ TEST_F(JointGroupVelocityControllerTest, CommandCallbackTest)
   rclcpp::spin_some(controller_->get_node()->get_node_base_interface());
 
   // update successful
-  ASSERT_EQ(controller_->update(), controller_interface::return_type::SUCCESS);
+  ASSERT_EQ(controller_->update(), controller_interface::return_type::OK);
 
   // check command in handle was set
   ASSERT_EQ(joint_1_cmd_.get_value(), 10.0);


### PR DESCRIPTION
Following up on https://github.com/ros-controls/ros2_control/pull/374 and https://github.com/ros-controls/ros2_control/pull/375