### PR TITLE
Remove unused variable

### DIFF
--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -323,7 +323,6 @@ TEST_F(JointStateBroadcasterTest, ExtraJointStatePublishTest)
   all_joint_names.insert(all_joint_names.end(), extra_joint_names.begin(), extra_joint_names.end());
   const size_t NUM_JOINTS = all_joint_names.size();
   const std::vector<std::string> IF_NAMES = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
-  const size_t NUM_IFS = IF_NAMES.size();
 
   // joint state initialized
   ASSERT_THAT(state_broadcaster_->joint_state_msg_.name, ElementsAreArray(all_joint_names));


### PR DESCRIPTION
as per title

```
workspace/ros2/ros2_control_ws/src/ros-controls/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:326:16: error: unused variable ‘NUM_IFS’ [-Werror=unused-variable]
  326 |   const size_t NUM_IFS = IF_NAMES.size();
```