### PR TITLE
joint_trajectory_controller: Fix compilation errors for error reporting

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -340,7 +340,7 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State &)
     auto it = std::find(
       allowed_interface_types_.begin(), allowed_interface_types_.end(), interface);
     if (it == allowed_interface_types_.end()) {
-      RCLCPP_ERROR(logger, "Command interface type '" + interface + "' not allowed!");
+      RCLCPP_ERROR(logger, "Command interface type '%s' not allowed!", interface.c_str());
       return CallbackReturn::FAILURE;
     }
   }
@@ -421,7 +421,7 @@ JointTrajectoryController::on_configure(const rclcpp_lifecycle::State &)
     auto it = std::find(
       allowed_interface_types_.begin(), allowed_interface_types_.end(), interface);
     if (it == allowed_interface_types_.end()) {
-      RCLCPP_ERROR(logger, "State interface type '" + interface + "' not allowed!");
+      RCLCPP_ERROR(logger, "State interface type '%s' not allowed!'", interface.c_str());
       return CallbackReturn::FAILURE;
     }
   }


### PR DESCRIPTION
Address c-string and c++-string incompatibility in logging