### PR TITLE
Fixes for Windows

### DIFF
--- a/diff_drive_controller/test/test_accumulator.cpp
+++ b/diff_drive_controller/test/test_accumulator.cpp
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef _MSC_VER
 #define _USE_MATH_DEFINES
+#endif
 #include <diff_drive_controller/rolling_mean_accumulator.hpp>
 
 #include <gmock/gmock.h>

--- a/diff_drive_controller/test/test_accumulator.cpp
+++ b/diff_drive_controller/test/test_accumulator.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define _USE_MATH_DEFINES
 #include <diff_drive_controller/rolling_mean_accumulator.hpp>
 
 #include <gmock/gmock.h>

--- a/gripper_controllers/CMakeLists.txt
+++ b/gripper_controllers/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(gripper_controllers)
 
-if(APPLE)
-  message(WARNING "gripper controllers are not available on OSX")
+if(APPLE OR WIN32)
+  message(WARNING "gripper controllers are not available on OSX or Windows")
   return()
 endif()
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -194,7 +194,8 @@ protected:
   // sorts the joints of the incoming message to our local order
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC void sort_to_local_joint_order(
     std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg);
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC bool validate_trajectory_msg(const trajectory_msgs::msg::JointTrajectory & trajectory) const;
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC bool validate_trajectory_msg(
+    const trajectory_msgs::msg::JointTrajectory & trajectory) const;
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC void add_new_trajectory_msg(
     const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & traj_msg);
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC bool validate_trajectory_point_field(

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -179,26 +179,34 @@ protected:
   rclcpp::Duration action_monitor_period_ = rclcpp::Duration(RCUTILS_MS_TO_NS(50));
 
   // callbacks for action_server_
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC rclcpp_action::GoalResponse goal_callback(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  rclcpp_action::GoalResponse goal_callback(
     const rclcpp_action::GoalUUID & uuid,
     std::shared_ptr<const FollowJTrajAction::Goal> goal);
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC rclcpp_action::CancelResponse cancel_callback(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  rclcpp_action::CancelResponse cancel_callback(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void feedback_setup_callback(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  void feedback_setup_callback(
     std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
 
   // fill trajectory_msg so it matches joints controlled by this controller
   // positions set to current position, velocities, accelerations and efforts to 0.0
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void fill_partial_goal(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  void fill_partial_goal(
     std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg) const;
   // sorts the joints of the incoming message to our local order
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void sort_to_local_joint_order(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  void sort_to_local_joint_order(
     std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg);
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC bool validate_trajectory_msg(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  bool validate_trajectory_msg(
     const trajectory_msgs::msg::JointTrajectory & trajectory) const;
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void add_new_trajectory_msg(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  void add_new_trajectory_msg(
     const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & traj_msg);
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC bool validate_trajectory_point_field(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  bool validate_trajectory_point_field(
     size_t joint_names_size,
     const std::vector<double> & vector_field,
     const std::string & string_for_vector_field, size_t i,
@@ -206,13 +214,17 @@ protected:
 
   SegmentTolerances default_tolerances_;
 
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void preempt_active_goal();
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void set_hold_position();
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  void preempt_active_goal();
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  void set_hold_position();
 
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC bool reset();
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  bool reset();
 
   using JointTrajectoryPoint = trajectory_msgs::msg::JointTrajectoryPoint;
-  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void publish_state(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC
+  void publish_state(
     const JointTrajectoryPoint & desired_state,
     const JointTrajectoryPoint & current_state,
     const JointTrajectoryPoint & state_error);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -179,25 +179,25 @@ protected:
   rclcpp::Duration action_monitor_period_ = rclcpp::Duration(RCUTILS_MS_TO_NS(50));
 
   // callbacks for action_server_
-  rclcpp_action::GoalResponse goal_callback(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC rclcpp_action::GoalResponse goal_callback(
     const rclcpp_action::GoalUUID & uuid,
     std::shared_ptr<const FollowJTrajAction::Goal> goal);
-  rclcpp_action::CancelResponse cancel_callback(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC rclcpp_action::CancelResponse cancel_callback(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
-  void feedback_setup_callback(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void feedback_setup_callback(
     std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle);
 
   // fill trajectory_msg so it matches joints controlled by this controller
   // positions set to current position, velocities, accelerations and efforts to 0.0
-  void fill_partial_goal(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void fill_partial_goal(
     std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg) const;
   // sorts the joints of the incoming message to our local order
-  void sort_to_local_joint_order(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void sort_to_local_joint_order(
     std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg);
-  bool validate_trajectory_msg(const trajectory_msgs::msg::JointTrajectory & trajectory) const;
-  void add_new_trajectory_msg(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC bool validate_trajectory_msg(const trajectory_msgs::msg::JointTrajectory & trajectory) const;
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void add_new_trajectory_msg(
     const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & traj_msg);
-  bool validate_trajectory_point_field(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC bool validate_trajectory_point_field(
     size_t joint_names_size,
     const std::vector<double> & vector_field,
     const std::string & string_for_vector_field, size_t i,
@@ -205,13 +205,13 @@ protected:
 
   SegmentTolerances default_tolerances_;
 
-  void preempt_active_goal();
-  void set_hold_position();
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void preempt_active_goal();
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void set_hold_position();
 
-  bool reset();
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC bool reset();
 
   using JointTrajectoryPoint = trajectory_msgs::msg::JointTrajectoryPoint;
-  void publish_state(
+  JOINT_TRAJECTORY_CONTROLLER_PUBLIC void publish_state(
     const JointTrajectoryPoint & desired_state,
     const JointTrajectoryPoint & current_state,
     const JointTrajectoryPoint & state_error);

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _MSC_VER
 #include <cxxabi.h>
+#endif
 #include <algorithm>
 #include <chrono>
 #include <functional>


### PR DESCRIPTION
I changed a couple things to get this working on Windows.
1. For the same reason as #192, the gripper controller doesn't work on Windows as well, so I disabled it.
2. `M_PI` is not defined unless `_USE_MATH_DEFINES` is also defined
3. I had to export some protected functions of the joint trajectory controller to fix missing symbol errors.
4. Lastly, `cxxabi.h` doesn't exist on MSVC, so I didn't include it when MSVC was detected. It still still seems to compile fine without it.