### PR TITLE
Reset external trajectory message upon activation

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -148,7 +148,7 @@ JointTrajectoryController::update()
   state_current.time_from_start.set__sec(0);
 
   // currently carrying out a trajectory
-  if (traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_trajectory_msg() == false) {
+  if (traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_trajectory_msg()) {
     // if sampling the first time, set the point before you sample
     if (!(*traj_point_active_ptr_)->is_sampled_already()) {
       (*traj_point_active_ptr_)->set_point_before_trajectory_msg(
@@ -427,6 +427,7 @@ JointTrajectoryController::on_activate(const rclcpp_lifecycle::State &)
 
   traj_external_point_ptr_ = std::make_shared<Trajectory>();
   traj_home_point_ptr_ = std::make_shared<Trajectory>();
+  traj_msg_external_point_ptr_.writeFromNonRT(std::shared_ptr<trajectory_msgs::msg::JointTrajectory>());
 
   is_halted = false;
   subscriber_is_active_ = true;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -427,7 +427,8 @@ JointTrajectoryController::on_activate(const rclcpp_lifecycle::State &)
 
   traj_external_point_ptr_ = std::make_shared<Trajectory>();
   traj_home_point_ptr_ = std::make_shared<Trajectory>();
-  traj_msg_external_point_ptr_.writeFromNonRT(std::shared_ptr<trajectory_msgs::msg::JointTrajectory>());
+  traj_msg_external_point_ptr_.writeFromNonRT(
+    std::shared_ptr<trajectory_msgs::msg::JointTrajectory>());
 
   is_halted = false;
   subscriber_is_active_ = true;

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -296,7 +296,7 @@ Trajectory::time_from_start() const
 bool
 Trajectory::has_trajectory_msg() const
 {
-  return trajectory_msg_.get() != 0;
+  return trajectory_msg_.get() != nullptr;
 }
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -296,7 +296,7 @@ Trajectory::time_from_start() const
 bool
 Trajectory::has_trajectory_msg() const
 {
-  return !trajectory_msg_;
+  return trajectory_msg_.get() != 0;
 }
 
 }  // namespace joint_trajectory_controller


### PR DESCRIPTION
Reset external trajectory message to prevent preserving the old goal on systems with hardware offsets

- Fix has_trajectory_msg() function: two wrongs were making a right so functionally things were fine