### PR TITLE
[JointTrajectoryController] Add velocity-only command option for JTC with closed loop controller

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(ament_cmake REQUIRED)
 find_package(angles REQUIRED)
 find_package(controller_interface REQUIRED)
 find_package(control_msgs REQUIRED)
+find_package(control_toolbox REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -31,6 +32,7 @@ ament_target_dependencies(joint_trajectory_controller
   builtin_interfaces
   controller_interface
   control_msgs
+  control_toolbox
   hardware_interface
   pluginlib
   rclcpp

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -67,7 +67,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_trajectory_controller
     test/test_trajectory_controller.cpp
     ENV config_file=${CMAKE_CURRENT_SOURCE_DIR}/test/config/test_joint_trajectory_controller.yaml)
-  set_tests_properties(test_trajectory_controller PROPERTIES TIMEOUT 180)
+  set_tests_properties(test_trajectory_controller PROPERTIES TIMEOUT 220)
   target_include_directories(test_trajectory_controller PRIVATE include)
   target_link_libraries(test_trajectory_controller
     joint_trajectory_controller

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -150,6 +150,7 @@ protected:
   std::vector<PidPtr> pids_;
   std::chrono::steady_clock::time_point last_update_time_;
   std::vector<double> velocity_ff_;
+  std::vector<double> command_;
 
   // TODO(karsten1987): eventually activate and deactivate subscriber directly when its supported
   bool subscriber_is_active_ = false;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -135,6 +135,7 @@ protected:
   InterfaceReferences<hardware_interface::LoanedCommandInterface> joint_command_interface_;
   InterfaceReferences<hardware_interface::LoanedStateInterface> joint_state_interface_;
 
+  bool has_position_state_interface_ = false;
   bool has_velocity_state_interface_ = false;
   bool has_acceleration_state_interface_ = false;
   bool has_position_command_interface_ = false;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -148,9 +148,10 @@ protected:
   bool use_closed_loop_pid_adapter = false;
   using PidPtr = std::shared_ptr<control_toolbox::Pid>;
   std::vector<PidPtr> pids_;
-  std::chrono::steady_clock::time_point last_update_time_;
-  std::vector<double> velocity_ff_;
-  std::vector<double> command_;
+    /// Feed-forward velocity weight factor when calculating closed loop pid adapter's command
+  std::vector<double> ff_velocity_scale_;
+    /// reserved storage for result of the command when closed loop pid adapter is used
+  std::vector<double> tmp_command_;
 
   // TODO(karsten1987): eventually activate and deactivate subscriber directly when its supported
   bool subscriber_is_active_ = false;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -24,6 +24,7 @@
 
 #include "control_msgs/action/follow_joint_trajectory.hpp"
 #include "control_msgs/msg/joint_trajectory_controller_state.hpp"
+#include "control_toolbox/pid.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "joint_trajectory_controller/tolerances.hpp"
@@ -145,6 +146,10 @@ protected:
   // There should be PID-approach used as in ROS1:
   // https://github.com/ros-controls/ros_controllers/blob/noetic-devel/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h#L283
   bool use_closed_loop_pid_adapter = false;
+  using PidPtr = std::shared_ptr<control_toolbox::Pid>;
+  std::vector<PidPtr> pids_;
+  std::chrono::steady_clock::time_point last_update_time_;
+  std::vector<double> velocity_ff_;
 
   // TODO(karsten1987): eventually activate and deactivate subscriber directly when its supported
   bool subscriber_is_active_ = false;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -148,9 +148,9 @@ protected:
   bool use_closed_loop_pid_adapter = false;
   using PidPtr = std::shared_ptr<control_toolbox::Pid>;
   std::vector<PidPtr> pids_;
-    /// Feed-forward velocity weight factor when calculating closed loop pid adapter's command
+  /// Feed-forward velocity weight factor when calculating closed loop pid adapter's command
   std::vector<double> ff_velocity_scale_;
-    /// reserved storage for result of the command when closed loop pid adapter is used
+  /// reserved storage for result of the command when closed loop pid adapter is used
   std::vector<double> tmp_command_;
 
   // TODO(karsten1987): eventually activate and deactivate subscriber directly when its supported

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -205,11 +205,11 @@ controller_interface::return_type JointTrajectoryController::update(
           // Update PIDs
           for (auto i = 0ul; i < joint_num; ++i)
           {
-            tmp_command_[i] =
-              (state_desired.velocities[i] * ff_velocity_scale_[i]) +
-              pids_[i]->computeCommand(
-                state_desired.positions[i] - state_current.positions[i],
-                state_desired.velocities[i] - state_current.velocities[i], period.seconds());
+            tmp_command_[i] = (state_desired.velocities[i] * ff_velocity_scale_[i]) +
+                              pids_[i]->computeCommand(
+                                state_desired.positions[i] - state_current.positions[i],
+                                state_desired.velocities[i] - state_current.velocities[i],
+                                (uint64_t)period.nanoseconds());
           }
 
           assign_interface_from_point(joint_command_interface_[1], tmp_command_);

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -558,7 +558,7 @@ CallbackReturn JointTrajectoryController::on_configure(const rclcpp_lifecycle::S
       // Initialize PID
       pids_[i] = std::make_shared<control_toolbox::Pid>(k_p, k_i, k_d, i_clamp, -i_clamp);
     }
-    //TODO(livanov93) add other option when implemented
+    // TODO(livanov93): add other option when implemented
   }
 
   // Read always state interfaces from the parameter because they can be used

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -591,10 +591,7 @@ CallbackReturn JointTrajectoryController::on_configure(const rclcpp_lifecycle::S
     }
   }
 
-  if (contains_interface_type(state_interface_types_, hardware_interface::HW_IF_POSITION))
-  {
-    has_position_state_interface_ = true;
-  }
+  has_position_state_interface_ = contains_interface_type(state_interface_types_, hardware_interface::HW_IF_POSITION;
   if (contains_interface_type(state_interface_types_, hardware_interface::HW_IF_VELOCITY))
   {
     has_velocity_state_interface_ = true;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -558,7 +558,7 @@ CallbackReturn JointTrajectoryController::on_configure(const rclcpp_lifecycle::S
       // Initialize PID
       pids_[i] = std::make_shared<control_toolbox::Pid>(k_p, k_i, k_d, i_clamp, -i_clamp);
     }
-    //TODO add other option when implemented
+    //TODO(livanov93) add other option when implemented
   }
 
   // Read always state interfaces from the parameter because they can be used

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -829,8 +829,7 @@ CallbackReturn JointTrajectoryController::on_deactivate(const rclcpp_lifecycle::
 
     if (has_velocity_command_interface_)
     {
-      joint_command_interface_[1][index].get().set_value(
-        joint_command_interface_[1][index].get().get_value());
+      joint_command_interface_[1][index].get().set_value(0.0);
     }
   }
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -498,18 +498,12 @@ CallbackReturn JointTrajectoryController::on_configure(const rclcpp_lifecycle::S
     }
   }
 
-  if (contains_interface_type(command_interface_types_, hardware_interface::HW_IF_POSITION))
-  {
-    has_position_command_interface_ = true;
-  }
-  if (contains_interface_type(command_interface_types_, hardware_interface::HW_IF_VELOCITY))
-  {
-    has_velocity_command_interface_ = true;
-  }
-  if (contains_interface_type(command_interface_types_, hardware_interface::HW_IF_ACCELERATION))
-  {
-    has_acceleration_command_interface_ = true;
-  }
+  has_position_command_interface_ =
+    contains_interface_type(command_interface_types_, hardware_interface::HW_IF_POSITION);
+  has_velocity_command_interface_ =
+    contains_interface_type(command_interface_types_, hardware_interface::HW_IF_VELOCITY);
+  has_acceleration_command_interface_ =
+    contains_interface_type(command_interface_types_, hardware_interface::HW_IF_ACCELERATION);
 
   if (has_velocity_command_interface_)
   {
@@ -591,15 +585,12 @@ CallbackReturn JointTrajectoryController::on_configure(const rclcpp_lifecycle::S
     }
   }
 
-  has_position_state_interface_ = contains_interface_type(state_interface_types_, hardware_interface::HW_IF_POSITION;
-  if (contains_interface_type(state_interface_types_, hardware_interface::HW_IF_VELOCITY))
-  {
-    has_velocity_state_interface_ = true;
-  }
-  if (contains_interface_type(state_interface_types_, hardware_interface::HW_IF_ACCELERATION))
-  {
-    has_acceleration_state_interface_ = true;
-  }
+  has_position_state_interface_ =
+    contains_interface_type(state_interface_types_, hardware_interface::HW_IF_POSITION);
+  has_velocity_state_interface_ =
+    contains_interface_type(state_interface_types_, hardware_interface::HW_IF_VELOCITY);
+  has_acceleration_state_interface_ =
+    contains_interface_type(state_interface_types_, hardware_interface::HW_IF_ACCELERATION);
 
   if (has_velocity_state_interface_)
   {

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -58,6 +58,11 @@ using test_trajectory_controllers::TestableJointTrajectoryController;
 using test_trajectory_controllers::TrajectoryControllerTest;
 using test_trajectory_controllers::TrajectoryControllerTestParameterized;
 
+bool is_same_sign(double val1, double val2)
+{
+  return val1 * val2 >= 0.0;
+}
+
 void spin(rclcpp::executors::MultiThreadedExecutor * exe) { exe->spin(); }
 
 TEST_P(TrajectoryControllerTestParameterized, configure)
@@ -545,22 +550,8 @@ TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list)
   {
     // estimate the sign of the velocity
     // joint rotates forward
-    if (traj_msg.points[0].positions[0] - initial_joint2_cmd < 0.0)
-    {
-      EXPECT_GT(0.0, joint_vel_[0]);
-    }
-    else if (0 < copysign(2.0, traj_msg.points[0].positions[0] - initial_joint2_cmd))
-    {
-      EXPECT_LT(0.0, joint_vel_[0]);
-    }
-    if (0 > copysign(2.0, traj_msg.points[0].positions[1] - initial_joint1_cmd))
-    {
-      EXPECT_GT(0.0, joint_vel_[1]);
-    }
-    else if (0 < copysign(2.0, traj_msg.points[0].positions[1] - initial_joint1_cmd))
-    {
-      EXPECT_LT(0.0, joint_vel_[1]);
-    }
+    EXPECT_TRUE(is_same_sign(traj_msg.points[0].positions[0] - initial_joint2_cmd, joint_vel_[0]));
+    EXPECT_TRUE(is_same_sign(traj_msg.points[0].positions[1] - initial_joint1_cmd, joint_vel_[1]));
     EXPECT_NEAR(0.0, joint_vel_[2], threshold)
       << "Joint 3 velocity should be 0.0 since it's not in the goal";
   }

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1104,6 +1104,17 @@ INSTANTIATE_TEST_SUITE_P(
       std::vector<std::string>({"position", "velocity", "acceleration"}),
       std::vector<std::string>({"position", "velocity", "acceleration"}))));
 
+// only velocity controller
+INSTANTIATE_TEST_CASE_P(
+  OnlyVelocityTrajectoryControllers, TrajectoryControllerTestParameterized,
+  ::testing::Values(
+    std::make_tuple(std::vector<std::string>({"velocity"}), std::vector<std::string>({"position"})),
+    std::make_tuple(
+      std::vector<std::string>({"velocity"}), std::vector<std::string>({"position", "velocity"})),
+    std::make_tuple(
+      std::vector<std::string>({"velocity"}),
+      std::vector<std::string>({"position", "velocity", "acceleration"}))));
+
 TEST_F(TrajectoryControllerTest, incorrect_initialization_using_interface_parameters)
 {
   auto set_parameter_and_check_result = [&]() {

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1142,10 +1142,6 @@ TEST_F(TrajectoryControllerTest, incorrect_initialization_using_interface_parame
   command_interface_types_ = {"effort", "position"};
   set_parameter_and_check_result();
 
-  // command interfaces: velocity alone not yet implemented
-  command_interface_types_ = {"velocity"};
-  set_parameter_and_check_result();
-
   // command interfaces: velocity - position not present
   command_interface_types_ = {"velocity", "acceleration"};
   set_parameter_and_check_result();

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -544,7 +544,8 @@ TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list)
     command_interface_types_.end())
   {
     // estimate the sign of the velocity
-    if (0 > copysign(2.0, traj_msg.points[0].positions[0] - initial_joint2_cmd))
+    // joint rotates forward
+    if (traj_msg.points[0].positions[0] - initial_joint2_cmd < 0.0)
     {
       EXPECT_GT(0.0, joint_vel_[0]);
     }

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -318,9 +318,9 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
 
   if (traj_controller_->has_velocity_command_interface())
   {
-    EXPECT_LT(0.0, joint_vel_[0]);
-    EXPECT_LT(0.0, joint_vel_[1]);
-    EXPECT_LT(0.0, joint_vel_[2]);
+    EXPECT_LE(0.0, joint_vel_[0]);
+    EXPECT_LE(0.0, joint_vel_[1]);
+    EXPECT_LE(0.0, joint_vel_[2]);
   }
 
   // cleanup

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -267,6 +267,7 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
 
   // This call is replacing the way parameters are set via launch
   SetParameters();
+  SetPidParameters();
   traj_controller_->configure();
   auto state = traj_controller_->get_state();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
@@ -287,8 +288,10 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   // *INDENT-OFF*
   std::vector<std::vector<double>> points{
     {{3.3, 4.4, 5.5}}, {{7.7, 8.8, 9.9}}, {{10.10, 11.11, 12.12}}};
+  std::vector<std::vector<double>> points_velocities{
+    {{0.01, 0.01, 0.01}}, {{0.05, 0.05, 0.05}}, {{0.06, 0.06, 0.06}}};
   // *INDENT-ON*
-  publish(time_from_start, points);
+  publish(time_from_start, points, rclcpp::Time(), {}, points_velocities);
   traj_controller_->wait_for_trajectory(executor);
 
   // first update
@@ -304,10 +307,19 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   // TODO(denis): on my laptop I get delta of approx 0.1083. Is this me or is it something wrong?
   // Come the flackiness here?
   const auto allowed_delta = 0.11;  // 0.05;
+  if (traj_controller_->get_has_position_command_interface())
+  {
+    EXPECT_NEAR(3.3, joint_pos_[0], allowed_delta);
+    EXPECT_NEAR(4.4, joint_pos_[1], allowed_delta);
+    EXPECT_NEAR(5.5, joint_pos_[2], allowed_delta);
+  }
 
-  EXPECT_NEAR(3.3, joint_pos_[0], allowed_delta);
-  EXPECT_NEAR(4.4, joint_pos_[1], allowed_delta);
-  EXPECT_NEAR(5.5, joint_pos_[2], allowed_delta);
+  if (traj_controller_->get_has_velocity_command_interface())
+  {
+    EXPECT_LT(0.0, joint_vel_[0]);
+    EXPECT_LT(0.0, joint_vel_[1]);
+    EXPECT_LT(0.0, joint_vel_[2]);
+  }
 
   // cleanup
   state = traj_controller_->cleanup();
@@ -447,6 +459,14 @@ TEST_P(TrajectoryControllerTestParameterized, test_jumbled_joint_order)
     traj_msg.points[0].positions[1] = 3.0;
     traj_msg.points[0].positions[2] = 1.0;
 
+    if (traj_controller_->get_has_velocity_command_interface())
+    {
+      traj_msg.points[0].velocities.resize(3);
+      traj_msg.points[0].velocities[0] = -0.1;
+      traj_msg.points[0].velocities[1] = -0.1;
+      traj_msg.points[0].velocities[2] = -0.1;
+    }
+
     trajectory_publisher_->publish(traj_msg);
   }
 
@@ -456,9 +476,19 @@ TEST_P(TrajectoryControllerTestParameterized, test_jumbled_joint_order)
   //                Currently COMMON_THRESHOLD is adjusted.
   updateController(rclcpp::Duration::from_seconds(0.25));
 
-  EXPECT_NEAR(1.0, joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_NEAR(2.0, joint_pos_[1], COMMON_THRESHOLD);
-  EXPECT_NEAR(3.0, joint_pos_[2], COMMON_THRESHOLD);
+  if (traj_controller_->get_has_position_command_interface())
+  {
+    EXPECT_NEAR(1.0, joint_pos_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(2.0, joint_pos_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(3.0, joint_pos_[2], COMMON_THRESHOLD);
+  }
+
+  if (traj_controller_->get_has_velocity_command_interface())
+  {
+    EXPECT_GT(0.0, joint_vel_[0]);
+    EXPECT_GT(0.0, joint_vel_[1]);
+    EXPECT_GT(0.0, joint_vel_[2]);
+  }
 }
 
 /**
@@ -471,6 +501,8 @@ TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list)
   rclcpp::executors::SingleThreadedExecutor executor;
   SetUpAndActivateTrajectoryController(true, {partial_joints_parameters}, &executor);
 
+  const double initial_joint1_cmd = joint_pos_[0];
+  const double initial_joint2_cmd = joint_pos_[1];
   const double initial_joint3_cmd = joint_pos_[2];
   trajectory_msgs::msg::JointTrajectory traj_msg;
 
@@ -485,8 +517,10 @@ TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list)
     traj_msg.points[0].positions[0] = 2.0;
     traj_msg.points[0].positions[1] = 1.0;
     traj_msg.points[0].velocities.resize(2);
-    traj_msg.points[0].velocities[0] = 2.0;
-    traj_msg.points[0].velocities[1] = 1.0;
+    traj_msg.points[0].velocities[0] =
+      copysign(2.0, traj_msg.points[0].positions[0] - initial_joint2_cmd);
+    traj_msg.points[0].velocities[1] =
+      copysign(1.0, traj_msg.points[0].positions[1] - initial_joint1_cmd);
 
     trajectory_publisher_->publish(traj_msg);
   }
@@ -496,18 +530,36 @@ TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list)
   updateController(rclcpp::Duration::from_seconds(0.25));
 
   double threshold = 0.001;
-  EXPECT_NEAR(traj_msg.points[0].positions[1], joint_pos_[0], threshold);
-  EXPECT_NEAR(traj_msg.points[0].positions[0], joint_pos_[1], threshold);
-  EXPECT_NEAR(initial_joint3_cmd, joint_pos_[2], threshold)
-    << "Joint 3 command should be current position";
+
+  if (traj_controller_->get_has_position_command_interface())
+  {
+    EXPECT_NEAR(traj_msg.points[0].positions[1], joint_pos_[0], threshold);
+    EXPECT_NEAR(traj_msg.points[0].positions[0], joint_pos_[1], threshold);
+    EXPECT_NEAR(initial_joint3_cmd, joint_pos_[2], threshold)
+      << "Joint 3 command should be current position";
+  }
 
   if (
     std::find(command_interface_types_.begin(), command_interface_types_.end(), "velocity") !=
     command_interface_types_.end())
   {
-    // TODO(anyone): need help here - we should at least estimate the sign of the velocity
-    //     EXPECT_NEAR(traj_msg.points[0].velocities[1], joint_vel_[0], threshold);
-    //     EXPECT_NEAR(traj_msg.points[0].velocities[0], joint_vel_[1], threshold);
+    // estimate the sign of the velocity
+    if (0 > copysign(2.0, traj_msg.points[0].positions[0] - initial_joint2_cmd))
+    {
+      EXPECT_GT(0.0, joint_vel_[0]);
+    }
+    else if (0 < copysign(2.0, traj_msg.points[0].positions[0] - initial_joint2_cmd))
+    {
+      EXPECT_LT(0.0, joint_vel_[0]);
+    }
+    if (0 > copysign(2.0, traj_msg.points[0].positions[1] - initial_joint1_cmd))
+    {
+      EXPECT_GT(0.0, joint_vel_[1]);
+    }
+    else if (0 < copysign(2.0, traj_msg.points[0].positions[1] - initial_joint1_cmd))
+    {
+      EXPECT_LT(0.0, joint_vel_[1]);
+    }
     EXPECT_NEAR(0.0, joint_vel_[2], threshold)
       << "Joint 3 velocity should be 0.0 since it's not in the goal";
   }
@@ -664,24 +716,33 @@ TEST_P(TrajectoryControllerTestParameterized, test_trajectory_replace)
   subscribeToState();
 
   std::vector<std::vector<double>> points_old{{{2., 3., 4.}}};
+  std::vector<std::vector<double>> points_old_velocities{{{0.2, 0.3, 0.4}}};
   std::vector<std::vector<double>> points_partial_new{{1.5}};
+  std::vector<std::vector<double>> points_partial_new_velocities{{0.15}};
 
   const auto delay = std::chrono::milliseconds(500);
   builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(delay)};
-  publish(time_from_start, points_old);
+  publish(time_from_start, points_old, rclcpp::Time(), {}, points_old_velocities);
   trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
   expected_actual.positions = {points_old[0].begin(), points_old[0].end()};
   expected_desired.positions = {points_old[0].begin(), points_old[0].end()};
+  expected_actual.velocities = {points_old_velocities[0].begin(), points_old_velocities[0].end()};
+  expected_desired.velocities = {points_old_velocities[0].begin(), points_old_velocities[0].end()};
   //  Check that we reached end of points_old trajectory
   // Denis: delta was 0.1 with 0.2 works for me
   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.2);
 
   RCLCPP_INFO(traj_node_->get_logger(), "Sending new trajectory");
-  publish(time_from_start, points_partial_new);
+  points_partial_new_velocities[0][0] =
+    copysign(0.15, points_partial_new[0][0] - joint_state_pos_[0]);
+  publish(time_from_start, points_partial_new, rclcpp::Time(), {}, points_partial_new_velocities);
   // Replaced trajectory is a mix of previous and current goal
   expected_desired.positions[0] = points_partial_new[0][0];
   expected_desired.positions[1] = points_old[0][1];
   expected_desired.positions[2] = points_old[0][2];
+  expected_desired.velocities[0] = points_partial_new_velocities[0][0];
+  expected_desired.velocities[1] = 0.0;
+  expected_desired.velocities[2] = 0.0;
   expected_actual = expected_desired;
   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
 }
@@ -764,16 +825,23 @@ TEST_P(TrajectoryControllerTestParameterized, test_execute_partial_traj_in_futur
   traj_controller_->activate();
 
   std::vector<std::vector<double>> full_traj{{{2., 3., 4.}, {4., 6., 8.}}};
+  std::vector<std::vector<double>> full_traj_velocities{{{0.2, 0.3, 0.4}, {0.4, 0.6, 0.8}}};
   std::vector<std::vector<double>> partial_traj{
     {{-1., -2.},
      {
        -2.,
        -4,
      }}};
+  std::vector<std::vector<double>> partial_traj_velocities{
+    {{-0.1, -0.2},
+     {
+       -0.2,
+       -0.4,
+     }}};
   const auto delay = std::chrono::milliseconds(500);
   builtin_interfaces::msg::Duration points_delay{rclcpp::Duration(delay)};
   // Send full trajectory
-  publish(points_delay, full_traj);
+  publish(points_delay, full_traj, rclcpp::Time(), {}, full_traj_velocities);
   // Sleep until first waypoint of full trajectory
 
   trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
@@ -784,7 +852,8 @@ TEST_P(TrajectoryControllerTestParameterized, test_execute_partial_traj_in_futur
 
   // Send partial trajectory starting after full trajecotry is complete
   RCLCPP_INFO(traj_node->get_logger(), "Sending new trajectory in the future");
-  publish(points_delay, partial_traj, rclcpp::Clock().now() + delay * 2);
+  publish(
+    points_delay, partial_traj, rclcpp::Clock().now() + delay * 2, {}, partial_traj_velocities);
   // Wait until the end start and end of partial traj
 
   expected_actual.positions = {partial_traj.back()[0], partial_traj.back()[1], full_traj.back()[2]};
@@ -803,7 +872,9 @@ TEST_P(TrajectoryControllerTestParameterized, test_jump_when_state_tracking_erro
 
   // goal setup
   std::vector<double> first_goal = {3.3, 4.4, 5.5};
+  std::vector<std::vector<double>> first_goal_velocities = {{0.33, 0.44, 0.55}};
   std::vector<double> second_goal = {6.6, 8.8, 11.0};
+  std::vector<std::vector<double>> second_goal_velocities = {{0.66, 0.88, 1.1}};
   double state_from_command_offset = 0.3;
 
   // send msg
@@ -811,69 +882,72 @@ TEST_P(TrajectoryControllerTestParameterized, test_jump_when_state_tracking_erro
   time_from_start.sec = 1;
   time_from_start.nanosec = 0;
   std::vector<std::vector<double>> points{{first_goal}};
-  publish(time_from_start, points);
+  publish(time_from_start, points, rclcpp::Time(), {}, first_goal_velocities);
   traj_controller_->wait_for_trajectory(executor);
   updateController(rclcpp::Duration::from_seconds(1.1));
 
-  // JTC is executing trajectory in open-loop therefore:
-  // - internal state does not have to be updated (in this test-case it shouldn't)
-  // - internal command is updated
-  EXPECT_NEAR(INITIAL_POS_JOINT1, joint_state_pos_[0], COMMON_THRESHOLD);
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+  if (traj_controller_->get_has_position_command_interface())
+  {
+    // JTC is executing trajectory in open-loop therefore:
+    // - internal state does not have to be updated (in this test-case it shouldn't)
+    // - internal command is updated
+    EXPECT_NEAR(INITIAL_POS_JOINT1, joint_state_pos_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
 
-  // State interface should have offset from the command before starting a new trajectory
-  joint_state_pos_[0] = first_goal[0] - state_from_command_offset;
+    // State interface should have offset from the command before starting a new trajectory
+    joint_state_pos_[0] = first_goal[0] - state_from_command_offset;
 
-  // Move joint further in the same direction as before (to the second goal)
-  points = {{second_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
+    // Move joint further in the same direction as before (to the second goal)
+    points = {{second_goal}};
+    publish(time_from_start, points, rclcpp::Time(), {}, second_goal_velocities);
+    traj_controller_->wait_for_trajectory(executor);
 
-  // One the first update(s) there should be a "jump" in opposite direction from command
-  // (towards the state value)
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  // Expect backward commands at first
-  EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_LT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_LT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_LT(joint_pos_[0], first_goal[0]);
+    // One the first update(s) there should be a "jump" in opposite direction from command
+    // (towards the state value)
+    EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    // Expect backward commands at first
+    EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
+    EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
+    EXPECT_LT(joint_pos_[0], first_goal[0]);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
+    EXPECT_LT(joint_pos_[0], first_goal[0]);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    EXPECT_GT(joint_pos_[0], joint_state_pos_[0]);
+    EXPECT_LT(joint_pos_[0], first_goal[0]);
 
-  // Finally the second goal will be commanded/reached
-  updateController(rclcpp::Duration::from_seconds(1.1));
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    // Finally the second goal will be commanded/reached
+    updateController(rclcpp::Duration::from_seconds(1.1));
+    EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
 
-  // State interface should have offset from the command before starting a new trajectory
-  joint_state_pos_[0] = second_goal[0] - state_from_command_offset;
+    // State interface should have offset from the command before starting a new trajectory
+    joint_state_pos_[0] = second_goal[0] - state_from_command_offset;
 
-  // Move joint back to the first goal
-  points = {{first_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
+    // Move joint back to the first goal
+    points = {{first_goal}};
+    publish(time_from_start, points);
+    traj_controller_->wait_for_trajectory(executor);
 
-  // One the first update(s) there should be a "jump" in the goal direction from command
-  // (towards the state value)
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  // Expect backward commands at first
-  EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
+    // One the first update(s) there should be a "jump" in the goal direction from command
+    // (towards the state value)
+    EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    // Expect backward commands at first
+    EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
+    EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
+    EXPECT_GT(joint_pos_[0], first_goal[0]);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
+    EXPECT_GT(joint_pos_[0], first_goal[0]);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    EXPECT_LT(joint_pos_[0], joint_state_pos_[0]);
+    EXPECT_GT(joint_pos_[0], first_goal[0]);
 
-  // Finally the first goal will be commanded/reached
-  updateController(rclcpp::Duration::from_seconds(1.1));
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    // Finally the first goal will be commanded/reached
+    updateController(rclcpp::Duration::from_seconds(1.1));
+    EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+  }
 
   executor.cancel();
 }
@@ -899,65 +973,68 @@ TEST_P(TrajectoryControllerTestParameterized, test_no_jump_when_state_tracking_e
   traj_controller_->wait_for_trajectory(executor);
   updateController(rclcpp::Duration::from_seconds(1.1));
 
-  // JTC is executing trajectory in open-loop therefore:
-  // - internal state does not have to be updated (in this test-case it shouldn't)
-  // - internal command is updated
-  EXPECT_NEAR(INITIAL_POS_JOINT1, joint_state_pos_[0], COMMON_THRESHOLD);
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+  if (traj_controller_->get_has_position_command_interface())
+  {
+    // JTC is executing trajectory in open-loop therefore:
+    // - internal state does not have to be updated (in this test-case it shouldn't)
+    // - internal command is updated
+    EXPECT_NEAR(INITIAL_POS_JOINT1, joint_state_pos_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
 
-  // State interface should have offset from the command before starting a new trajectory
-  joint_state_pos_[0] = first_goal[0] - state_from_command_offset;
+    // State interface should have offset from the command before starting a new trajectory
+    joint_state_pos_[0] = first_goal[0] - state_from_command_offset;
 
-  // Move joint further in the same direction as before (to the second goal)
-  points = {{second_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
+    // Move joint further in the same direction as before (to the second goal)
+    points = {{second_goal}};
+    publish(time_from_start, points);
+    traj_controller_->wait_for_trajectory(executor);
 
-  // One the first update(s) there **should not** be a "jump" in opposite direction from command
-  // (towards the state value)
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  // There should not be backward commands
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
+    // One the first update(s) there **should not** be a "jump" in opposite direction from command
+    // (towards the state value)
+    EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    // There should not be backward commands
+    EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    EXPECT_GT(joint_pos_[0], first_goal[0]);
+    EXPECT_LT(joint_pos_[0], second_goal[0]);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    EXPECT_GT(joint_pos_[0], first_goal[0]);
+    EXPECT_LT(joint_pos_[0], second_goal[0]);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    EXPECT_GT(joint_pos_[0], first_goal[0]);
+    EXPECT_LT(joint_pos_[0], second_goal[0]);
 
-  // Finally the second goal will be commanded/reached
-  updateController(rclcpp::Duration::from_seconds(1.1));
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    // Finally the second goal will be commanded/reached
+    updateController(rclcpp::Duration::from_seconds(1.1));
+    EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
 
-  // State interface should have offset from the command before starting a new trajectory
-  joint_state_pos_[0] = second_goal[0] - state_from_command_offset;
+    // State interface should have offset from the command before starting a new trajectory
+    joint_state_pos_[0] = second_goal[0] - state_from_command_offset;
 
-  // Move joint back to the first goal
-  points = {{first_goal}};
-  publish(time_from_start, points);
-  traj_controller_->wait_for_trajectory(executor);
+    // Move joint back to the first goal
+    points = {{first_goal}};
+    publish(time_from_start, points);
+    traj_controller_->wait_for_trajectory(executor);
 
-  // One the first update(s) there **should not** be a "jump" in the goal direction from command
-  // (towards the state value)
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  // There should not be a jump toward commands
-  EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
-  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
-  EXPECT_GT(joint_pos_[0], first_goal[0]);
-  EXPECT_LT(joint_pos_[0], second_goal[0]);
+    // One the first update(s) there **should not** be a "jump" in the goal direction from command
+    // (towards the state value)
+    EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    // There should not be a jump toward commands
+    EXPECT_NEAR(second_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    EXPECT_LT(joint_pos_[0], second_goal[0]);
+    EXPECT_GT(joint_pos_[0], first_goal[0]);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    EXPECT_GT(joint_pos_[0], first_goal[0]);
+    EXPECT_LT(joint_pos_[0], second_goal[0]);
+    traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+    EXPECT_GT(joint_pos_[0], first_goal[0]);
+    EXPECT_LT(joint_pos_[0], second_goal[0]);
 
-  // Finally the first goal will be commanded/reached
-  updateController(rclcpp::Duration::from_seconds(1.1));
-  EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+    // Finally the first goal will be commanded/reached
+    updateController(rclcpp::Duration::from_seconds(1.1));
+    EXPECT_NEAR(first_goal[0], joint_pos_[0], COMMON_THRESHOLD);
+  }
 
   executor.cancel();
 }
@@ -1108,7 +1185,6 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_CASE_P(
   OnlyVelocityTrajectoryControllers, TrajectoryControllerTestParameterized,
   ::testing::Values(
-    std::make_tuple(std::vector<std::string>({"velocity"}), std::vector<std::string>({"position"})),
     std::make_tuple(
       std::vector<std::string>({"velocity"}), std::vector<std::string>({"position", "velocity"})),
     std::make_tuple(

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -58,10 +58,7 @@ using test_trajectory_controllers::TestableJointTrajectoryController;
 using test_trajectory_controllers::TrajectoryControllerTest;
 using test_trajectory_controllers::TrajectoryControllerTestParameterized;
 
-bool is_same_sign(double val1, double val2)
-{
-  return val1 * val2 >= 0.0;
-}
+bool is_same_sign(double val1, double val2) { return val1 * val2 >= 0.0; }
 
 void spin(rclcpp::executors::MultiThreadedExecutor * exe) { exe->spin(); }
 

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -309,14 +309,14 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   // TODO(denis): on my laptop I get delta of approx 0.1083. Is this me or is it something wrong?
   // Come the flackiness here?
   const auto allowed_delta = 0.11;  // 0.05;
-  if (traj_controller_->get_has_position_command_interface())
+  if (traj_controller_->has_position_command_interface())
   {
     EXPECT_NEAR(3.3, joint_pos_[0], allowed_delta);
     EXPECT_NEAR(4.4, joint_pos_[1], allowed_delta);
     EXPECT_NEAR(5.5, joint_pos_[2], allowed_delta);
   }
 
-  if (traj_controller_->get_has_velocity_command_interface())
+  if (traj_controller_->has_velocity_command_interface())
   {
     EXPECT_LT(0.0, joint_vel_[0]);
     EXPECT_LT(0.0, joint_vel_[1]);
@@ -461,7 +461,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_jumbled_joint_order)
     traj_msg.points[0].positions[1] = 3.0;
     traj_msg.points[0].positions[2] = 1.0;
 
-    if (traj_controller_->get_has_velocity_command_interface())
+    if (traj_controller_->has_velocity_command_interface())
     {
       traj_msg.points[0].velocities.resize(3);
       traj_msg.points[0].velocities[0] = -0.1;
@@ -478,14 +478,14 @@ TEST_P(TrajectoryControllerTestParameterized, test_jumbled_joint_order)
   //                Currently COMMON_THRESHOLD is adjusted.
   updateController(rclcpp::Duration::from_seconds(0.25));
 
-  if (traj_controller_->get_has_position_command_interface())
+  if (traj_controller_->has_position_command_interface())
   {
     EXPECT_NEAR(1.0, joint_pos_[0], COMMON_THRESHOLD);
     EXPECT_NEAR(2.0, joint_pos_[1], COMMON_THRESHOLD);
     EXPECT_NEAR(3.0, joint_pos_[2], COMMON_THRESHOLD);
   }
 
-  if (traj_controller_->get_has_velocity_command_interface())
+  if (traj_controller_->has_velocity_command_interface())
   {
     EXPECT_GT(0.0, joint_vel_[0]);
     EXPECT_GT(0.0, joint_vel_[1]);
@@ -533,7 +533,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_partial_joint_list)
 
   double threshold = 0.001;
 
-  if (traj_controller_->get_has_position_command_interface())
+  if (traj_controller_->has_position_command_interface())
   {
     EXPECT_NEAR(traj_msg.points[0].positions[1], joint_pos_[0], threshold);
     EXPECT_NEAR(traj_msg.points[0].positions[0], joint_pos_[1], threshold);
@@ -875,7 +875,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_jump_when_state_tracking_erro
   traj_controller_->wait_for_trajectory(executor);
   updateController(rclcpp::Duration::from_seconds(1.1));
 
-  if (traj_controller_->get_has_position_command_interface())
+  if (traj_controller_->has_position_command_interface())
   {
     // JTC is executing trajectory in open-loop therefore:
     // - internal state does not have to be updated (in this test-case it shouldn't)
@@ -962,7 +962,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_no_jump_when_state_tracking_e
   traj_controller_->wait_for_trajectory(executor);
   updateController(rclcpp::Duration::from_seconds(1.1));
 
-  if (traj_controller_->get_has_position_command_interface())
+  if (traj_controller_->has_position_command_interface())
   {
     // JTC is executing trajectory in open-loop therefore:
     // - internal state does not have to be updated (in this test-case it shouldn't)

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -94,6 +94,10 @@ public:
     return last_commanded_state_;
   }
 
+  bool get_has_position_command_interface() { return has_position_command_interface_; }
+
+  bool get_has_velocity_command_interface() { return has_velocity_command_interface_; }
+
   rclcpp::WaitSet joint_cmd_sub_wait_set_;
 };
 
@@ -146,13 +150,27 @@ public:
     const rclcpp::Parameter state_interfaces_params("state_interfaces", state_interface_types_);
     node->set_parameters({joint_names_param, cmd_interfaces_params, state_interfaces_params});
   }
+  void SetPidParameters()
+  {
+    auto node = traj_controller_->get_node();
+
+    for (size_t i = 0; i < joint_names_.size(); ++i)
+    {
+      const std::string prefix = "gains." + joint_names_[i];
+      const rclcpp::Parameter k_p(prefix + ".p", 0.0);
+      const rclcpp::Parameter k_i(prefix + ".i", 0.0);
+      const rclcpp::Parameter k_d(prefix + ".d", 0.0);
+      const rclcpp::Parameter i_clamp(prefix + ".i_clamp", 0.0);
+      const rclcpp::Parameter ff_velocity_scale("ff_velocity_scale/" + joint_names_[i], 1.0);
+      node->set_parameters({k_p, k_i, k_d, i_clamp, ff_velocity_scale});
+    }
+  }
 
   void SetUpAndActivateTrajectoryController(
     bool use_local_parameters = true, const std::vector<rclcpp::Parameter> & parameters = {},
     rclcpp::Executor * executor = nullptr, bool separate_cmd_and_state_values = false)
   {
     SetUpTrajectoryController(use_local_parameters);
-
     traj_node_ = traj_controller_->get_node();
     for (const auto & param : parameters)
     {
@@ -166,6 +184,9 @@ public:
     // ignore velocity tolerances for this test since they aren't committed in test_robot->write()
     rclcpp::Parameter stopped_velocity_parameters("constraints.stopped_velocity_tolerance", 0.0);
     traj_node_->set_parameter(stopped_velocity_parameters);
+
+    // set pid parameters before configure
+    SetPidParameters();
 
     traj_controller_->configure();
     ActivateTrajectoryController(separate_cmd_and_state_values);
@@ -249,7 +270,8 @@ public:
   void publish(
     const builtin_interfaces::msg::Duration & delay_btwn_points,
     const std::vector<std::vector<double>> & points, rclcpp::Time start_time = rclcpp::Time(),
-    const std::vector<std::string> & joint_names = {})
+    const std::vector<std::string> & joint_names = {},
+    const std::vector<std::vector<double>> & points_velocities = {})
   {
     int wait_count = 0;
     const auto topic = trajectory_publisher_->get_topic_name();
@@ -294,6 +316,15 @@ public:
       duration_total = duration_total + duration;
     }
 
+    for (size_t index = 0; index < points_velocities.size(); ++index)
+    {
+      traj_msg.points[index].velocities.resize(points_velocities[index].size());
+      for (size_t j = 0; j < points_velocities[index].size(); ++j)
+      {
+        traj_msg.points[index].velocities[j] = points_velocities[index][j];
+      }
+    }
+
     trajectory_publisher_->publish(traj_msg);
   }
 
@@ -326,14 +357,20 @@ public:
     {
       SCOPED_TRACE("Joint " + std::to_string(i));
       // TODO(anyone): add checking for velocties and accelerations
-      EXPECT_NEAR(expected_actual.positions[i], state_msg->actual.positions[i], allowed_delta);
+      if (traj_controller_->get_has_position_command_interface())
+      {
+        EXPECT_NEAR(expected_actual.positions[i], state_msg->actual.positions[i], allowed_delta);
+      }
     }
 
     for (size_t i = 0; i < expected_desired.positions.size(); ++i)
     {
       SCOPED_TRACE("Joint " + std::to_string(i));
       // TODO(anyone): add checking for velocties and accelerations
-      EXPECT_NEAR(expected_desired.positions[i], state_msg->desired.positions[i], allowed_delta);
+      if (traj_controller_->get_has_position_command_interface())
+      {
+        EXPECT_NEAR(expected_desired.positions[i], state_msg->desired.positions[i], allowed_delta);
+      }
     }
   }
 

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -94,9 +94,9 @@ public:
     return last_commanded_state_;
   }
 
-  bool get_has_position_command_interface() { return has_position_command_interface_; }
+  bool has_position_command_interface() { return has_position_command_interface_; }
 
-  bool get_has_velocity_command_interface() { return has_velocity_command_interface_; }
+  bool has_velocity_command_interface() { return has_velocity_command_interface_; }
 
   rclcpp::WaitSet joint_cmd_sub_wait_set_;
 };

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -357,7 +357,7 @@ public:
     {
       SCOPED_TRACE("Joint " + std::to_string(i));
       // TODO(anyone): add checking for velocties and accelerations
-      if (traj_controller_->get_has_position_command_interface())
+      if (traj_controller_->has_position_command_interface())
       {
         EXPECT_NEAR(expected_actual.positions[i], state_msg->actual.positions[i], allowed_delta);
       }
@@ -367,7 +367,7 @@ public:
     {
       SCOPED_TRACE("Joint " + std::to_string(i));
       // TODO(anyone): add checking for velocties and accelerations
-      if (traj_controller_->get_has_position_command_interface())
+      if (traj_controller_->has_position_command_interface())
       {
         EXPECT_NEAR(expected_desired.positions[i], state_msg->desired.positions[i], allowed_delta);
       }


### PR DESCRIPTION
Introduce velocity-only command interface for `JointTrajectoryController` and extend tests for its usage.

