### PR TITLE
Fix diff_drive accel limit (#242)

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -165,10 +165,11 @@ controller_interface::return_type DiffDriveController::update(
     last_command_msg->twist.angular.z = 0.0;
   }
 
-  // linear_command and angular_command may be limited further by SpeedLimit,
+  // command may be limited further by SpeedLimit,
   // without affecting the stored twist command
-  double linear_command = last_command_msg->twist.linear.x;
-  double angular_command = last_command_msg->twist.angular.z;
+  Twist command = *last_command_msg;
+  double &linear_command = command.twist.linear.x;
+  double &angular_command = command.twist.angular.z;
 
   // Apply (possibly new) multipliers:
   const auto wheels = wheel_params_;
@@ -248,15 +249,14 @@ controller_interface::return_type DiffDriveController::update(
     angular_command, last_command.angular.z, second_to_last_command.angular.z, update_dt.seconds());
 
   previous_commands_.pop();
-  previous_commands_.emplace(*last_command_msg);
+  previous_commands_.emplace(command);
 
   //    Publish limited velocity
   if (publish_limited_velocity_ && realtime_limited_velocity_publisher_->trylock())
   {
     auto & limited_velocity_command = realtime_limited_velocity_publisher_->msg_;
     limited_velocity_command.header.stamp = current_time;
-    limited_velocity_command.twist.linear.x = linear_command;
-    limited_velocity_command.twist.angular.z = angular_command;
+    limited_velocity_command.twist = command.twist;
     realtime_limited_velocity_publisher_->unlockAndPublish();
   }
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -168,8 +168,8 @@ controller_interface::return_type DiffDriveController::update(
   // command may be limited further by SpeedLimit,
   // without affecting the stored twist command
   Twist command = *last_command_msg;
-  double &linear_command = command.twist.linear.x;
-  double &angular_command = command.twist.angular.z;
+  double & linear_command = command.twist.linear.x;
+  double & angular_command = command.twist.angular.z;
 
   // Apply (possibly new) multipliers:
   const auto wheels = wheel_params_;


### PR DESCRIPTION
This fixes the issue (#242) where diff_drive_controller does not apply acceleration limits when provided.

It has been tested on Foxy, and tested to compile but NOT tested to run on Galactic. At present I can only test on Galactic with Gazebo, and with the latest versions of everything, starting my controller results in an unrelated error.

I've created a new issue (#251) to add a test for this in future.

