### PR TITLE
[JTC] Allow integration of states in goal trajectories

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -129,6 +129,8 @@ protected:
   /// This is useful when robot is not exactly following the commanded trajectory.
   bool open_loop_control_ = false;
   trajectory_msgs::msg::JointTrajectoryPoint last_commanded_state_;
+  /// Allow integration in goal trajectories to accept goals without position or velocity specified
+  bool allow_integration_in_goal_trajectories_ = false;
 
   // The interfaces are defined as the types in 'allowed_interface_types_' member.
   // For convenience, for each type the interfaces are ordered so that i-th position

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -58,7 +58,7 @@ public:
   /// Find the segment (made up of 2 points) and its expected state from the
   /// containing trajectory.
   /**
-   * Samping trajector at given \p sample_time.
+   * Sampling trajectory at given \p sample_time.
    * If position in the \p end_segment_itr is missing it will be deduced from provided velocity, or acceleration respectively.
    * Deduction assumes that the provided velocity or acceleration have to be reached at the time defined in the segment.
    *

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -58,18 +58,27 @@ public:
   /// Find the segment (made up of 2 points) and its expected state from the
   /// containing trajectory.
   /**
-  * Specific case returns for start_segment_itr and end_segment_itr:
-  * - Sampling before the trajectory start:
-  *   start_segment_itr = begin(), end_segment_itr = begin()
-  * - Sampling exactly on a point of the trajectory:
-  *    start_segment_itr = iterator where point is, end_segment_itr = iterator after start_segment_itr
-  * - Sampling between points:
-  *    start_segment_itr = iterator before the sampled point, end_segment_itr = iterator after start_segment_itr
-  * - Sampling after entire trajectory:
-  *    start_segment_itr = --end(), end_segment_itr = end()
-  * - Sampling empty msg or before the time given in set_point_before_trajectory_msg()
-  *    return false
-  */
+   * Samping trajector at given \p sample_time.
+   * If position in the \p end_segment_itr is missing it will be deduced from provided velocity, or acceleration respectively.
+   * Deduction assumes that the provided velocity or acceleration have to be reached at the time defined in the segment.
+   *
+   * Specific case returns for start_segment_itr and end_segment_itr:
+   * - Sampling before the trajectory start:
+   *   start_segment_itr = begin(), end_segment_itr = begin()
+   * - Sampling exactly on a point of the trajectory:
+   *    start_segment_itr = iterator where point is, end_segment_itr = iterator after start_segment_itr
+   * - Sampling between points:
+   *    start_segment_itr = iterator before the sampled point, end_segment_itr = iterator after start_segment_itr
+   * - Sampling after entire trajectory:
+   *    start_segment_itr = --end(), end_segment_itr = end()
+   * - Sampling empty msg or before the time given in set_point_before_trajectory_msg()
+   *    return false
+   *
+   * \param[in] sample_time Time at which trajectory will be sampled.
+   * \param[out] expected_state Calculated new at \p sample_time.
+   * \param[out] start_segment_itr Iterator to the start segment for given \p sample_time. See description above.
+   * \param[out] end_segment_itr Iterator to the end segment for given \p sample_time. See description above.
+   */
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   bool sample(
     const rclcpp::Time & sample_time, trajectory_msgs::msg::JointTrajectoryPoint & output_state,

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -134,6 +134,11 @@ public:
   bool is_sampled_already() const { return sampled_already_; }
 
 private:
+  void deduce_from_derivatives(
+    trajectory_msgs::msg::JointTrajectoryPoint & first_state,
+    trajectory_msgs::msg::JointTrajectoryPoint & second_state, const size_t dim,
+    const double delta_t);
+
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg_;
   rclcpp::Time trajectory_start_time_;
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -62,6 +62,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
     auto_declare<double>("action_monitor_rate", 20.0);
     auto_declare<bool>("allow_partial_joints_goal", allow_partial_joints_goal_);
     auto_declare<bool>("open_loop_control", open_loop_control_);
+    auto_declare<bool>("allow_integration_in_goal_trajectories", allow_integration_in_goal_trajectories_);
     auto_declare<double>("constraints.stopped_velocity_tolerance", 0.01);
     auto_declare<double>("constraints.goal_time", 0.0);
   }
@@ -138,6 +139,7 @@ controller_interface::return_type JointTrajectoryController::update(
   {
     fill_partial_goal(*new_external_msg);
     sort_to_local_joint_order(*new_external_msg);
+    // TODO(denis): Add here integration of position and velocity
     traj_external_point_ptr_->update(*new_external_msg);
   }
 
@@ -659,6 +661,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
 
   // Read parameters customizing controller for special cases
   open_loop_control_ = node_->get_parameter("open_loop_control").get_value<bool>();
+  allow_integration_in_goal_trajectories_ =
+    node_->get_parameter("allow_integration_in_goal_trajectories").get_value<bool>();
 
   // subscriber callback
   // non realtime

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -180,7 +180,6 @@ controller_interface::return_type JointTrajectoryController::update(
 
     // find segment for current timestamp
     TrajectoryPointConstIter start_segment_itr, end_segment_itr;
-    // TODO(anyone): this is kind-of open-loop concept? I am right?
     const bool valid_point =
       (*traj_point_active_ptr_)->sample(time, state_desired, start_segment_itr, end_segment_itr);
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -966,6 +966,9 @@ rclcpp_action::GoalResponse JointTrajectoryController::goal_callback(
     return rclcpp_action::GoalResponse::REJECT;
   }
 
+  // TODO(denis): is here the following line missing?
+//   add_new_trajectory_msg(std::make_shared(goal->trajectory));
+
   RCLCPP_INFO(node_->get_logger(), "Accepted new action goal");
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
@@ -1208,11 +1211,26 @@ bool JointTrajectoryController::validate_trajectory_msg(
 
     const size_t joint_count = trajectory.joint_names.size();
     const auto & points = trajectory.points;
-    if (
+    // TODO(anyone): This currently supports only position, velocity and acceleration inputs
+    if (allow_integration_in_goal_trajectories_) {
+      const bool all_empty = points[i].positions.empty() && points[i].velocities.empty() &&
+        points[i].accelerations.empty();
+      const bool position_error = !points[i].positions.empty() &&
+        !validate_trajectory_point_field(joint_count, points[i].positions, "positions", i, false);
+      const bool velocity_error = !points[i].velocities.empty() &&
+        !validate_trajectory_point_field(joint_count, points[i].velocities, "velocities", i, false);
+      const bool acceleration_error = !points[i].accelerations.empty() &&
+        !validate_trajectory_point_field(
+        joint_count, points[i].accelerations, "accelerations", i, false);
+      if (all_empty || position_error || velocity_error || acceleration_error) {
+        return false;
+      }
+    } else if (
       !validate_trajectory_point_field(joint_count, points[i].positions, "positions", i, false) ||
       !validate_trajectory_point_field(joint_count, points[i].velocities, "velocities", i, true) ||
       !validate_trajectory_point_field(
         joint_count, points[i].accelerations, "accelerations", i, true) ||
+      // TODO(denis): should this be deleted, since effort goals are not supported?
       !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true))
     {
       return false;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -967,9 +967,6 @@ rclcpp_action::GoalResponse JointTrajectoryController::goal_callback(
     return rclcpp_action::GoalResponse::REJECT;
   }
 
-  // TODO(denis): is here the following line missing?
-  //   add_new_trajectory_msg(std::make_shared(goal->trajectory));
-
   RCLCPP_INFO(node_->get_logger(), "Accepted new action goal");
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
@@ -1212,7 +1209,7 @@ bool JointTrajectoryController::validate_trajectory_msg(
 
     const size_t joint_count = trajectory.joint_names.size();
     const auto & points = trajectory.points;
-    // TODO(anyone): This currently supports only position, velocity and acceleration inputs
+    // This currently supports only position, velocity and acceleration inputs
     if (allow_integration_in_goal_trajectories_)
     {
       const bool all_empty = points[i].positions.empty() && points[i].velocities.empty() &&
@@ -1237,7 +1234,6 @@ bool JointTrajectoryController::validate_trajectory_msg(
       !validate_trajectory_point_field(joint_count, points[i].velocities, "velocities", i, true) ||
       !validate_trajectory_point_field(
         joint_count, points[i].accelerations, "accelerations", i, true) ||
-      // TODO(denis): should this be deleted, since effort goals are not supported?
       !validate_trajectory_point_field(joint_count, points[i].effort, "effort", i, true))
     {
       return false;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -62,7 +62,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
     auto_declare<double>("action_monitor_rate", 20.0);
     auto_declare<bool>("allow_partial_joints_goal", allow_partial_joints_goal_);
     auto_declare<bool>("open_loop_control", open_loop_control_);
-    auto_declare<bool>("allow_integration_in_goal_trajectories", allow_integration_in_goal_trajectories_);
+    auto_declare<bool>(
+      "allow_integration_in_goal_trajectories", allow_integration_in_goal_trajectories_);
     auto_declare<double>("constraints.stopped_velocity_tolerance", 0.01);
     auto_declare<double>("constraints.goal_time", 0.0);
   }
@@ -967,7 +968,7 @@ rclcpp_action::GoalResponse JointTrajectoryController::goal_callback(
   }
 
   // TODO(denis): is here the following line missing?
-//   add_new_trajectory_msg(std::make_shared(goal->trajectory));
+  //   add_new_trajectory_msg(std::make_shared(goal->trajectory));
 
   RCLCPP_INFO(node_->get_logger(), "Accepted new action goal");
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
@@ -1212,20 +1213,26 @@ bool JointTrajectoryController::validate_trajectory_msg(
     const size_t joint_count = trajectory.joint_names.size();
     const auto & points = trajectory.points;
     // TODO(anyone): This currently supports only position, velocity and acceleration inputs
-    if (allow_integration_in_goal_trajectories_) {
+    if (allow_integration_in_goal_trajectories_)
+    {
       const bool all_empty = points[i].positions.empty() && points[i].velocities.empty() &&
-        points[i].accelerations.empty();
-      const bool position_error = !points[i].positions.empty() &&
+                             points[i].accelerations.empty();
+      const bool position_error =
+        !points[i].positions.empty() &&
         !validate_trajectory_point_field(joint_count, points[i].positions, "positions", i, false);
-      const bool velocity_error = !points[i].velocities.empty() &&
+      const bool velocity_error =
+        !points[i].velocities.empty() &&
         !validate_trajectory_point_field(joint_count, points[i].velocities, "velocities", i, false);
-      const bool acceleration_error = !points[i].accelerations.empty() &&
+      const bool acceleration_error =
+        !points[i].accelerations.empty() &&
         !validate_trajectory_point_field(
-        joint_count, points[i].accelerations, "accelerations", i, false);
-      if (all_empty || position_error || velocity_error || acceleration_error) {
+          joint_count, points[i].accelerations, "accelerations", i, false);
+      if (all_empty || position_error || velocity_error || acceleration_error)
+      {
         return false;
       }
-    } else if (
+    }
+    else if (
       !validate_trajectory_point_field(joint_count, points[i].positions, "positions", i, false) ||
       !validate_trajectory_point_field(joint_count, points[i].velocities, "velocities", i, true) ||
       !validate_trajectory_point_field(

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -88,42 +88,50 @@ bool Trajectory::sample(
     return false;
   }
 
-  auto deduce_from_derivatives = [&](trajectory_msgs::msg::JointTrajectoryPoint & first_state,
-      trajectory_msgs::msg::JointTrajectoryPoint & second_state,
-      const size_t dim, const double delta_t)
+  auto deduce_from_derivatives = [&](
+                                   trajectory_msgs::msg::JointTrajectoryPoint & first_state,
+                                   trajectory_msgs::msg::JointTrajectoryPoint & second_state,
+                                   const size_t dim, const double delta_t) {
+    if (second_state.positions.empty())
     {
-      if (second_state.positions.empty()) {
-        second_state.positions.resize(dim);
-        if (first_state.velocities.empty()) {
-          first_state.velocities.resize(dim, 0.0);
+      second_state.positions.resize(dim);
+      if (first_state.velocities.empty())
+      {
+        first_state.velocities.resize(dim, 0.0);
+      }
+      if (second_state.velocities.empty())
+      {
+        second_state.velocities.resize(dim);
+        if (first_state.accelerations.empty())
+        {
+          first_state.accelerations.resize(dim, 0.0);
         }
-        if (second_state.velocities.empty()) {
-          second_state.velocities.resize(dim);
-          if (first_state.accelerations.empty()) {
-            first_state.accelerations.resize(dim, 0.0);
-          }
-          for (size_t i = 0; i < dim; ++i) {
-            second_state.velocities[i] = first_state.velocities[i] +
-              (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
-          }
-        }
-        for (size_t i = 0; i < dim; ++i) {
-          // second state velocity should be reached on the end of the segment, so use middle
-          second_state.positions[i] = first_state.positions[i] +
-            (first_state.velocities[i] + second_state.velocities[i]) * 0.5 * delta_t;
+        for (size_t i = 0; i < dim; ++i)
+        {
+          second_state.velocities[i] =
+            first_state.velocities[i] +
+            (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
         }
       }
-    };
+      for (size_t i = 0; i < dim; ++i)
+      {
+        // second state velocity should be reached on the end of the segment, so use middle
+        second_state.positions[i] =
+          first_state.positions[i] +
+          (first_state.velocities[i] + second_state.velocities[i]) * 0.5 * delta_t;
+      }
+    }
+  };
 
   // current time hasn't reached traj time of the first point in the msg yet
   auto & first_point_in_msg = trajectory_msg_->points[0];
   const rclcpp::Time first_point_timestamp =
     trajectory_start_time_ + first_point_in_msg.time_from_start;
 
-  if (sample_time < first_point_timestamp) {
+  if (sample_time < first_point_timestamp)
+  {
     deduce_from_derivatives(
-      state_before_traj_msg_, first_point_in_msg,
-      state_before_traj_msg_.positions.size(),
+      state_before_traj_msg_, first_point_in_msg, state_before_traj_msg_.positions.size(),
       (first_point_timestamp - time_before_traj_msg_).seconds());
 
     interpolate_between_points(
@@ -139,20 +147,17 @@ bool Trajectory::sample(
   const auto last_idx = trajectory_msg_->points.size() - 1;
   for (size_t i = 0; i < last_idx; ++i)
   {
-    const auto & point = trajectory_msg_->points[i];
-    const auto & next_point = trajectory_msg_->points[i + 1];
+    auto & point = trajectory_msg_->points[i];
+    auto & next_point = trajectory_msg_->points[i + 1];
 
     const rclcpp::Time t0 = trajectory_start_time_ + point.time_from_start;
     const rclcpp::Time t1 = trajectory_start_time_ + next_point.time_from_start;
 
-    if (sample_time >= t0 && sample_time < t1) {
-      deduce_from_derivatives(
-        point, next_point,
-        state_before_traj_msg_.positions.size(),
-        (t1 - t0).seconds());
-
     if (sample_time >= t0 && sample_time < t1)
     {
+      deduce_from_derivatives(
+        point, next_point, state_before_traj_msg_.positions.size(), (t1 - t0).seconds());
+
       interpolate_between_points(t0, point, t1, next_point, sample_time, output_state);
 
       start_segment_itr = begin() + i;

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -88,20 +88,20 @@ bool Trajectory::sample(
     return false;
   }
 
-  auto add_missing_states = [&](trajectory_msgs::msg::JointTrajectoryPoint & first_state,
+  auto deduce_from_derivaties = [&](trajectory_msgs::msg::JointTrajectoryPoint & first_state,
       trajectory_msgs::msg::JointTrajectoryPoint & second_state,
       const size_t dim, const double delta_t)
     {
-      if (first_state.velocities.empty()) {
-        first_state.velocities.resize(dim, 0.0);
-      }
-      if (first_state.accelerations.empty()) {
-        first_state.accelerations.resize(dim, 0.0);
-      }
       if (second_state.positions.empty()) {
         second_state.positions.resize(dim);
+        if (first_state.velocities.empty()) {
+          first_state.velocities.resize(dim, 0.0);
+        }
         if (second_state.velocities.empty()) {
           second_state.velocities.resize(dim);
+          if (first_state.accelerations.empty()) {
+            first_state.accelerations.resize(dim, 0.0);
+          }
           for (size_t i = 0; i < dim; ++i) {
             second_state.velocities[i] = first_state.velocities[i] +
               (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
@@ -119,18 +119,17 @@ bool Trajectory::sample(
   auto & first_point_in_msg = trajectory_msg_->points[0];
   const rclcpp::Time first_point_timestamp =
     trajectory_start_time_ + first_point_in_msg.time_from_start;
+
   if (sample_time < first_point_timestamp) {
-    trajectory_msgs::msg::JointTrajectoryPoint state_before = state_before_traj_msg_;
-    if (integrate_missing_states) {
-      add_missing_states(
-        state_before, first_point_in_msg,
-        state_before_traj_msg_.positions.size(),
-        (first_point_timestamp - time_before_traj_msg_).seconds());
-    }
+    deduce_from_derivaties(
+      state_before_traj_msg_, first_point_in_msg,
+      state_before_traj_msg_.positions.size(),
+      (first_point_timestamp - time_before_traj_msg_).seconds());
 
     interpolate_between_points(
-      time_before_traj_msg_, state_before, first_point_timestamp, first_point_in_msg,
+      time_before_traj_msg_, state_before_traj_msg_, first_point_timestamp, first_point_in_msg,
       sample_time, output_state);
+
     start_segment_itr = begin();  // no segments before the first
     end_segment_itr = begin();
     return true;
@@ -146,16 +145,16 @@ bool Trajectory::sample(
     const rclcpp::Time t0 = trajectory_start_time_ + point.time_from_start;
     const rclcpp::Time t1 = trajectory_start_time_ + next_point.time_from_start;
 
-    if (integrate_missing_states) {
-      add_missing_states(
+    if (sample_time >= t0 && sample_time < t1) {
+      deduce_from_derivaties(
         point, next_point,
         state_before_traj_msg_.positions.size(),
         (t1 - t0).seconds());
-    }
 
     if (sample_time >= t0 && sample_time < t1)
     {
       interpolate_between_points(t0, point, t1, next_point, sample_time, output_state);
+
       start_segment_itr = begin() + i;
       end_segment_itr = begin() + (i + 1);
       return true;

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -88,7 +88,7 @@ bool Trajectory::sample(
     return false;
   }
 
-  auto deduce_from_derivaties = [&](trajectory_msgs::msg::JointTrajectoryPoint & first_state,
+  auto deduce_from_derivatives = [&](trajectory_msgs::msg::JointTrajectoryPoint & first_state,
       trajectory_msgs::msg::JointTrajectoryPoint & second_state,
       const size_t dim, const double delta_t)
     {
@@ -121,7 +121,7 @@ bool Trajectory::sample(
     trajectory_start_time_ + first_point_in_msg.time_from_start;
 
   if (sample_time < first_point_timestamp) {
-    deduce_from_derivaties(
+    deduce_from_derivatives(
       state_before_traj_msg_, first_point_in_msg,
       state_before_traj_msg_.positions.size(),
       (first_point_timestamp - time_before_traj_msg_).seconds());
@@ -146,7 +146,7 @@ bool Trajectory::sample(
     const rclcpp::Time t1 = trajectory_start_time_ + next_point.time_from_start;
 
     if (sample_time >= t0 && sample_time < t1) {
-      deduce_from_derivaties(
+      deduce_from_derivatives(
         point, next_point,
         state_before_traj_msg_.positions.size(),
         (t1 - t0).seconds());

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -88,17 +88,49 @@ bool Trajectory::sample(
     return false;
   }
 
+  auto add_missing_states = [&](trajectory_msgs::msg::JointTrajectoryPoint & first_state,
+      trajectory_msgs::msg::JointTrajectoryPoint & second_state,
+      const size_t dim, const double delta_t)
+    {
+      if (first_state.velocities.empty()) {
+        first_state.velocities.resize(dim, 0.0);
+      }
+      if (first_state.accelerations.empty()) {
+        first_state.accelerations.resize(dim, 0.0);
+      }
+      if (second_state.positions.empty()) {
+        second_state.positions.resize(dim);
+        if (second_state.velocities.empty()) {
+          second_state.velocities.resize(dim);
+          for (size_t i = 0; i < dim; ++i) {
+            second_state.velocities[i] = first_state.velocities[i] +
+              (first_state.accelerations[i] + second_state.accelerations[i]) * 0.5 * delta_t;
+          }
+        }
+        for (size_t i = 0; i < dim; ++i) {
+          // second state velocity should be reached on the end of the segment, so use middle
+          second_state.positions[i] = first_state.positions[i] +
+            (first_state.velocities[i] + second_state.velocities[i]) * 0.5 * delta_t;
+        }
+      }
+    };
+
   // current time hasn't reached traj time of the first point in the msg yet
-  const auto & first_point_in_msg = trajectory_msg_->points[0];
-  const rclcpp::Duration offset = first_point_in_msg.time_from_start;
-  const rclcpp::Time first_point_timestamp = trajectory_start_time_ + offset;
-  if (sample_time < first_point_timestamp)
-  {
-    const rclcpp::Time t0 = time_before_traj_msg_;
+  auto & first_point_in_msg = trajectory_msg_->points[0];
+  const rclcpp::Time first_point_timestamp =
+    trajectory_start_time_ + first_point_in_msg.time_from_start;
+  if (sample_time < first_point_timestamp) {
+    trajectory_msgs::msg::JointTrajectoryPoint state_before = state_before_traj_msg_;
+    if (integrate_missing_states) {
+      add_missing_states(
+        state_before, first_point_in_msg,
+        state_before_traj_msg_.positions.size(),
+        (first_point_timestamp - time_before_traj_msg_).seconds());
+    }
 
     interpolate_between_points(
-      t0, state_before_traj_msg_, first_point_timestamp, first_point_in_msg, sample_time,
-      output_state);
+      time_before_traj_msg_, state_before, first_point_timestamp, first_point_in_msg,
+      sample_time, output_state);
     start_segment_itr = begin();  // no segments before the first
     end_segment_itr = begin();
     return true;
@@ -111,10 +143,15 @@ bool Trajectory::sample(
     const auto & point = trajectory_msg_->points[i];
     const auto & next_point = trajectory_msg_->points[i + 1];
 
-    const rclcpp::Duration t0_offset = point.time_from_start;
-    const rclcpp::Duration t1_offset = next_point.time_from_start;
-    const rclcpp::Time t0 = trajectory_start_time_ + t0_offset;
-    const rclcpp::Time t1 = trajectory_start_time_ + t1_offset;
+    const rclcpp::Time t0 = trajectory_start_time_ + point.time_from_start;
+    const rclcpp::Time t1 = trajectory_start_time_ + next_point.time_from_start;
+
+    if (integrate_missing_states) {
+      add_missing_states(
+        point, next_point,
+        state_before_traj_msg_.positions.size(),
+        (t1 - t0).seconds());
+    }
 
     if (sample_time >= t0 && sample_time < t1)
     {

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -280,3 +280,256 @@ TEST(TestTrajectory, interpolation_pos_vel_accel)
     EXPECT_NEAR(end_state.accelerations[0], expected_state.accelerations[0], EPS);
   }
 }
+
+TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation) {
+  auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+  full_msg->header.stamp = rclcpp::Time(0);
+
+  // definitions
+  double time_first_seg = 1.0;
+  double time_second_seg = 2.0;
+  double time_third_seg = 3.0;
+  double velocity_first_seg = 1.0;
+  double velocity_second_seg = 2.0;
+  double velocity_third_seg = 1.0;
+
+  trajectory_msgs::msg::JointTrajectoryPoint p1;
+  p1.velocities.push_back(velocity_first_seg);
+  p1.time_from_start = rclcpp::Duration::from_seconds(time_first_seg);
+  full_msg->points.push_back(p1);
+
+  trajectory_msgs::msg::JointTrajectoryPoint p2;
+  p2.velocities.push_back(velocity_second_seg);
+  p2.time_from_start = rclcpp::Duration::from_seconds(time_second_seg);
+  full_msg->points.push_back(p2);
+
+  trajectory_msgs::msg::JointTrajectoryPoint p3;
+  p3.velocities.push_back(velocity_third_seg);
+  p3.time_from_start = rclcpp::Duration::from_seconds(time_third_seg);
+  full_msg->points.push_back(p3);
+
+  trajectory_msgs::msg::JointTrajectoryPoint point_before_msg;
+  point_before_msg.time_from_start = rclcpp::Duration::from_seconds(0.0);
+  point_before_msg.positions.push_back(0.0);
+
+  // set current state before trajectory msg was sent
+  const rclcpp::Time time_now = rclcpp::Clock().now();
+  auto traj = joint_trajectory_controller::Trajectory(time_now, point_before_msg, full_msg);
+
+  trajectory_msgs::msg::JointTrajectoryPoint expected_state;
+  joint_trajectory_controller::TrajectoryPointConstIter start, end;
+
+  // sample at trajectory starting time
+  {
+    traj.sample(time_now, expected_state, start, end, true);
+    EXPECT_EQ(traj.begin(), start);
+    EXPECT_EQ(traj.begin(), end);
+    EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
+    EXPECT_NEAR(0.0, expected_state.velocities[0], EPS);
+    // is 0 because point_before_msg does not have velocity defined
+    EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
+  }
+
+  // sample before time_now
+  {
+    bool result =
+      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), expected_state, start, end, true);
+    EXPECT_EQ(result, false);
+  }
+
+  // sample 0.5s after msg
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), expected_state, start, end, true);
+    EXPECT_EQ(traj.begin(), start);
+    EXPECT_EQ(traj.begin(), end);
+    double half_current_to_p1 = point_before_msg.positions[0] +
+      (0.0 + (0.0 + p1.velocities[0]) / 4) * 0.5;
+    EXPECT_NEAR(half_current_to_p1, expected_state.positions[0], EPS);
+    EXPECT_NEAR(p1.velocities[0] / 2, expected_state.velocities[0], EPS);
+    EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
+  }
+
+  // sample 1s after msg
+  double position_first_seg = point_before_msg.positions[0] +
+    (0.0 + p1.velocities[0]) / 2 * time_first_seg;
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end, true);
+    EXPECT_EQ(traj.begin(), start);
+    EXPECT_EQ((++traj.begin()), end);
+    EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
+    EXPECT_NEAR(p1.velocities[0], expected_state.velocities[0], EPS);
+    EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
+  }
+
+  // sample 1.5s after msg
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), expected_state, start, end, true);
+    EXPECT_EQ(traj.begin(), start);
+    EXPECT_EQ((++traj.begin()), end);
+    double half_p1_to_p2 = position_first_seg +
+      (p1.velocities[0] + ((p1.velocities[0] + p2.velocities[0]) / 2 - p1.velocities[0]) / 2) * 0.5;
+    EXPECT_NEAR(half_p1_to_p2, expected_state.positions[0], EPS);
+    double half_p1_to_p2_vel = (p1.velocities[0] + p2.velocities[0]) / 2;
+    EXPECT_NEAR(half_p1_to_p2_vel, expected_state.velocities[0], EPS);
+    EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
+  }
+
+  // sample 2s after msg
+  double position_second_seg = position_first_seg +
+    (p1.velocities[0] + p2.velocities[0]) / 2 * (time_second_seg - time_first_seg);
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(2), expected_state, start, end, true);
+    EXPECT_EQ((++traj.begin()), start);
+    EXPECT_EQ((--traj.end()), end);
+    EXPECT_NEAR(position_second_seg, expected_state.positions[0], EPS);
+    EXPECT_NEAR(p2.velocities[0], expected_state.velocities[0], EPS);
+    EXPECT_NEAR(-1.0, expected_state.accelerations[0], EPS);
+  }
+
+  // sample 2.5s after msg
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), expected_state, start, end, true);
+    EXPECT_EQ((++traj.begin()), start);
+    EXPECT_EQ((--traj.end()), end);
+    double half_p2_to_p3 = position_second_seg +
+      (p2.velocities[0] + ((p2.velocities[0] + p3.velocities[0]) / 2 - p2.velocities[0]) / 2) * 0.5;
+    EXPECT_NEAR(half_p2_to_p3, expected_state.positions[0], EPS);
+    double half_p2_to_p3_vel = (p2.velocities[0] + p3.velocities[0]) / 2;
+    EXPECT_NEAR(half_p2_to_p3_vel, expected_state.velocities[0], EPS);
+    EXPECT_NEAR(-1.0, expected_state.accelerations[0], EPS);
+  }
+
+  // sample 3s after msg
+  double position_third_seg = position_second_seg +
+    (p2.velocities[0] + p3.velocities[0]) / 2 * (time_third_seg - time_second_seg);
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), expected_state, start, end, true);
+    EXPECT_EQ((--traj.end()), start);
+    EXPECT_EQ(traj.end(), end);
+    EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
+    EXPECT_NEAR(p3.velocities[0], expected_state.velocities[0], EPS);
+    EXPECT_NEAR(0, expected_state.accelerations[0], EPS);
+  }
+
+  // sample past given points - movement virtually stops
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), expected_state, start, end, true);
+    EXPECT_EQ((--traj.end()), start);
+    EXPECT_EQ(traj.end(), end);
+    EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
+    EXPECT_NEAR(p3.velocities[0], expected_state.velocities[0], EPS);
+    EXPECT_NEAR(0.0, expected_state.accelerations[0], EPS);
+  }
+}
+
+TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation) {
+  auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+  full_msg->header.stamp = rclcpp::Time(0);
+
+  // definitions
+  double time_first_seg = 1.0;
+  double time_second_seg = 2.0;
+  double time_third_seg = 3.0;
+  double acceleration_first_seg = 1.0;
+  double acceleration_second_seg = 2.0;
+  double acceleration_third_seg = 1.0;
+
+  trajectory_msgs::msg::JointTrajectoryPoint p1;
+  p1.accelerations.push_back(acceleration_first_seg);
+  p1.time_from_start = rclcpp::Duration::from_seconds(time_first_seg);
+  full_msg->points.push_back(p1);
+
+  trajectory_msgs::msg::JointTrajectoryPoint p2;
+  p2.accelerations.push_back(acceleration_second_seg);
+  p2.time_from_start = rclcpp::Duration::from_seconds(time_second_seg);
+  full_msg->points.push_back(p2);
+
+  trajectory_msgs::msg::JointTrajectoryPoint p3;
+  p3.accelerations.push_back(acceleration_third_seg);
+  p3.time_from_start = rclcpp::Duration::from_seconds(time_third_seg);
+  full_msg->points.push_back(p3);
+
+  trajectory_msgs::msg::JointTrajectoryPoint point_before_msg;
+  point_before_msg.time_from_start = rclcpp::Duration::from_seconds(0.0);
+  point_before_msg.positions.push_back(0.0);
+  point_before_msg.velocities.push_back(0.0);
+
+  // set current state before trajectory msg was sent
+  const rclcpp::Time time_now = rclcpp::Clock().now();
+  auto traj = joint_trajectory_controller::Trajectory(time_now, point_before_msg, full_msg);
+
+  trajectory_msgs::msg::JointTrajectoryPoint expected_state;
+  joint_trajectory_controller::TrajectoryPointConstIter start, end;
+
+  // sample at trajectory starting time
+  {
+    traj.sample(time_now, expected_state, start, end, true);
+    EXPECT_EQ(traj.begin(), start);
+    EXPECT_EQ(traj.begin(), end);
+    EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
+    EXPECT_NEAR(0.0, expected_state.velocities[0], EPS);
+    // is 0 because point_before_msg does not have velocity defined
+    EXPECT_NEAR(0.0, expected_state.accelerations[0], EPS);
+  }
+
+  // sample before time_now
+  {
+    bool result =
+      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), expected_state, start, end, true);
+    EXPECT_EQ(result, false);
+  }
+
+  // Sample only on points testing of intermediate values is too complex and not necessary
+
+  // sample 1s after msg
+  double velocity_first_seg = point_before_msg.velocities[0] +
+    (0.0 + p1.accelerations[0]) / 2 * time_first_seg;
+  double position_first_seg = point_before_msg.positions[0] +
+    (0.0 + velocity_first_seg) / 2 * time_first_seg;
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end, true);
+    EXPECT_EQ(traj.begin(), start);
+    EXPECT_EQ((++traj.begin()), end);
+    EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
+    EXPECT_NEAR(velocity_first_seg, expected_state.velocities[0], EPS);
+    EXPECT_NEAR(p1.accelerations[0], expected_state.accelerations[0], EPS);
+  }
+
+  // sample 2s after msg
+  double velocity_second_seg = velocity_first_seg +
+    (p1.accelerations[0] + p2.accelerations[0]) / 2 * (time_second_seg - time_first_seg);
+  double position_second_seg = position_first_seg +
+    (velocity_first_seg + velocity_second_seg) / 2 * (time_second_seg - time_first_seg);
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(2), expected_state, start, end, true);
+    EXPECT_EQ((++traj.begin()), start);
+    EXPECT_EQ((--traj.end()), end);
+    EXPECT_NEAR(position_second_seg, expected_state.positions[0], EPS);
+    EXPECT_NEAR(velocity_second_seg, expected_state.velocities[0], EPS);
+    EXPECT_NEAR(p2.accelerations[0], expected_state.accelerations[0], EPS);
+  }
+
+  // sample 3s after msg
+  double velocity_third_seg = velocity_second_seg +
+    (p2.accelerations[0] + p3.accelerations[0]) / 2 * (time_third_seg - time_second_seg);
+  double position_third_seg = position_second_seg +
+    (velocity_second_seg + velocity_third_seg) / 2 * (time_third_seg - time_second_seg);
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), expected_state, start, end, true);
+    EXPECT_EQ((--traj.end()), start);
+    EXPECT_EQ(traj.end(), end);
+    EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
+    EXPECT_NEAR(velocity_third_seg, expected_state.velocities[0], EPS);
+    EXPECT_NEAR(p3.accelerations[0], expected_state.accelerations[0], EPS);
+  }
+
+  // sample past given points - movement virtually stops
+  {
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), expected_state, start, end, true);
+    EXPECT_EQ((--traj.end()), start);
+    EXPECT_EQ(traj.end(), end);
+    EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
+    EXPECT_NEAR(velocity_third_seg, expected_state.velocities[0], EPS);
+    EXPECT_NEAR(p3.accelerations[0], expected_state.accelerations[0], EPS);
+  }
+}

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -328,8 +328,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_EQ(traj.begin(), end);
     EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
     EXPECT_NEAR(point_before_msg.velocities[0], expected_state.velocities[0], EPS);
-    // is 0 because point_before_msg does not have velocity defined
-    EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
+    EXPECT_NEAR((velocity_first_seg/time_first_seg), expected_state.accelerations[0], EPS);
   }
 
   // sample before time_now
@@ -352,7 +351,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
         0.5;
     EXPECT_NEAR(half_current_to_p1, expected_state.positions[0], EPS);
     EXPECT_NEAR(p1.velocities[0] / 2, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
+    EXPECT_NEAR((velocity_first_seg/time_first_seg), expected_state.accelerations[0], EPS);
   }
 
   // sample 1s after msg
@@ -364,7 +363,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_EQ((++traj.begin()), end);
     EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
     EXPECT_NEAR(p1.velocities[0], expected_state.velocities[0], EPS);
-    EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(((velocity_second_seg - velocity_first_seg/(time_second_seg - time_first_seg)), expected_state.accelerations[0], EPS);
   }
 
   // sample 1.5s after msg
@@ -378,7 +377,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_NEAR(half_p1_to_p2, expected_state.positions[0], EPS);
     double half_p1_to_p2_vel = (p1.velocities[0] + p2.velocities[0]) / 2;
     EXPECT_NEAR(half_p1_to_p2_vel, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(((velocity_second_seg - velocity_first_seg/(time_second_seg - time_first_seg)), expected_state.accelerations[0], EPS);
   }
 
   // sample 2s after msg
@@ -390,7 +389,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_EQ((--traj.end()), end);
     EXPECT_NEAR(position_second_seg, expected_state.positions[0], EPS);
     EXPECT_NEAR(p2.velocities[0], expected_state.velocities[0], EPS);
-    EXPECT_NEAR(-1.0, expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(((velocity_third_seg - velocity_second_seg/(time_third_seg - time_second_seg)), expected_state.accelerations[0], EPS);
   }
 
   // sample 2.5s after msg
@@ -404,7 +403,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_NEAR(half_p2_to_p3, expected_state.positions[0], EPS);
     double half_p2_to_p3_vel = (p2.velocities[0] + p3.velocities[0]) / 2;
     EXPECT_NEAR(half_p2_to_p3_vel, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(-1.0, expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(((velocity_third_seg - velocity_second_seg/(time_third_seg - time_second_seg)), expected_state.accelerations[0], EPS);
   }
 
   // sample 3s after msg
@@ -416,6 +415,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_EQ(traj.end(), end);
     EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
     EXPECT_NEAR(p3.velocities[0], expected_state.velocities[0], EPS);
+    // the goal is reached so no acceleration anymore
     EXPECT_NEAR(0, expected_state.accelerations[0], EPS);
   }
 

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -281,7 +281,8 @@ TEST(TestTrajectory, interpolation_pos_vel_accel)
   }
 }
 
-TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation) {
+TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
+{
   auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
   full_msg->header.stamp = rclcpp::Time(0);
 
@@ -343,18 +344,20 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation) {
     traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ(traj.begin(), end);
-    double half_current_to_p1 = point_before_msg.positions[0] +
+    double half_current_to_p1 =
+      point_before_msg.positions[0] +
       (point_before_msg.velocities[0] +
-      ((point_before_msg.velocities[0] + p1.velocities[0]) / 2 -
-      point_before_msg.velocities[0]) / 2) * 0.5;
+       ((point_before_msg.velocities[0] + p1.velocities[0]) / 2 - point_before_msg.velocities[0]) /
+         2) *
+        0.5;
     EXPECT_NEAR(half_current_to_p1, expected_state.positions[0], EPS);
     EXPECT_NEAR(p1.velocities[0] / 2, expected_state.velocities[0], EPS);
     EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
   }
 
   // sample 1s after msg
-  double position_first_seg = point_before_msg.positions[0] +
-    (0.0 + p1.velocities[0]) / 2 * time_first_seg;
+  double position_first_seg =
+    point_before_msg.positions[0] + (0.0 + p1.velocities[0]) / 2 * time_first_seg;
   {
     traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
@@ -369,7 +372,8 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation) {
     traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ((++traj.begin()), end);
-    double half_p1_to_p2 = position_first_seg +
+    double half_p1_to_p2 =
+      position_first_seg +
       (p1.velocities[0] + ((p1.velocities[0] + p2.velocities[0]) / 2 - p1.velocities[0]) / 2) * 0.5;
     EXPECT_NEAR(half_p1_to_p2, expected_state.positions[0], EPS);
     double half_p1_to_p2_vel = (p1.velocities[0] + p2.velocities[0]) / 2;
@@ -378,8 +382,8 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation) {
   }
 
   // sample 2s after msg
-  double position_second_seg = position_first_seg +
-    (p1.velocities[0] + p2.velocities[0]) / 2 * (time_second_seg - time_first_seg);
+  double position_second_seg = position_first_seg + (p1.velocities[0] + p2.velocities[0]) / 2 *
+                                                      (time_second_seg - time_first_seg);
   {
     traj.sample(time_now + rclcpp::Duration::from_seconds(2), expected_state, start, end);
     EXPECT_EQ((++traj.begin()), start);
@@ -394,7 +398,8 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation) {
     traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), expected_state, start, end);
     EXPECT_EQ((++traj.begin()), start);
     EXPECT_EQ((--traj.end()), end);
-    double half_p2_to_p3 = position_second_seg +
+    double half_p2_to_p3 =
+      position_second_seg +
       (p2.velocities[0] + ((p2.velocities[0] + p3.velocities[0]) / 2 - p2.velocities[0]) / 2) * 0.5;
     EXPECT_NEAR(half_p2_to_p3, expected_state.positions[0], EPS);
     double half_p2_to_p3_vel = (p2.velocities[0] + p3.velocities[0]) / 2;
@@ -403,8 +408,8 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation) {
   }
 
   // sample 3s after msg
-  double position_third_seg = position_second_seg +
-    (p2.velocities[0] + p3.velocities[0]) / 2 * (time_third_seg - time_second_seg);
+  double position_third_seg = position_second_seg + (p2.velocities[0] + p3.velocities[0]) / 2 *
+                                                      (time_third_seg - time_second_seg);
   {
     traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), expected_state, start, end);
     EXPECT_EQ((--traj.end()), start);
@@ -427,7 +432,8 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation) {
 
 // This test is added because previous one behaved strange if
 // "point_before_msg.velocities.push_back(0.0);" was not defined
-TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_without_vel) {
+TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_without_vel)
+{
   auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
   full_msg->header.stamp = rclcpp::Time(0);
 
@@ -488,20 +494,20 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_witho
     traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ(traj.begin(), end);
-//     double half_current_to_p1 = point_before_msg.positions[0] +
-//     (point_before_msg.velocities[0] +
-//     ((point_before_msg.velocities[0] + p1.velocities[0]) / 2 -
-//     point_before_msg.velocities[0]) / 2) * 0.5;
-    double half_current_to_p1 = point_before_msg.positions[0] +
-      (0.0 + ((0.0 + p1.velocities[0]) / 2 - 0.0) / 2) * 0.5;
+    //     double half_current_to_p1 = point_before_msg.positions[0] +
+    //     (point_before_msg.velocities[0] +
+    //     ((point_before_msg.velocities[0] + p1.velocities[0]) / 2 -
+    //     point_before_msg.velocities[0]) / 2) * 0.5;
+    double half_current_to_p1 =
+      point_before_msg.positions[0] + (0.0 + ((0.0 + p1.velocities[0]) / 2 - 0.0) / 2) * 0.5;
     EXPECT_NEAR(half_current_to_p1, expected_state.positions[0], EPS);
     EXPECT_NEAR(p1.velocities[0] / 2, expected_state.velocities[0], EPS);
     EXPECT_NEAR(1.0, expected_state.accelerations[0], EPS);
   }
 
   // sample 1s after msg
-  double position_first_seg = point_before_msg.positions[0] +
-    (0.0 + p1.velocities[0]) / 2 * time_first_seg;
+  double position_first_seg =
+    point_before_msg.positions[0] + (0.0 + p1.velocities[0]) / 2 * time_first_seg;
   {
     traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
@@ -512,7 +518,8 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_witho
   }
 }
 
-TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation) {
+TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
+{
   auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
   full_msg->header.stamp = rclcpp::Time(0);
 
@@ -572,10 +579,10 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation) {
   // Sample only on points testing of intermediate values is too complex and not necessary
 
   // sample 1s after msg
-  double velocity_first_seg = point_before_msg.velocities[0] +
-    (0.0 + p1.accelerations[0]) / 2 * time_first_seg;
-  double position_first_seg = point_before_msg.positions[0] +
-    (0.0 + velocity_first_seg) / 2 * time_first_seg;
+  double velocity_first_seg =
+    point_before_msg.velocities[0] + (0.0 + p1.accelerations[0]) / 2 * time_first_seg;
+  double position_first_seg =
+    point_before_msg.positions[0] + (0.0 + velocity_first_seg) / 2 * time_first_seg;
   {
     traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
@@ -586,10 +593,10 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation) {
   }
 
   // sample 2s after msg
-  double velocity_second_seg = velocity_first_seg +
-    (p1.accelerations[0] + p2.accelerations[0]) / 2 * (time_second_seg - time_first_seg);
-  double position_second_seg = position_first_seg +
-    (velocity_first_seg + velocity_second_seg) / 2 * (time_second_seg - time_first_seg);
+  double velocity_second_seg = velocity_first_seg + (p1.accelerations[0] + p2.accelerations[0]) /
+                                                      2 * (time_second_seg - time_first_seg);
+  double position_second_seg = position_first_seg + (velocity_first_seg + velocity_second_seg) / 2 *
+                                                      (time_second_seg - time_first_seg);
   {
     traj.sample(time_now + rclcpp::Duration::from_seconds(2), expected_state, start, end);
     EXPECT_EQ((++traj.begin()), start);
@@ -600,10 +607,10 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation) {
   }
 
   // sample 3s after msg
-  double velocity_third_seg = velocity_second_seg +
-    (p2.accelerations[0] + p3.accelerations[0]) / 2 * (time_third_seg - time_second_seg);
-  double position_third_seg = position_second_seg +
-    (velocity_second_seg + velocity_third_seg) / 2 * (time_third_seg - time_second_seg);
+  double velocity_third_seg = velocity_second_seg + (p2.accelerations[0] + p3.accelerations[0]) /
+                                                      2 * (time_third_seg - time_second_seg);
+  double position_third_seg = position_second_seg + (velocity_second_seg + velocity_third_seg) / 2 *
+                                                      (time_third_seg - time_second_seg);
   {
     traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), expected_state, start, end);
     EXPECT_EQ((--traj.end()), start);

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -328,7 +328,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_EQ(traj.begin(), end);
     EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
     EXPECT_NEAR(point_before_msg.velocities[0], expected_state.velocities[0], EPS);
-    EXPECT_NEAR((velocity_first_seg/time_first_seg), expected_state.accelerations[0], EPS);
+    EXPECT_NEAR((velocity_first_seg / time_first_seg), expected_state.accelerations[0], EPS);
   }
 
   // sample before time_now
@@ -351,7 +351,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
         0.5;
     EXPECT_NEAR(half_current_to_p1, expected_state.positions[0], EPS);
     EXPECT_NEAR(p1.velocities[0] / 2, expected_state.velocities[0], EPS);
-    EXPECT_NEAR((velocity_first_seg/time_first_seg), expected_state.accelerations[0], EPS);
+    EXPECT_NEAR((velocity_first_seg / time_first_seg), expected_state.accelerations[0], EPS);
   }
 
   // sample 1s after msg
@@ -363,7 +363,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_EQ((++traj.begin()), end);
     EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
     EXPECT_NEAR(p1.velocities[0], expected_state.velocities[0], EPS);
-    EXPECT_NEAR(((velocity_second_seg - velocity_first_seg/(time_second_seg - time_first_seg)), expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(
+      (velocity_second_seg - velocity_first_seg / (time_second_seg - time_first_seg)),
+      expected_state.accelerations[0], EPS);
   }
 
   // sample 1.5s after msg
@@ -377,7 +379,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_NEAR(half_p1_to_p2, expected_state.positions[0], EPS);
     double half_p1_to_p2_vel = (p1.velocities[0] + p2.velocities[0]) / 2;
     EXPECT_NEAR(half_p1_to_p2_vel, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(((velocity_second_seg - velocity_first_seg/(time_second_seg - time_first_seg)), expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(
+      (velocity_second_seg - velocity_first_seg / (time_second_seg - time_first_seg)),
+      expected_state.accelerations[0], EPS);
   }
 
   // sample 2s after msg
@@ -389,7 +393,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_EQ((--traj.end()), end);
     EXPECT_NEAR(position_second_seg, expected_state.positions[0], EPS);
     EXPECT_NEAR(p2.velocities[0], expected_state.velocities[0], EPS);
-    EXPECT_NEAR(((velocity_third_seg - velocity_second_seg/(time_third_seg - time_second_seg)), expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(
+      (velocity_third_seg - velocity_second_seg / (time_third_seg - time_second_seg)),
+      expected_state.accelerations[0], EPS);
   }
 
   // sample 2.5s after msg
@@ -403,7 +409,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
     EXPECT_NEAR(half_p2_to_p3, expected_state.positions[0], EPS);
     double half_p2_to_p3_vel = (p2.velocities[0] + p3.velocities[0]) / 2;
     EXPECT_NEAR(half_p2_to_p3_vel, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(((velocity_third_seg - velocity_second_seg/(time_third_seg - time_second_seg)), expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(
+      (velocity_third_seg - velocity_second_seg / (time_third_seg - time_second_seg)),
+      expected_state.accelerations[0], EPS);
   }
 
   // sample 3s after msg

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -269,8 +269,8 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
 
   // This call is replacing the way parameters are set via launch
   SetParameters();
-  SetPidParameters();
-  traj_controller_->get_node()->configure();
+  SetParameters();  // This call is replacing the way parameters are set via launch
+  traj_controller_->configure();
   auto state = traj_controller_->get_state();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
 
@@ -670,8 +670,10 @@ TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list_not_allowe
 TEST_P(TrajectoryControllerTestParameterized, invalid_message)
 {
   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", false);
+  rclcpp::Parameter allow_integration_parameters("allow_integration_in_goal_trajectories", false);
   rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(true, {partial_joints_parameters}, &executor);
+  SetUpAndActivateTrajectoryController(
+    true, {partial_joints_parameters, allow_integration_parameters}, &executor);
 
   trajectory_msgs::msg::JointTrajectory traj_msg, good_traj_msg;
 
@@ -724,6 +726,67 @@ TEST_P(TrajectoryControllerTestParameterized, invalid_message)
   // Non-strictly increasing waypoint times
   traj_msg = good_traj_msg;
   traj_msg.points.push_back(traj_msg.points.front());
+  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+}
+
+/// With allow_integration_in_goal_trajectories parameter trajectory missing position or velocities
+/// are accepted
+TEST_P(TrajectoryControllerTestParameterized, missing_positions_message_accepted)
+{
+  rclcpp::Parameter allow_integration_parameters("allow_integration_in_goal_trajectories", true);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  SetUpAndActivateTrajectoryController(true, {allow_integration_parameters}, &executor);
+
+  trajectory_msgs::msg::JointTrajectory traj_msg, good_traj_msg;
+
+  good_traj_msg.joint_names = joint_names_;
+  good_traj_msg.header.stamp = rclcpp::Time(0);
+  good_traj_msg.points.resize(1);
+  good_traj_msg.points[0].time_from_start = rclcpp::Duration::from_seconds(0.25);
+  good_traj_msg.points[0].positions.resize(1);
+  good_traj_msg.points[0].positions = {1.0, 2.0, 3.0};
+  good_traj_msg.points[0].velocities.resize(1);
+  good_traj_msg.points[0].velocities = {-1.0, -2.0, -3.0};
+  good_traj_msg.points[0].accelerations.resize(1);
+  good_traj_msg.points[0].accelerations = {1.0, 2.0, 3.0};
+  EXPECT_TRUE(traj_controller_->validate_trajectory_msg(good_traj_msg));
+
+  // No position data
+  traj_msg = good_traj_msg;
+  traj_msg.points[0].positions.clear();
+  EXPECT_TRUE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+  // No position and velocity data
+  traj_msg = good_traj_msg;
+  traj_msg.points[0].positions.clear();
+  traj_msg.points[0].velocities.clear();
+  EXPECT_TRUE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+  // All empty
+  traj_msg = good_traj_msg;
+  traj_msg.points[0].positions.clear();
+  traj_msg.points[0].velocities.clear();
+  traj_msg.points[0].accelerations.clear();
+  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+  // Incompatible data sizes, too few positions
+  traj_msg = good_traj_msg;
+  traj_msg.points[0].positions = {1.0, 2.0};
+  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+  // Incompatible data sizes, too many positions
+  traj_msg = good_traj_msg;
+  traj_msg.points[0].positions = {1.0, 2.0, 3.0, 4.0};
+  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+  // Incompatible data sizes, too few velocities
+  traj_msg = good_traj_msg;
+  traj_msg.points[0].velocities = {1.0};
+  EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
+
+  // Incompatible data sizes, too few accelerations
+  traj_msg = good_traj_msg;
+  traj_msg.points[0].accelerations = {2.0};
   EXPECT_FALSE(traj_controller_->validate_trajectory_msg(traj_msg));
 }
 


### PR DESCRIPTION
Second part of #161,

Enabling integration of states in goal trajectories. This means that goal trajectories may have only velocity of acceleration defined. Then posiitions and/or velocities will be integrated from inputs.
