### PR TITLE
Add publish_rate option for diff_drive_controller (Foxy)

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
@@ -155,6 +155,11 @@ protected:
 
   rclcpp::Time previous_update_timestamp_{0};
 
+  // publish rate limiter
+  double publish_rate_ = 50.0;
+  std::chrono::milliseconds publish_period_{0};
+  rclcpp::Time previous_publish_timestamp_{0};
+
   bool is_halted = false;
   bool use_stamped_vel_ = true;
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -101,6 +101,8 @@ controller_interface::return_type DiffDriveController::init(const std::string & 
     auto_declare<double>("angular.z.min_acceleration", NAN);
     auto_declare<double>("angular.z.max_jerk", NAN);
     auto_declare<double>("angular.z.min_jerk", NAN);
+
+    auto_declare<double>("publish_rate", publish_rate_);
   }
   catch (const std::exception & e)
   {
@@ -216,32 +218,37 @@ controller_interface::return_type DiffDriveController::update()
   tf2::Quaternion orientation;
   orientation.setRPY(0.0, 0.0, odometry_.getHeading());
 
-  if (realtime_odometry_publisher_->trylock())
+  if (previous_publish_timestamp_ + publish_period_ < current_time)
   {
-    auto & odometry_message = realtime_odometry_publisher_->msg_;
-    odometry_message.header.stamp = current_time;
-    odometry_message.pose.pose.position.x = odometry_.getX();
-    odometry_message.pose.pose.position.y = odometry_.getY();
-    odometry_message.pose.pose.orientation.x = orientation.x();
-    odometry_message.pose.pose.orientation.y = orientation.y();
-    odometry_message.pose.pose.orientation.z = orientation.z();
-    odometry_message.pose.pose.orientation.w = orientation.w();
-    odometry_message.twist.twist.linear.x = odometry_.getLinear();
-    odometry_message.twist.twist.angular.z = odometry_.getAngular();
-    realtime_odometry_publisher_->unlockAndPublish();
-  }
+    previous_publish_timestamp_ += publish_period_;
 
-  if (odom_params_.enable_odom_tf && realtime_odometry_transform_publisher_->trylock())
-  {
-    auto & transform = realtime_odometry_transform_publisher_->msg_.transforms.front();
-    transform.header.stamp = current_time;
-    transform.transform.translation.x = odometry_.getX();
-    transform.transform.translation.y = odometry_.getY();
-    transform.transform.rotation.x = orientation.x();
-    transform.transform.rotation.y = orientation.y();
-    transform.transform.rotation.z = orientation.z();
-    transform.transform.rotation.w = orientation.w();
-    realtime_odometry_transform_publisher_->unlockAndPublish();
+    if (realtime_odometry_publisher_->trylock())
+    {
+      auto & odometry_message = realtime_odometry_publisher_->msg_;
+      odometry_message.header.stamp = current_time;
+      odometry_message.pose.pose.position.x = odometry_.getX();
+      odometry_message.pose.pose.position.y = odometry_.getY();
+      odometry_message.pose.pose.orientation.x = orientation.x();
+      odometry_message.pose.pose.orientation.y = orientation.y();
+      odometry_message.pose.pose.orientation.z = orientation.z();
+      odometry_message.pose.pose.orientation.w = orientation.w();
+      odometry_message.twist.twist.linear.x = odometry_.getLinear();
+      odometry_message.twist.twist.angular.z = odometry_.getAngular();
+      realtime_odometry_publisher_->unlockAndPublish();
+    }
+
+    if (odom_params_.enable_odom_tf && realtime_odometry_transform_publisher_->trylock())
+    {
+      auto & transform = realtime_odometry_transform_publisher_->msg_.transforms.front();
+      transform.header.stamp = current_time;
+      transform.transform.translation.x = odometry_.getX();
+      transform.transform.translation.y = odometry_.getY();
+      transform.transform.rotation.x = orientation.x();
+      transform.transform.rotation.y = orientation.y();
+      transform.transform.rotation.z = orientation.z();
+      transform.transform.rotation.w = orientation.w();
+      realtime_odometry_transform_publisher_->unlockAndPublish();
+    }
   }
 
   const auto update_dt = current_time - previous_update_timestamp_;
@@ -454,6 +461,11 @@ CallbackReturn DiffDriveController::on_configure(const rclcpp_lifecycle::State &
   auto & odometry_message = realtime_odometry_publisher_->msg_;
   odometry_message.header.frame_id = odom_params_.odom_frame_id;
   odometry_message.child_frame_id = odom_params_.base_frame_id;
+
+  // limit the publication on the topics /odom and /tf
+  publish_rate_ = node_->get_parameter("publish_rate").as_double();
+  publish_period_ = std::chrono::milliseconds(static_cast<int>(1000.0 / publish_rate_));
+  previous_publish_timestamp_ = node_->get_clock()->now();
 
   // initialize odom values zeros
   odometry_message.twist =


### PR DESCRIPTION
This PR add a `publish_rate` option for the `diff_drive_controller` in order to limit the publication on the `/odom` and `/tf` topics.

This solve request #274 for `Foxy`