### PR TITLE
[CI] Replace colcon-mixin-name with colcon-defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,12 @@ jobs:
             velocity_controllers
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/.github/workspace.repos
-          colcon-mixin-name: coverage-gcc
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
The former is not a valid option in action-ros-ci@v0.2, having been removed in favor of the latter in https://github.com/ros-tooling/action-ros-ci/pull/591.

Fixes https://github.com/ros-controls/ros2_controllers/issues/305.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>