### PR TITLE
[Joint State Broadcaster] Add mapping of custom states to standard values in "/joint_state" message

### DIFF
--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -65,18 +65,25 @@ Parameters
   Examples:
 
   .. code-block:: yaml
-      map_interface_to_joint_state
+
+      map_interface_to_joint_state:
         position: kf_estimated_position
 
+
   .. code-block:: yaml
-      map_interface_to_joint_state
+
+      map_interface_to_joint_state:
         velocity: derived_velocity
         effort: derived_effort
 
-  .. code-block:: yaml
-      map_interface_to_joint_state
-        effort: torque_sensor
 
   .. code-block:: yaml
-      map_interface_to_joint_state
+
+      map_interface_to_joint_state:
+        effort: torque_sensor
+
+
+  .. code-block:: yaml
+
+      map_interface_to_joint_state:
         effort: current_sensor

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -60,3 +60,23 @@ Parameters
         position: <custom_interface>
         velocity: <custom_interface>
         effort: <custom_interface>
+
+
+  Examples:
+
+  .. code-block:: yaml
+      map_interface_to_joint_state
+        position: kf_estimated_position
+
+  .. code-block:: yaml
+      map_interface_to_joint_state
+        velocity: derived_velocity
+        effort: derived_effort
+
+  .. code-block:: yaml
+      map_interface_to_joint_state
+        effort: torque_sensor
+
+  .. code-block:: yaml
+      map_interface_to_joint_state
+        effort: current_sensor

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -40,3 +40,26 @@ Parameters
 ``extra_joints``
 
   Optional parameter (string array) with names of extra joints to be added to ``joint_states`` and ``dynamic_joint_states`` with state set to 0.
+
+
+``map_interface_to_joint_state``
+
+  Optional parameter (map) providing mapping between custom interface names to standard fields in ``joints_states`` message.
+  Usecases:
+
+    1. Hydraulics robots where feedback and commanded values have offset.
+       Typically one would map both values in separate interfaces in the framework.
+       To visualize those data multiple JSB's and robot_state_publishers would be used to visualize both values in RViz.
+
+    1. A robot provides different measuring tequniques for its joint values which results in slightly different values.
+       Typically one would use separate interface for providing those values in the framework.
+       Using multiple JSB's we could publish and show both in RViz.
+
+  Format (each line is optional):
+
+  .. code-block:: yaml
+
+     map_interface_to_joint_state
+       position: <custom_interfce>
+       velocity: <custom_interface>
+       effort: <custom_interface>

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -27,14 +27,12 @@ Parameters
 
 
 ``joints``
-
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with the ``interfaces`` parameter.
   Joint state broadcaster asks for access to all defined interfaces on all defined joints.
 
 
 ``interfaces``
-
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with the ``joints`` parameter.
 

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -56,7 +56,7 @@ Parameters
 
   .. code-block:: yaml
 
-      map_interface_to_joint_state
+      map_interface_to_joint_state:
         position: <custom_interface>
         velocity: <custom_interface>
         effort: <custom_interface>

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -22,28 +22,21 @@ Parameters
 ----------
 
 ``use_local_topics``
-
   Optional parameter (boolean; default: ``False``) defining if ``joint_states`` and ``dynamic_joint_states`` messages should be published into local namespace, e.g., ``/my_state_broadcaster/joint_states``.
-
 
 ``joints``
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with the ``interfaces`` parameter.
   Joint state broadcaster asks for access to all defined interfaces on all defined joints.
 
-
 ``interfaces``
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with the ``joints`` parameter.
 
-
 ``extra_joints``
-
   Optional parameter (string array) with names of extra joints to be added to ``joint_states`` and ``dynamic_joint_states`` with state set to 0.
 
-
 ``map_interface_to_joint_state``
-
   Optional parameter (map) providing mapping between custom interface names to standard fields in ``joints_states`` message.
   Usecases:
 
@@ -51,7 +44,7 @@ Parameters
        Typically one would map both values in separate interfaces in the framework.
        To visualize those data multiple JSB's and robot_state_publishers would be used to visualize both values in RViz.
 
-    1. A robot provides different measuring tequniques for its joint values which results in slightly different values.
+    1. A robot provides different measuring techniques for its joint values which results in slightly different values.
        Typically one would use separate interface for providing those values in the framework.
        Using multiple JSB's we could publish and show both in RViz.
 
@@ -59,7 +52,7 @@ Parameters
 
   .. code-block:: yaml
 
-     map_interface_to_joint_state
-       position: <custom_interfce>
-       velocity: <custom_interface>
-       effort: <custom_interface>
+      map_interface_to_joint_state
+        position: <custom_interfce>
+        velocity: <custom_interface>
+        effort: <custom_interface>

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -41,22 +41,22 @@ Parameters
 
 
 ``map_interface_to_joint_state``
-  Optional parameter (map) providing mapping between custom interface names to standard fields in ``joints_states`` message.
+  Optional parameter (map) providing mapping between custom interface names to standard fields in ``joint_states`` message.
   Usecases:
 
-    1. Hydraulics robots where feedback and commanded values have offset.
+    1. Hydraulics robots where feedback and commanded values often have an offset and reliance on open-loop control is common.
        Typically one would map both values in separate interfaces in the framework.
-       To visualize those data multiple JSB's and robot_state_publishers would be used to visualize both values in RViz.
+       To visualize those data multiple joint_state_broadcaster instances and robot_state_publishers would be used to visualize both values in RViz.
 
-    1. A robot provides different measuring techniques for its joint values which results in slightly different values.
+    1. A robot provides multiple measuring techniques for its joint values which results in slightly different values.
        Typically one would use separate interface for providing those values in the framework.
-       Using multiple JSB's we could publish and show both in RViz.
+       Using multiple joint_state_broadcaster instances we could publish and show both in RViz.
 
   Format (each line is optional):
 
   .. code-block:: yaml
 
       map_interface_to_joint_state
-        position: <custom_interfce>
+        position: <custom_interface>
         velocity: <custom_interface>
         effort: <custom_interface>

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -24,17 +24,21 @@ Parameters
 ``use_local_topics``
   Optional parameter (boolean; default: ``False``) defining if ``joint_states`` and ``dynamic_joint_states`` messages should be published into local namespace, e.g., ``/my_state_broadcaster/joint_states``.
 
+
 ``joints``
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with the ``interfaces`` parameter.
   Joint state broadcaster asks for access to all defined interfaces on all defined joints.
 
+
 ``interfaces``
   Optional parameter (string array) to support broadcasting of only specific joints and interfaces.
   It has to be used in combination with the ``joints`` parameter.
 
+
 ``extra_joints``
   Optional parameter (string array) with names of extra joints to be added to ``joint_states`` and ``dynamic_joint_states`` with state set to 0.
+
 
 ``map_interface_to_joint_state``
   Optional parameter (map) providing mapping between custom interface names to standard fields in ``joints_states`` message.

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -38,7 +38,7 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
  * There is a possibility to publish all available states (typical use), or only specific ones.
  * The latter is, for example, used when hardware provides multiple measurement sources for some
  * of its states, e.g., position.
- * Mapping of interfaces parameter enables to map the measurements
+ * It is possible to define a mapping of measurements
  * from different sources stored in custom interfaces to standard dynamic names in JointState
  * message.
  * If "joints" or "interfaces" parameter is empty, all available states are published.

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -57,10 +57,6 @@ public:
   JointStateBroadcaster();
 
   JOINT_STATE_BROADCASTER_PUBLIC
-  controller_interface::return_type
-  init(const std::string & controller_name) override;
-
-  JOINT_STATE_BROADCASTER_PUBLIC
   controller_interface::InterfaceConfiguration command_interface_configuration() const override;
 
   JOINT_STATE_BROADCASTER_PUBLIC

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -38,11 +38,16 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
  * There is a possibility to publish all available states (typical use), or only specific ones.
  * The latter is, for example, used when hardware provides multiple measurement sources for some
  * of its states, e.g., position.
+ * Mapping of interfaces parameter enables to map the measurements
+ * from different sources stored in custom interfaces to standard dynamic names in JointState
+ * message.
  * If "joints" or "interfaces" parameter is empty, all available states are published.
  *
  * \param use_local_topics Flag to publish topics in local namespace.
  * \param joints Names of the joints to publish.
  * \param interfaces Names of interfaces to publish.
+ * \param map_interface_to_joint_state.{HW_IF_POSITION|HW_IF_VELOCITY|HW_IF_EFFORT} mapping
+ * between custom interface names and standard names in sensor_msgs::msg::JointState message.
  *
  * Publishes to:
  * - \b joint_states (sensor_msgs::msg::JointState): Joint states related to movement
@@ -89,6 +94,7 @@ protected:
   bool use_local_topics_;
   std::vector<std::string> joints_;
   std::vector<std::string> interfaces_;
+  std::unordered_map<std::string, std::string> map_interface_to_joint_state_;
 
   //  For the JointState message,
   //  we store the name of joints with compatible interfaces

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -57,6 +57,10 @@ public:
   JointStateBroadcaster();
 
   JOINT_STATE_BROADCASTER_PUBLIC
+  controller_interface::return_type
+  init(const std::string & controller_name) override;
+
+  JOINT_STATE_BROADCASTER_PUBLIC
   controller_interface::InterfaceConfiguration command_interface_configuration() const override;
 
   JOINT_STATE_BROADCASTER_PUBLIC

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -115,8 +115,7 @@ CallbackReturn JointStateBroadcaster::on_configure(
       "Publishing state interfaces defined in 'joints' and 'interfaces' parameters.");
   }
 
-  try
-  {
+  try {
     const std::string topic_name_prefix = use_local_topics_ ? "~/" : "";
 
     joint_state_publisher_ = get_node()->create_publisher<sensor_msgs::msg::JointState>(

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -239,7 +239,7 @@ bool JointStateBroadcaster::init_joint_data()
     {
       interface_name = map_interface_to_joint_state_[interface_name];
     }
-    name_if_value_mapping_[si->get_name()][si->get_interface_name()] = kUninitializedValue;
+        name_if_value_mapping_[si->get_name()][interface_name] = kUninitializedValue;
   }
 
   // filter state interfaces that have at least one of the joint_states fields,
@@ -335,7 +335,7 @@ controller_interface::return_type JointStateBroadcaster::update(
     {
       interface_name = map_interface_to_joint_state_[interface_name];
     }
-    name_if_value_mapping_[state_interface.get_name()][state_interface.get_interface_name()] =
+    name_if_value_mapping_[state_interface.get_name()][interface_name] =
       state_interface.get_value();
     RCLCPP_DEBUG(
       get_node()->get_logger(), "%s: %f\n", state_interface.get_full_name().c_str(),

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -239,7 +239,7 @@ bool JointStateBroadcaster::init_joint_data()
     {
       interface_name = map_interface_to_joint_state_[interface_name];
     }
-        name_if_value_mapping_[si->get_name()][interface_name] = kUninitializedValue;
+    name_if_value_mapping_[si->get_name()][interface_name] = kUninitializedValue;
   }
 
   // filter state interfaces that have at least one of the joint_states fields,

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -115,7 +115,8 @@ CallbackReturn JointStateBroadcaster::on_configure(
       "Publishing state interfaces defined in 'joints' and 'interfaces' parameters.");
   }
 
-  try {
+  try
+  {
     const std::string topic_name_prefix = use_local_topics_ ? "~/" : "";
 
     joint_state_publisher_ = get_node()->create_publisher<sensor_msgs::msg::JointState>(

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -473,6 +473,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing)
   ASSERT_TRUE(state_broadcaster_->dynamic_joint_state_publisher_);
 }
 
+
 TEST_F(JointStateBroadcasterTest, UpdateTest)
 {
   SetUpStateBroadcaster();

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -40,6 +40,9 @@ class FriendJointStateBroadcaster : public joint_state_broadcaster::JointStateBr
   FRIEND_TEST(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces);
   FRIEND_TEST(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesAllMissing);
   FRIEND_TEST(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing);
+  FRIEND_TEST(JointStateBroadcasterTest, TestCustomInterfaceWithoutMapping);
+  FRIEND_TEST(JointStateBroadcasterTest, TestCustomInterfaceMapping);
+  FRIEND_TEST(JointStateBroadcasterTest, TestCustomInterfaceMappingUpdate);
   FRIEND_TEST(JointStateBroadcasterTest, ExtraJointStatePublishTest);
 };
 
@@ -72,7 +75,9 @@ protected:
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
   const std::vector<std::string> interface_names_ = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
+  std::string custom_interface_name_ = "measured_position";
   std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
+  double custom_joint_value_ = 3.5;
 
   hardware_interface::StateInterface joint_1_pos_state_{
     joint_names_[0], interface_names_[0], &joint_values_[0]};
@@ -92,6 +97,9 @@ protected:
     joint_names_[1], interface_names_[2], &joint_values_[1]};
   hardware_interface::StateInterface joint_3_eff_state_{
     joint_names_[2], interface_names_[2], &joint_values_[2]};
+
+  hardware_interface::StateInterface joint_X_custom_state{
+    joint_names_[0], custom_interface_name_, &custom_joint_value_};
 
   std::unique_ptr<FriendJointStateBroadcaster> state_broadcaster_;
 };


### PR DESCRIPTION
Note: it has also changes from #216 beucase it sits ontop the changes.

This mapping is useful when using multiple broadcaster to publish custom values on separate "joint_states" topic.
For example: 
1. Hydraulics robots where feedback and commanded values have offset.
   Typically one would map both values in separete interfaces inthe framework.
   To visualize those data mutiple JSB's and `robot_state_publishers` would be used to visualize both values in RViz.

1. A robot provides different measuring tequniques for its joint values which results in slightly differnt values.
   Typically one would use separate interface for providing those values in the framework. 
   Using multiple JSB's we could publish and show both in RViz.

What do you think about this functionality?