### PR TITLE
Delete failing parameter undeclare in JointGroupPositionController

### DIFF
--- a/effort_controllers/src/joint_group_effort_controller.cpp
+++ b/effort_controllers/src/joint_group_effort_controller.cpp
@@ -40,8 +40,10 @@ JointGroupEffortController::init(
   }
 
   try {
-    // undeclare interface parameter used in the general forward_command_controller
-    get_node()->undeclare_parameter("interface_name");
+    // Explicitly set the interface parameter declared by the forward_command_controller
+    // to match the value set in the JointGroupEffortController constructor.
+    get_node()->set_parameter(rclcpp::Parameter("interface_name", hardware_interface::HW_IF_EFFORT));
+
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;

--- a/effort_controllers/src/joint_group_effort_controller.cpp
+++ b/effort_controllers/src/joint_group_effort_controller.cpp
@@ -43,7 +43,7 @@ JointGroupEffortController::init(
     // Explicitly set the interface parameter declared by the forward_command_controller
     // to match the value set in the JointGroupEffortController constructor.
     get_node()->set_parameter(
-          rclcpp::Parameter("interface_name", hardware_interface::HW_IF_EFFORT));
+      rclcpp::Parameter("interface_name", hardware_interface::HW_IF_EFFORT));
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;

--- a/effort_controllers/src/joint_group_effort_controller.cpp
+++ b/effort_controllers/src/joint_group_effort_controller.cpp
@@ -42,8 +42,8 @@ JointGroupEffortController::init(
   try {
     // Explicitly set the interface parameter declared by the forward_command_controller
     // to match the value set in the JointGroupEffortController constructor.
-    get_node()->set_parameter(rclcpp::Parameter("interface_name", hardware_interface::HW_IF_EFFORT));
-
+    get_node()->set_parameter(
+          rclcpp::Parameter("interface_name", hardware_interface::HW_IF_EFFORT));
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;

--- a/position_controllers/src/joint_group_position_controller.cpp
+++ b/position_controllers/src/joint_group_position_controller.cpp
@@ -38,6 +38,16 @@ JointGroupPositionController::init(const std::string & controller_name)
     return ret;
   }
 
+  try {
+    // Explicitly set the interface parameter declared by the forward_command_controller
+    // to match the value set in the JointGroupPositionController constructor.
+    get_node()->set_parameter(rclcpp::Parameter("interface_name", hardware_interface::HW_IF_POSITION));
+
+  } catch (const std::exception & e) {
+    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
+    return controller_interface::return_type::ERROR;
+  }
+
   return controller_interface::return_type::OK;
 }
 }  // namespace position_controllers

--- a/position_controllers/src/joint_group_position_controller.cpp
+++ b/position_controllers/src/joint_group_position_controller.cpp
@@ -38,14 +38,6 @@ JointGroupPositionController::init(const std::string & controller_name)
     return ret;
   }
 
-  try {
-    // undeclare interface parameter used in the general forward_command_controller
-    get_node()->undeclare_parameter("interface_name");
-  } catch (const std::exception & e) {
-    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
-    return controller_interface::return_type::ERROR;
-  }
-
   return controller_interface::return_type::OK;
 }
 }  // namespace position_controllers

--- a/position_controllers/src/joint_group_position_controller.cpp
+++ b/position_controllers/src/joint_group_position_controller.cpp
@@ -41,8 +41,8 @@ JointGroupPositionController::init(const std::string & controller_name)
   try {
     // Explicitly set the interface parameter declared by the forward_command_controller
     // to match the value set in the JointGroupPositionController constructor.
-    get_node()->set_parameter(rclcpp::Parameter("interface_name", hardware_interface::HW_IF_POSITION));
-
+    get_node()->set_parameter(
+          rclcpp::Parameter("interface_name", hardware_interface::HW_IF_POSITION));
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;

--- a/position_controllers/src/joint_group_position_controller.cpp
+++ b/position_controllers/src/joint_group_position_controller.cpp
@@ -42,7 +42,7 @@ JointGroupPositionController::init(const std::string & controller_name)
     // Explicitly set the interface parameter declared by the forward_command_controller
     // to match the value set in the JointGroupPositionController constructor.
     get_node()->set_parameter(
-          rclcpp::Parameter("interface_name", hardware_interface::HW_IF_POSITION));
+      rclcpp::Parameter("interface_name", hardware_interface::HW_IF_POSITION));
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;

--- a/velocity_controllers/src/joint_group_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_group_velocity_controller.cpp
@@ -40,8 +40,10 @@ JointGroupVelocityController::init(
   }
 
   try {
-    // undeclare interface parameter used in the general forward_command_controller
-    get_node()->undeclare_parameter("interface_name");
+    // Explicitly set the interface parameter declared by the forward_command_controller
+    // to match the value set in the JointGroupVelocityController constructor.
+    get_node()->set_parameter(rclcpp::Parameter("interface_name", hardware_interface::HW_IF_VELOCITY));
+
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;

--- a/velocity_controllers/src/joint_group_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_group_velocity_controller.cpp
@@ -43,7 +43,7 @@ JointGroupVelocityController::init(
     // Explicitly set the interface parameter declared by the forward_command_controller
     // to match the value set in the JointGroupVelocityController constructor.
     get_node()->set_parameter(
-          rclcpp::Parameter("interface_name", hardware_interface::HW_IF_VELOCITY));
+      rclcpp::Parameter("interface_name", hardware_interface::HW_IF_VELOCITY));
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;

--- a/velocity_controllers/src/joint_group_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_group_velocity_controller.cpp
@@ -42,8 +42,8 @@ JointGroupVelocityController::init(
   try {
     // Explicitly set the interface parameter declared by the forward_command_controller
     // to match the value set in the JointGroupVelocityController constructor.
-    get_node()->set_parameter(rclcpp::Parameter("interface_name", hardware_interface::HW_IF_VELOCITY));
-
+    get_node()->set_parameter(
+          rclcpp::Parameter("interface_name", hardware_interface::HW_IF_VELOCITY));
   } catch (const std::exception & e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return controller_interface::return_type::ERROR;


### PR DESCRIPTION
This is one way to fix #221 and allow loading the JointGroupPositionController plugin on Rolling.

If I understand correctly, the JointGroupPositionController just sets the value of `interface_name_` to `hardware_interface::HW_IF_POSITION` instead of reading it from a parameter, so it shouldn't make a functional difference whether the parameter is explicitly undeclared or simply not read.