### PR TITLE
[Joint State Broadcaster] Add option to support only specific interfaces on specific joints

### DIFF
--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -13,7 +13,10 @@ Broadcasters are not real controllers, and therefore take no commands.
 Hardware interface type
 -----------------------
 
-All available *joint state interfaces* are used by this broadcaster.
+All available *joint state interfaces* are used, or interfaces defined by the ``joints`` and ``interfaces`` parameters of both are not empty.
+In the latter case, resulting interfaces is a "matrix" of interfaces resulting from the cross-product of those two vectors.
+If some requested interfaces are missing, the controller will print a warning about that, but work for other interfaces.
+If none of the requested interface are not defined, the controller returns error on activation.
 
 Parameters
 ----------
@@ -32,6 +35,9 @@ Parameters
 ``interfaces``
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with ``joints`` parameters.
+  
+  
+ 
 
 
 ``extra_joints``

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -37,7 +37,7 @@ Parameters
 
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with ``joints`` parameters.
-   
+
 
 ``extra_joints``
 

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -13,8 +13,8 @@ Broadcasters are not real controllers, and therefore take no commands.
 Hardware interface type
 -----------------------
 
-All available *joint state interfaces* are used, or interfaces defined by the ``joints`` and ``interfaces`` parameters of both are not empty.
-In the latter case, resulting interfaces is a "matrix" of interfaces resulting from the cross-product of those two vectors.
+By default, all available *joint state interfaces* are used, unless configured otherwise.
+In the latter case, resulting interfaces is defined by a "matrix" of interfaces defined by the cross-product of the ``joints`` and ``interfaces`` parameters.
 If some requested interfaces are missing, the controller will print a warning about that, but work for other interfaces.
 If none of the requested interface are not defined, the controller returns error on activation.
 
@@ -29,14 +29,14 @@ Parameters
 ``joints``
 
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
-  It has to be used in combination with ``interfaces`` parameters.
+  It has to be used in combination with the ``interfaces`` parameter.
   Joint state broadcaster asks for access to all defined interfaces on all defined joints.
 
 
 ``interfaces``
 
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
-  It has to be used in combination with ``joints`` parameters.
+  It has to be used in combination with the ``joints`` parameter.
 
 
 ``extra_joints``

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -19,7 +19,23 @@ Parameters
 ----------
 
 ``use_local_topics``
+
   Optional parameter (boolean; default: ``False``) defining if ``joint_states`` and ``dynamic_joint_states`` messages should be published into local namespace, e.g., ``/my_state_broadcaster/joint_states``.
 
+
+``joints``
+
+  Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
+  It has to be used in combination with ``interfaces`` parameters.
+  Joint state broadcaster asks for access to all defined interfaces on all defined joints.
+
+
+``interfaces``
+
+  Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
+  It has to be used in combination with ``joints`` parameters.
+
+
 ``extra_joints``
+
   Optional parameter (string array) with names of extra joints to be added to ``joint_states`` and ``dynamic_joint_states`` with state set to 0.

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -24,14 +24,12 @@ Parameters
 
 
 ``joints``
-
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with ``interfaces`` parameters.
   Joint state broadcaster asks for access to all defined interfaces on all defined joints.
 
 
 ``interfaces``
-
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with ``joints`` parameters.
 

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -27,18 +27,17 @@ Parameters
 
 
 ``joints``
+
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with ``interfaces`` parameters.
   Joint state broadcaster asks for access to all defined interfaces on all defined joints.
 
 
 ``interfaces``
+
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with ``joints`` parameters.
-  
-  
- 
-
+   
 
 ``extra_joints``
 

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -40,6 +40,7 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
  * of its states, e.g., position.
  * If "joints" or "interfaces" parameter is empty, all available states are published.
  *
+ * \param use_local_topics Flag to publish topics in local namespace.
  * \param joints Names of the joints to control.
  * \param interfaces Name of the interface to command.
  *
@@ -54,10 +55,6 @@ class JointStateBroadcaster : public controller_interface::ControllerInterface
 public:
   JOINT_STATE_BROADCASTER_PUBLIC
   JointStateBroadcaster();
-
-  JOINT_STATE_BROADCASTER_PUBLIC
-  controller_interface::return_type
-  init(const std::string & controller_name) override;
 
   JOINT_STATE_BROADCASTER_PUBLIC
   controller_interface::InterfaceConfiguration command_interface_configuration() const override;
@@ -85,7 +82,7 @@ protected:
   bool init_joint_data();
   void init_joint_state_msg();
   void init_dynamic_joint_state_msg();
-  bool use_all_available_interfaces();
+  bool use_all_available_interfaces() const;
 
 protected:
   // Optional parameters

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -31,11 +31,27 @@ namespace joint_state_broadcaster
 {
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
+/**
+ * \brief Joint State Broadcaster for all or some state in ros2_control system.
+ *
+ * This class forwards the command signal down to a set of joints
+ * on the specified interface.
+ *
+ * \param joints Names of the joints to control.
+ * \param interface_name Name of the interface to command.
+ *
+ * Subscribes to:
+ * - \b commands (std_msgs::msg::Float64MultiArray) : The commands to apply.
+ */
 class JointStateBroadcaster : public controller_interface::ControllerInterface
 {
 public:
   JOINT_STATE_BROADCASTER_PUBLIC
   JointStateBroadcaster();
+
+  JOINT_STATE_BROADCASTER_PUBLIC
+  controller_interface::return_type
+  init(const std::string & controller_name) override;
 
   JOINT_STATE_BROADCASTER_PUBLIC
   controller_interface::InterfaceConfiguration command_interface_configuration() const override;
@@ -65,7 +81,10 @@ protected:
   void init_dynamic_joint_state_msg();
 
 protected:
+  // Optional parameters
   bool use_local_topics_;
+  std::vector<std::string> joints_;
+  std::vector<std::string> interfaces_;
 
   //  For the JointState message,
   //  we store the name of joints with compatible interfaces

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -34,14 +34,20 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 /**
  * \brief Joint State Broadcaster for all or some state in ros2_control system.
  *
- * This class forwards the command signal down to a set of joints
- * on the specified interface.
+ * Joint State Broadcasters publishes state interfaces from ros2_control as ROS messages.
+ * There is a possibility to publish all available states (typical use), or only specific ones.
+ * The latter is, for example, used when hardware provides multiple measurement source for some
+ * of its states, e.g., position.
+ * If "joints" or "interfaces" parameter is empty, all available states are published.
  *
  * \param joints Names of the joints to control.
- * \param interface_name Name of the interface to command.
+ * \param interfaces Name of the interface to command.
  *
- * Subscribes to:
- * - \b commands (std_msgs::msg::Float64MultiArray) : The commands to apply.
+ * Publishes to:
+ * - \b joint_states (sensor_msgs::msg::JointState): Joint states related to movement
+ * (position, velocity, effort).
+ * - \b dynamic_joint_states (control_msgs::msg::DynamicJointState): Joint states unlrelated to
+ * its interface type.
  */
 class JointStateBroadcaster : public controller_interface::ControllerInterface
 {
@@ -79,6 +85,7 @@ protected:
   bool init_joint_data();
   void init_joint_state_msg();
   void init_dynamic_joint_state_msg();
+  bool use_all_available_interfaces();
 
 protected:
   // Optional parameters

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -32,22 +32,22 @@ namespace joint_state_broadcaster
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 /**
- * \brief Joint State Broadcaster for all or some state in ros2_control system.
+ * \brief Joint State Broadcaster for all or some state in a ros2_control system.
  *
- * Joint State Broadcasters publishes state interfaces from ros2_control as ROS messages.
+ * JointStateBroadcaster publishes state interfaces from ros2_control as ROS messages.
  * There is a possibility to publish all available states (typical use), or only specific ones.
- * The latter is, for example, used when hardware provides multiple measurement source for some
+ * The latter is, for example, used when hardware provides multiple measurement sources for some
  * of its states, e.g., position.
  * If "joints" or "interfaces" parameter is empty, all available states are published.
  *
  * \param use_local_topics Flag to publish topics in local namespace.
- * \param joints Names of the joints to control.
- * \param interfaces Name of the interface to command.
+ * \param joints Names of the joints to publish.
+ * \param interfaces Names of interfaces to publish.
  *
  * Publishes to:
  * - \b joint_states (sensor_msgs::msg::JointState): Joint states related to movement
  * (position, velocity, effort).
- * - \b dynamic_joint_states (control_msgs::msg::DynamicJointState): Joint states unlrelated to
+ * - \b dynamic_joint_states (control_msgs::msg::DynamicJointState): Joint states regardless of
  * its interface type.
  */
 class JointStateBroadcaster : public controller_interface::ControllerInterface

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -75,7 +75,7 @@ controller_interface::InterfaceConfiguration JointStateBroadcaster::state_interf
 {
   controller_interface::InterfaceConfiguration state_interfaces_config;
 
-  if (joints_.empty() || interfaces_.empty()) {
+  if (use_all_available_interfaces()) {
     state_interfaces_config.type = controller_interface::interface_configuration_type::ALL;
   } else {
     state_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
@@ -96,7 +96,7 @@ CallbackReturn JointStateBroadcaster::on_configure(
   joints_ = get_node()->get_parameter("joints").as_string_array();
   interfaces_ = get_node()->get_parameter("interfaces").as_string_array();
 
-  if (joints_.empty() || interfaces_.empty()) {
+  if (use_all_available_interfaces()) {
     RCLCPP_INFO(
       node_->get_logger(), "'joints' or 'interfaces' parameter is empty. "
       "All available state interfaces will be published");
@@ -236,6 +236,11 @@ void JointStateBroadcaster::init_dynamic_joint_state_msg()
     }
     dynamic_joint_state_msg_.interface_values.emplace_back(if_value);
   }
+}
+
+bool JointStateBroadcaster::use_all_available_interfaces()
+{
+  return joints_.empty() || interfaces_.empty();
 }
 
 double get_value(

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -238,7 +238,7 @@ void JointStateBroadcaster::init_dynamic_joint_state_msg()
   }
 }
 
-bool JointStateBroadcaster::use_all_available_interfaces()
+bool JointStateBroadcaster::use_all_available_interfaces() const
 {
   return joints_.empty() || interfaces_.empty();
 }

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -75,12 +75,17 @@ controller_interface::InterfaceConfiguration JointStateBroadcaster::state_interf
 {
   controller_interface::InterfaceConfiguration state_interfaces_config;
 
-  if (use_all_available_interfaces()) {
+  if (use_all_available_interfaces())
+  {
     state_interfaces_config.type = controller_interface::interface_configuration_type::ALL;
-  } else {
+  }
+  else
+  {
     state_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
-    for (const auto & joint : joints_) {
-      for (const auto & interface : interfaces_) {
+    for (const auto & joint : joints_)
+    {
+      for (const auto & interface : interfaces_)
+      {
         state_interfaces_config.names.push_back(joint + "/" + interface);
       }
     }
@@ -96,17 +101,22 @@ CallbackReturn JointStateBroadcaster::on_configure(
   joints_ = get_node()->get_parameter("joints").as_string_array();
   interfaces_ = get_node()->get_parameter("interfaces").as_string_array();
 
-  if (use_all_available_interfaces()) {
+  if (use_all_available_interfaces())
+  {
     RCLCPP_INFO(
-      node_->get_logger(), "'joints' or 'interfaces' parameter is empty. "
+      node_->get_logger(),
+      "'joints' or 'interfaces' parameter is empty. "
       "All available state interfaces will be published");
-  } else {
+  }
+  else
+  {
     RCLCPP_INFO(
       node_->get_logger(),
       "Publishing state interfaces defined in 'joints' and 'interfaces' parameters.");
   }
 
-  try {
+  try
+  {
     const std::string topic_name_prefix = use_local_topics_ ? "~/" : "";
 
     joint_state_publisher_ = get_node()->create_publisher<sensor_msgs::msg::JointState>(

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -336,9 +336,6 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointsOneInterface)
   ASSERT_THAT(
     state_broadcaster_->dynamic_joint_state_msg_.interface_values[1].interface_names,
     ElementsAreArray(IF_NAMES));
-//   ASSERT_THAT(
-//     state_broadcaster_->dynamic_joint_state_msg_.interface_values[2].interface_names,
-//     ElementsAreArray(IF_NAMES));
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->joint_state_publisher_);
@@ -376,12 +373,6 @@ TEST_F(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces)
   ASSERT_THAT(
     state_broadcaster_->dynamic_joint_state_msg_.interface_values[0].interface_names,
     ElementsAreArray(IF_NAMES));
-//   ASSERT_THAT(
-//     state_broadcaster_->dynamic_joint_state_msg_.interface_values[1].interface_names,
-//     ElementsAreArray(IF_NAMES));
-//   ASSERT_THAT(
-//     state_broadcaster_->dynamic_joint_state_msg_.interface_values[2].interface_names,
-//     ElementsAreArray(IF_NAMES));
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->joint_state_publisher_);

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -70,9 +70,7 @@ void JointStateBroadcasterTest::SetUp()
 void JointStateBroadcasterTest::TearDown() { state_broadcaster_.reset(nullptr); }
 
 void JointStateBroadcasterTest::SetUpStateBroadcaster(
-  const std::vector<std::string> & joint_names,
-  const std::vector<std::string> & interfaces
-)
+  const std::vector<std::string> & joint_names, const std::vector<std::string> & interfaces)
 {
   const auto result = state_broadcaster_->init("joint_state_broadcaster");
   ASSERT_EQ(result, controller_interface::return_type::OK);
@@ -82,7 +80,8 @@ void JointStateBroadcasterTest::SetUpStateBroadcaster(
 
   std::vector<LoanedStateInterface> state_ifs;
 
-  if (joint_names.empty() || interfaces.empty()) {
+  if (joint_names.empty() || interfaces.empty())
+  {
     state_ifs.emplace_back(joint_1_pos_state_);
     state_ifs.emplace_back(joint_2_pos_state_);
     state_ifs.emplace_back(joint_3_pos_state_);
@@ -92,34 +91,47 @@ void JointStateBroadcasterTest::SetUpStateBroadcaster(
     state_ifs.emplace_back(joint_1_eff_state_);
     state_ifs.emplace_back(joint_2_eff_state_);
     state_ifs.emplace_back(joint_3_eff_state_);
-  } else {
-    for (const auto & joint : joint_names) {
-      for (const auto & interface : interfaces) {
-        if (joint == joint_names_[0] && interface == interface_names_[0]) {
+  }
+  else
+  {
+    for (const auto & joint : joint_names)
+    {
+      for (const auto & interface : interfaces)
+      {
+        if (joint == joint_names_[0] && interface == interface_names_[0])
+        {
           state_ifs.emplace_back(joint_1_pos_state_);
         }
-        if (joint == joint_names_[1] && interface == interface_names_[0]) {
+        if (joint == joint_names_[1] && interface == interface_names_[0])
+        {
           state_ifs.emplace_back(joint_2_pos_state_);
         }
-        if (joint == joint_names_[2] && interface == interface_names_[0]) {
+        if (joint == joint_names_[2] && interface == interface_names_[0])
+        {
           state_ifs.emplace_back(joint_3_pos_state_);
         }
-        if (joint == joint_names_[0] && interface == interface_names_[1]) {
+        if (joint == joint_names_[0] && interface == interface_names_[1])
+        {
           state_ifs.emplace_back(joint_1_vel_state_);
         }
-        if (joint == joint_names_[1] && interface == interface_names_[1]) {
+        if (joint == joint_names_[1] && interface == interface_names_[1])
+        {
           state_ifs.emplace_back(joint_2_vel_state_);
         }
-        if (joint == joint_names_[2] && interface == interface_names_[1]) {
+        if (joint == joint_names_[2] && interface == interface_names_[1])
+        {
           state_ifs.emplace_back(joint_3_vel_state_);
         }
-        if (joint == joint_names_[0] && interface == interface_names_[2]) {
+        if (joint == joint_names_[0] && interface == interface_names_[2])
+        {
           state_ifs.emplace_back(joint_1_eff_state_);
         }
-        if (joint == joint_names_[1] && interface == interface_names_[2]) {
+        if (joint == joint_names_[1] && interface == interface_names_[2])
+        {
           state_ifs.emplace_back(joint_2_eff_state_);
         }
-        if (joint == joint_names_[2] && interface == interface_names_[2]) {
+        if (joint == joint_names_[2] && interface == interface_names_[2])
+        {
           state_ifs.emplace_back(joint_3_eff_state_);
         }
       }
@@ -239,8 +251,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutJointsParameter)
   ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.interface_values, SizeIs(NUM_JOINTS));
   ASSERT_THAT(
-    state_broadcaster_->dynamic_joint_state_msg_.joint_names,
-    ElementsAreArray(joint_names_));
+    state_broadcaster_->dynamic_joint_state_msg_.joint_names, ElementsAreArray(joint_names_));
   ASSERT_THAT(
     state_broadcaster_->dynamic_joint_state_msg_.interface_values[0].interface_names,
     ElementsAreArray(interface_names_));
@@ -279,8 +290,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutInterfacesParameter)
   ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.interface_values, SizeIs(NUM_JOINTS));
   ASSERT_THAT(
-    state_broadcaster_->dynamic_joint_state_msg_.joint_names,
-    ElementsAreArray(joint_names_));
+    state_broadcaster_->dynamic_joint_state_msg_.joint_names, ElementsAreArray(joint_names_));
   ASSERT_THAT(
     state_broadcaster_->dynamic_joint_state_msg_.interface_values[0].interface_names,
     ElementsAreArray(interface_names_));
@@ -316,11 +326,13 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointsOneInterface)
   ASSERT_THAT(state_broadcaster_->joint_state_msg_.name, ElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(state_broadcaster_->joint_state_msg_.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(state_broadcaster_->joint_state_msg_.velocity, SizeIs(NUM_JOINTS));
-  for (auto i = 0ul; i < NUM_JOINTS; ++i) {
+  for (auto i = 0ul; i < NUM_JOINTS; ++i)
+  {
     ASSERT_TRUE(std::isnan(state_broadcaster_->joint_state_msg_.velocity[i]));
   }
   ASSERT_THAT(state_broadcaster_->joint_state_msg_.effort, SizeIs(NUM_JOINTS));
-  for (auto i = 0ul; i < NUM_JOINTS; ++i) {
+  for (auto i = 0ul; i < NUM_JOINTS; ++i)
+  {
     ASSERT_TRUE(std::isnan(state_broadcaster_->joint_state_msg_.effort[i]));
   }
 
@@ -328,8 +340,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointsOneInterface)
   ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.interface_values, SizeIs(NUM_JOINTS));
   ASSERT_THAT(
-    state_broadcaster_->dynamic_joint_state_msg_.joint_names,
-    ElementsAreArray(JOINT_NAMES));
+    state_broadcaster_->dynamic_joint_state_msg_.joint_names, ElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(
     state_broadcaster_->dynamic_joint_state_msg_.interface_values[0].interface_names,
     ElementsAreArray(IF_NAMES));
@@ -360,7 +371,8 @@ TEST_F(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces)
   ASSERT_THAT(state_broadcaster_->joint_state_msg_.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(state_broadcaster_->joint_state_msg_.velocity, SizeIs(NUM_JOINTS));
   ASSERT_THAT(state_broadcaster_->joint_state_msg_.effort, SizeIs(NUM_JOINTS));
-  for (auto i = 0ul; i < NUM_JOINTS; ++i) {
+  for (auto i = 0ul; i < NUM_JOINTS; ++i)
+  {
     ASSERT_TRUE(std::isnan(state_broadcaster_->joint_state_msg_.effort[i]));
   }
 
@@ -368,8 +380,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces)
   ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.interface_values, SizeIs(NUM_JOINTS));
   ASSERT_THAT(
-    state_broadcaster_->dynamic_joint_state_msg_.joint_names,
-    ElementsAreArray(JOINT_NAMES));
+    state_broadcaster_->dynamic_joint_state_msg_.joint_names, ElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(
     state_broadcaster_->dynamic_joint_state_msg_.interface_values[0].interface_names,
     ElementsAreArray(IF_NAMES));
@@ -378,7 +389,6 @@ TEST_F(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces)
   ASSERT_TRUE(state_broadcaster_->joint_state_publisher_);
   ASSERT_TRUE(state_broadcaster_->dynamic_joint_state_publisher_);
 }
-
 
 TEST_F(JointStateBroadcasterTest, UpdateTest)
 {

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -38,6 +38,8 @@ class FriendJointStateBroadcaster : public joint_state_broadcaster::JointStateBr
   FRIEND_TEST(JointStateBroadcasterTest, ActivateTestWithoutInterfacesParameter);
   FRIEND_TEST(JointStateBroadcasterTest, ActivateTestTwoJointsOneInterface);
   FRIEND_TEST(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces);
+  FRIEND_TEST(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesAllMissing);
+  FRIEND_TEST(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing);
   FRIEND_TEST(JointStateBroadcasterTest, ExtraJointStatePublishTest);
 };
 
@@ -51,6 +53,14 @@ public:
   void TearDown();
 
   void SetUpStateBroadcaster(
+    const std::vector<std::string> & joint_names = {},
+    const std::vector<std::string> & interfaces = {});
+
+  void init_broadcaster_and_set_parameters(
+    const std::vector<std::string> & joint_names = {},
+    const std::vector<std::string> & interfaces = {});
+
+  void assign_state_interfaces(
     const std::vector<std::string> & joint_names = {},
     const std::vector<std::string> & interfaces = {});
 

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -25,11 +25,11 @@
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 
+using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::HW_IF_VELOCITY;
-using hardware_interface::HW_IF_EFFORT;
 
-// subclassing and friending so we can access member varibles
+// subclassing and friending so we can access member variables
 class FriendJointStateBroadcaster : public joint_state_broadcaster::JointStateBroadcaster
 {
   FRIEND_TEST(JointStateBroadcasterTest, ConfigureErrorTest);
@@ -52,8 +52,7 @@ public:
 
   void SetUpStateBroadcaster(
     const std::vector<std::string> & joint_names = {},
-    const std::vector<std::string> & interfaces = {}
-  );
+    const std::vector<std::string> & interfaces = {});
 
   void test_published_joint_state_message(const std::string & topic);
 
@@ -65,24 +64,24 @@ protected:
   const std::vector<std::string> interface_names_ = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
   std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
 
-  hardware_interface::StateInterface joint_1_pos_state_{joint_names_[0], interface_names_[0],
-    &joint_values_[0]};
-  hardware_interface::StateInterface joint_2_pos_state_{joint_names_[1], interface_names_[0],
-    &joint_values_[1]};
-  hardware_interface::StateInterface joint_3_pos_state_{joint_names_[2], interface_names_[0],
-    &joint_values_[2]};
-  hardware_interface::StateInterface joint_1_vel_state_{joint_names_[0], interface_names_[1],
-    &joint_values_[0]};
-  hardware_interface::StateInterface joint_2_vel_state_{joint_names_[1], interface_names_[1],
-    &joint_values_[1]};
-  hardware_interface::StateInterface joint_3_vel_state_{joint_names_[2], interface_names_[1],
-    &joint_values_[2]};
-  hardware_interface::StateInterface joint_1_eff_state_{joint_names_[0], interface_names_[2],
-    &joint_values_[0]};
-  hardware_interface::StateInterface joint_2_eff_state_{joint_names_[1], interface_names_[2],
-    &joint_values_[1]};
-  hardware_interface::StateInterface joint_3_eff_state_{joint_names_[2], interface_names_[2],
-    &joint_values_[2]};
+  hardware_interface::StateInterface joint_1_pos_state_{
+    joint_names_[0], interface_names_[0], &joint_values_[0]};
+  hardware_interface::StateInterface joint_2_pos_state_{
+    joint_names_[1], interface_names_[0], &joint_values_[1]};
+  hardware_interface::StateInterface joint_3_pos_state_{
+    joint_names_[2], interface_names_[0], &joint_values_[2]};
+  hardware_interface::StateInterface joint_1_vel_state_{
+    joint_names_[0], interface_names_[1], &joint_values_[0]};
+  hardware_interface::StateInterface joint_2_vel_state_{
+    joint_names_[1], interface_names_[1], &joint_values_[1]};
+  hardware_interface::StateInterface joint_3_vel_state_{
+    joint_names_[2], interface_names_[1], &joint_values_[2]};
+  hardware_interface::StateInterface joint_1_eff_state_{
+    joint_names_[0], interface_names_[2], &joint_values_[0]};
+  hardware_interface::StateInterface joint_2_eff_state_{
+    joint_names_[1], interface_names_[2], &joint_values_[1]};
+  hardware_interface::StateInterface joint_3_eff_state_{
+    joint_names_[2], interface_names_[2], &joint_values_[2]};
 
   std::unique_ptr<FriendJointStateBroadcaster> state_broadcaster_;
 };

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -23,11 +23,21 @@
 
 #include "joint_state_broadcaster/joint_state_broadcaster.hpp"
 
-// subclassing and friending so we can access member variables
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+using hardware_interface::HW_IF_POSITION;
+using hardware_interface::HW_IF_VELOCITY;
+using hardware_interface::HW_IF_EFFORT;
+
+// subclassing and friending so we can access member varibles
 class FriendJointStateBroadcaster : public joint_state_broadcaster::JointStateBroadcaster
 {
   FRIEND_TEST(JointStateBroadcasterTest, ConfigureErrorTest);
-  FRIEND_TEST(JointStateBroadcasterTest, ConfigureSuccessTest);
+  FRIEND_TEST(JointStateBroadcasterTest, ActivateTest);
+  FRIEND_TEST(JointStateBroadcasterTest, ActivateTestWithoutJointsParameter);
+  FRIEND_TEST(JointStateBroadcasterTest, ActivateTestWithoutInterfacesParameter);
+  FRIEND_TEST(JointStateBroadcasterTest, ActivateTestTwoJointsOneInterface);
+  FRIEND_TEST(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces);
   FRIEND_TEST(JointStateBroadcasterTest, ExtraJointStatePublishTest);
 };
 
@@ -40,7 +50,10 @@ public:
   void SetUp();
   void TearDown();
 
-  void SetUpStateBroadcaster();
+  void SetUpStateBroadcaster(
+    const std::vector<std::string> & joint_names = {},
+    const std::vector<std::string> & interfaces = {}
+  );
 
   void test_published_joint_state_message(const std::string & topic);
 
@@ -49,26 +62,27 @@ public:
 protected:
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
+  const std::vector<std::string> interface_names_ = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
   std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
 
-  hardware_interface::StateInterface joint_1_pos_state_{
-    joint_names_[0], "position", &joint_values_[0]};
-  hardware_interface::StateInterface joint_2_pos_state_{
-    joint_names_[1], "position", &joint_values_[1]};
-  hardware_interface::StateInterface joint_3_pos_state_{
-    joint_names_[2], "position", &joint_values_[2]};
-  hardware_interface::StateInterface joint_1_vel_state_{
-    joint_names_[0], "velocity", &joint_values_[0]};
-  hardware_interface::StateInterface joint_2_vel_state_{
-    joint_names_[1], "velocity", &joint_values_[1]};
-  hardware_interface::StateInterface joint_3_vel_state_{
-    joint_names_[2], "velocity", &joint_values_[2]};
-  hardware_interface::StateInterface joint_1_eff_state_{
-    joint_names_[0], "effort", &joint_values_[0]};
-  hardware_interface::StateInterface joint_2_eff_state_{
-    joint_names_[1], "effort", &joint_values_[1]};
-  hardware_interface::StateInterface joint_3_eff_state_{
-    joint_names_[2], "effort", &joint_values_[2]};
+  hardware_interface::StateInterface joint_1_pos_state_{joint_names_[0], interface_names_[0],
+    &joint_values_[0]};
+  hardware_interface::StateInterface joint_2_pos_state_{joint_names_[1], interface_names_[0],
+    &joint_values_[1]};
+  hardware_interface::StateInterface joint_3_pos_state_{joint_names_[2], interface_names_[0],
+    &joint_values_[2]};
+  hardware_interface::StateInterface joint_1_vel_state_{joint_names_[0], interface_names_[1],
+    &joint_values_[0]};
+  hardware_interface::StateInterface joint_2_vel_state_{joint_names_[1], interface_names_[1],
+    &joint_values_[1]};
+  hardware_interface::StateInterface joint_3_vel_state_{joint_names_[2], interface_names_[1],
+    &joint_values_[2]};
+  hardware_interface::StateInterface joint_1_eff_state_{joint_names_[0], interface_names_[2],
+    &joint_values_[0]};
+  hardware_interface::StateInterface joint_2_eff_state_{joint_names_[1], interface_names_[2],
+    &joint_values_[1]};
+  hardware_interface::StateInterface joint_3_eff_state_{joint_names_[2], interface_names_[2],
+    &joint_values_[2]};
 
   std::unique_ptr<FriendJointStateBroadcaster> state_broadcaster_;
 };


### PR DESCRIPTION
- Joint state broadcaster support for specific joint_names and interface_names.
- Extend documentation.
