### PR TITLE
Fixed #255

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/rolling_mean_accumulator.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/rolling_mean_accumulator.hpp
@@ -20,8 +20,8 @@
 #define DIFF_DRIVE_CONTROLLER__ROLLING_MEAN_ACCUMULATOR_HPP_
 
 #include <cassert>
-#include <vector>
 #include <cstdio>
+#include <vector>
 
 namespace diff_drive_controller
 {


### PR DESCRIPTION
Compiling diff_drive_controller on Fedora (gcc 11.2.1 and glibc 2.33) results in missing definitions in `rolling_mean_accumulator.hpp`. Adding a simple `#include <stdio.h>` fixes it though. For more information please see #255. 
The Foxy branch could also benefit from this change thought (not sure how to do a pull request for a single commit to two branches).