### PR TITLE
Add reset() for the controllers

### DIFF
--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -124,7 +124,7 @@ CallbackReturn ForwardCommandController::on_activate(
   }
 
   // reset command buffer if a command came through callback when controller was inactive
-  rt_command_ptr_ = realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);
+  rt_command_ptr_.reset();
 
   return CallbackReturn::SUCCESS;
 }
@@ -133,7 +133,7 @@ CallbackReturn ForwardCommandController::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
   // reset command buffer
-  rt_command_ptr_ = realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);
+  rt_command_ptr_.reset();
   return CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
This PR is the follow up of the https://github.com/ros-controls/ros2_controllers/issues/247. Now the usage of reset() function of RealtimeBuffer is added in controllers (wherever possible).