### PR TITLE
ci: :building_construction: add rhel test script to ci

### DIFF
--- a/.github/workflows/RHEL.yml
+++ b/.github/workflows/RHEL.yml
@@ -1,0 +1,30 @@
+name: RHEL Test
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '17 8 * * *'
+env:
+  # if changing this variable, also change jobs.RHEL.container to match
+  ROS_DISTRO: galactic
+
+jobs:
+  RHEL:
+    name: RHEL test
+    runs-on: ubuntu-latest
+    container: jaronl/ros:galactic-alma
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: src/ros2_controllers
+      - run: |
+          rosdep init
+          rosdep update
+          rosdep install -iy --from-path src/ros2_controllers
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          colcon build
+          colcon test

--- a/.github/workflows/RHEL.yml
+++ b/.github/workflows/RHEL.yml
@@ -16,13 +16,11 @@ jobs:
     name: RHEL test
     runs-on: ubuntu-latest
     container: jaronl/ros:galactic-alma
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
         with:
           path: src/ros2_controllers
       - run: |
-          rosdep init
           rosdep update
           rosdep install -iy --from-path src/ros2_controllers
           source /opt/ros/$ROS_DISTRO/setup.bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '17 8 * * *'
 env:
-  # if changing this variable, also change jobs.rhel.container to match
   ROS_DISTRO: galactic
 
 jobs:
@@ -25,22 +24,6 @@ jobs:
      - uses: ros-industrial/industrial_ci@master
        env:
         ROS_REPO: ${{ matrix.ROS_REPO }}
-
-  rhel:
-    name: RHEL
-    runs-on: ubuntu-latest
-    container: jaronl/ros:galactic-alma
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          path: src/ros2_controllers
-      - run: |
-          rosdep init
-          rosdep update
-          rosdep install -iy --from-path src/ros2_controllers
-          source /opt/ros/$ROS_DISTRO/setup.bash
-          colcon build
-          colcon test
 
   ros-tooling-ci:
     name: ros-tooling ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,35 +7,53 @@ on:
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '17 8 * * *'
+env:
+  # if changing this variable, also change jobs.rhel.container to match
+  ROS_DISTRO: galactic
 
 jobs:
-  ci_binary:
-    name: Galactic binary job
+  ros_industrial_ci:
+    name: industrial ci
     runs-on: ubuntu-latest
     strategy:
      matrix:
-       env:
-         - {ROS_DISTRO: galactic, ROS_REPO: main}
-         - {ROS_DISTRO: galactic, ROS_REPO: testing}
+      ROS_REPO: [main, testing]
     env:
      UPSTREAM_WORKSPACE: .github/workspace.repos
     steps:
-     - uses: actions/checkout@v1
+     - uses: actions/checkout@v2
      - uses: ros-industrial/industrial_ci@master
-       env: ${{matrix.env}}
+       env:
+        ROS_REPO: ${{ matrix.ROS_REPO }}
 
-  ci_source:
-    name: Galactic source job
+  rhel:
+    name: RHEL
+    runs-on: ubuntu-latest
+    container: jaronl/ros:galactic-alma
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: src/ros2_controllers
+      - run: |
+          rosdep init
+          rosdep update
+          rosdep install -iy --from-path src/ros2_controllers
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          colcon build
+          colcon test
+
+  ros-tooling-ci:
+    name: ros-tooling ci
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     steps:
       - uses: ros-tooling/setup-ros@v0.2
         with:
-          required-ros-distributions: galactic
+          required-ros-distributions: ${{env.ROS_DISTRO}}
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
-          target-ros2-distro: galactic
+          target-ros2-distro: ${{env.ROS_DISTRO}}
           # build all packages listed in the meta package
           package-name: |
             diff_drive_controller


### PR DESCRIPTION
* Adds RHEL-based build and test to ros2_controllers
* renames some of the other ci jobs (I thought the names were misleading as they are all source jobs as far as I can tell)
* move almost all rosdistro references to a singular environment variable
   - I tried moving the docker image tag to be based on the same environment variable but it turns out github actions doesn't allow that. I then tried running the whole thing in a `docker run` command so I could force the use of the environment variable but I couldn't get that to work either.

refs: #248 

As a side note, this CI file currently depends on the docker image jaronl/ros:galactic-alma as there is no official ros image for RHEL based distributions. I'll investigate moving my image to osrf/docker-templates and see how hard it would be to add a template for it.