### PR TITLE
disable griper on OSX

### DIFF
--- a/gripper_controllers/CMakeLists.txt
+++ b/gripper_controllers/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(gripper_controllers)
 
+if(APPLE)
+  message(WARNING "gripper controllers are not available on OSX")
+  return()
+endif()
+
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
`experimental/optional` is not supported on OSX. I believe the proper fix would be to `ifdef` the logic around optional, but for now I am simply disabling the compilation on OSX. 