### PR TITLE
[Joint State Broadcaster] Add option to publish joint states to local topics

### DIFF
--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -19,10 +19,7 @@ Parameters
 ----------
 
 ``use_local_topics``
-
   Optional parameter (boolean; default: ``False``) defining if ``joint_states`` and ``dynamic_joint_states`` messages should be published into local namespace, e.g., ``/my_state_broadcaster/joint_states``.
 
-
 ``extra_joints``
-
   Optional parameter (string array) with names of extra joints to be added to ``joint_states`` and ``dynamic_joint_states`` with state set to 0.

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -18,5 +18,11 @@ All available *joint state interfaces* are used by this broadcaster.
 Parameters
 ----------
 
-extra_joints (optional; string array; default: empty)
-  Names of extra joints to be added to ``/joint_states`` and ``/dynamic_joint_states`` with state set to 0.
+``use_local_topics``
+
+  Optional parameter (boolean; default: ``False``) defining if ``joint_states`` and ``dynamic_joint_states`` messages should be published into local namespace, e.g., ``/my_state_broadcaster/joint_states``.
+
+
+``extra_joints``
+
+  Optional parameter (string array) with names of extra joints to be added to ``joint_states`` and ``dynamic_joint_states`` with state set to 0.

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -37,6 +37,10 @@ public:
   JointStateBroadcaster();
 
   JOINT_STATE_BROADCASTER_PUBLIC
+  controller_interface::return_type
+  init(const std::string & controller_name) override;
+
+  JOINT_STATE_BROADCASTER_PUBLIC
   controller_interface::InterfaceConfiguration command_interface_configuration() const override;
 
   JOINT_STATE_BROADCASTER_PUBLIC
@@ -64,6 +68,8 @@ protected:
   void init_dynamic_joint_state_msg();
 
 protected:
+  bool use_local_topics_;
+
   //  For the JointState message,
   //  we store the name of joints with compatible interfaces
   std::vector<std::string> joint_names_;

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -62,6 +62,8 @@ JointStateBroadcaster::init(const std::string & controller_name)
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;
   }
+
+  return controller_interface::return_type::OK;
 }
 
 controller_interface::InterfaceConfiguration

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -229,8 +229,8 @@ JointStateBroadcaster::update()
       state_interface.get_value());
   }
 
-  joint_state_msg_.header.stamp = node_->get_clock()->now();
-  dynamic_joint_state_msg_.header.stamp = node_->get_clock()->now();
+  joint_state_msg_.header.stamp = get_node()->get_clock()->now();
+  dynamic_joint_state_msg_.header.stamp = get_node()->get_clock()->now();
 
   // update joint state message and dynamic joint state message
   for (auto i = 0ul; i < joint_names_.size(); ++i) {

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -67,11 +67,11 @@ JointStateBroadcaster::on_configure(const rclcpp_lifecycle::State & /*previous_s
 {
   try {
     joint_state_publisher_ = get_node()->create_publisher<sensor_msgs::msg::JointState>(
-      "joint_states", rclcpp::SystemDefaultsQoS());
+      "~/joint_states", rclcpp::SystemDefaultsQoS());
 
     dynamic_joint_state_publisher_ =
       get_node()->create_publisher<control_msgs::msg::DynamicJointState>(
-      "dynamic_joint_states", rclcpp::SystemDefaultsQoS());
+      "~/dynamic_joint_states", rclcpp::SystemDefaultsQoS());
   } catch (const std::exception & e) {
     // get_node() may throw, logging raw here
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -213,7 +213,7 @@ TEST_F(JointStateBroadcasterTest, JointStatePublishTest)
     {
     };
   auto subscription = test_node.create_subscription<sensor_msgs::msg::JointState>(
-    "joint_states",
+    "joint_state_broadcaster/joint_states",
     10,
     subs_callback);
 
@@ -253,7 +253,7 @@ TEST_F(JointStateBroadcasterTest, DynamicJointStatePublishTest)
     {
     };
   auto subscription = test_node.create_subscription<control_msgs::msg::DynamicJointState>(
-    "dynamic_joint_states",
+    "joint_state_broadcaster/dynamic_joint_states",
     10,
     subs_callback);
 

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -336,10 +336,8 @@ TEST_F(JointStateBroadcasterTest, ExtraJointStatePublishTest)
   SetUpStateBroadcaster();
 
   // Add extra joints as parameters
-  auto broadcaster_node = state_broadcaster_->get_node();
   const std::vector<std::string> extra_joint_names = {"extra1", "extra2", "extra3"};
-  const rclcpp::Parameter extra_joints_parameters("extra_joints", extra_joint_names);
-  broadcaster_node->set_parameter(extra_joints_parameters);
+  state_broadcaster_->get_node()->set_parameter({"extra_joints", extra_joint_names});
 
   // configure ok
   ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -42,6 +42,10 @@ public:
 
   void SetUpStateBroadcaster();
 
+  void test_published_joint_state_message(const std::string & topic);
+
+  void test_published_dynamic_joint_state_message(const std::string & topic);
+
 protected:
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};


### PR DESCRIPTION
This PR is related/inspired by #217 and #218.

Changes:
- Use local topics for publishing joint states
- Parameterize local namespace topics.
- Unify test structure.
- Use get_node() instead of node_ everywhere.

What do you think?