### PR TITLE
Foxy:  `joint_state_broadcaster` to use realtime tools

### DIFF
--- a/joint_state_broadcaster/CMakeLists.txt
+++ b/joint_state_broadcaster/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(controller_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(realtime_tools REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 add_library(joint_state_broadcaster
@@ -30,6 +31,7 @@ ament_target_dependencies(joint_state_broadcaster
   pluginlib
   rclcpp_lifecycle
   rcutils
+  realtime_tools
   sensor_msgs
 )
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -25,6 +25,7 @@
 #include "joint_state_broadcaster/visibility_control.h"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+#include "realtime_tools/realtime_publisher.h"
 #include "sensor_msgs/msg/joint_state.hpp"
 
 namespace joint_state_broadcaster
@@ -71,14 +72,16 @@ protected:
   //  we store the name of joints with compatible interfaces
   std::vector<std::string> joint_names_;
   std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::JointState>> joint_state_publisher_;
-  sensor_msgs::msg::JointState joint_state_msg_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>
+    realtime_joint_state_publisher_;
 
   //  For the DynamicJointState format, we use a map to buffer values in for easier lookup
   //  This allows to preserve whatever order or names/interfaces were initialized.
   std::unordered_map<std::string, std::unordered_map<std::string, double>> name_if_value_mapping_;
   std::shared_ptr<rclcpp::Publisher<control_msgs::msg::DynamicJointState>>
     dynamic_joint_state_publisher_;
-  control_msgs::msg::DynamicJointState dynamic_joint_state_msg_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<control_msgs::msg::DynamicJointState>>
+    realtime_dynamic_joint_state_publisher_;
 };
 
 }  // namespace joint_state_broadcaster

--- a/joint_state_broadcaster/package.xml
+++ b/joint_state_broadcaster/package.xml
@@ -23,6 +23,7 @@
   <depend>hardware_interface</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
+  <depend>realtime_tools</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -93,9 +93,17 @@ JointStateBroadcaster::on_configure(const rclcpp_lifecycle::State & /*previous_s
     joint_state_publisher_ = get_node()->create_publisher<sensor_msgs::msg::JointState>(
       topic_name_prefix + "joint_states", rclcpp::SystemDefaultsQoS());
 
+    realtime_joint_state_publisher_ =
+      std::make_shared<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>(
+        joint_state_publisher_);
+
     dynamic_joint_state_publisher_ =
       get_node()->create_publisher<control_msgs::msg::DynamicJointState>(
         topic_name_prefix + "dynamic_joint_states", rclcpp::SystemDefaultsQoS());
+
+    realtime_dynamic_joint_state_publisher_ =
+      std::make_shared<realtime_tools::RealtimePublisher<control_msgs::msg::DynamicJointState>>(
+        dynamic_joint_state_publisher_);
   }
   catch (const std::exception & e)
   {
@@ -196,26 +204,28 @@ void JointStateBroadcaster::init_joint_state_msg()
   /// with at least one of these interfaces, the rest are omitted from this message
 
   // default initialization for joint state message
-  joint_state_msg_.name = joint_names_;
-  joint_state_msg_.position.resize(num_joints, kUninitializedValue);
-  joint_state_msg_.velocity.resize(num_joints, kUninitializedValue);
-  joint_state_msg_.effort.resize(num_joints, kUninitializedValue);
+  auto & joint_state_msg = realtime_joint_state_publisher_->msg_;
+  joint_state_msg.name = joint_names_;
+  joint_state_msg.position.resize(num_joints, kUninitializedValue);
+  joint_state_msg.velocity.resize(num_joints, kUninitializedValue);
+  joint_state_msg.effort.resize(num_joints, kUninitializedValue);
 }
 
 void JointStateBroadcaster::init_dynamic_joint_state_msg()
 {
+  auto & dynamic_joint_state_msg = realtime_dynamic_joint_state_publisher_->msg_;
   for (const auto & name_ifv : name_if_value_mapping_)
   {
     const auto & name = name_ifv.first;
     const auto & interfaces_and_values = name_ifv.second;
-    dynamic_joint_state_msg_.joint_names.push_back(name);
+    dynamic_joint_state_msg.joint_names.push_back(name);
     control_msgs::msg::InterfaceValue if_value;
     for (const auto & interface_and_value : interfaces_and_values)
     {
       if_value.interface_names.emplace_back(interface_and_value.first);
       if_value.values.emplace_back(kUninitializedValue);
     }
-    dynamic_joint_state_msg_.interface_values.emplace_back(if_value);
+    dynamic_joint_state_msg.interface_values.emplace_back(if_value);
   }
 }
 
@@ -246,37 +256,45 @@ controller_interface::return_type JointStateBroadcaster::update()
       state_interface.get_interface_name().c_str(), state_interface.get_value());
   }
 
-  joint_state_msg_.header.stamp = get_node()->get_clock()->now();
-  dynamic_joint_state_msg_.header.stamp = get_node()->get_clock()->now();
-
-  // update joint state message and dynamic joint state message
-  for (auto i = 0ul; i < joint_names_.size(); ++i)
+  if (realtime_joint_state_publisher_ && realtime_joint_state_publisher_->trylock())
   {
-    joint_state_msg_.position[i] =
-      get_value(name_if_value_mapping_, joint_names_[i], HW_IF_POSITION);
-    joint_state_msg_.velocity[i] =
-      get_value(name_if_value_mapping_, joint_names_[i], HW_IF_VELOCITY);
-    joint_state_msg_.effort[i] = get_value(name_if_value_mapping_, joint_names_[i], HW_IF_EFFORT);
-  }
+    auto & joint_state_msg = realtime_joint_state_publisher_->msg_;
 
-  for (auto joint_index = 0ul; joint_index < dynamic_joint_state_msg_.joint_names.size();
-       ++joint_index)
-  {
-    const auto & name = dynamic_joint_state_msg_.joint_names[joint_index];
-    for (auto interface_index = 0ul;
-         interface_index <
-         dynamic_joint_state_msg_.interface_values[joint_index].interface_names.size();
-         ++interface_index)
+    joint_state_msg.header.stamp = get_node()->get_clock()->now();
+
+    // update joint state message and dynamic joint state message
+    for (size_t i = 0; i < joint_names_.size(); ++i)
     {
-      const auto & interface_name =
-        dynamic_joint_state_msg_.interface_values[joint_index].interface_names[interface_index];
-      dynamic_joint_state_msg_.interface_values[joint_index].values[interface_index] =
-        name_if_value_mapping_[name][interface_name];
+      joint_state_msg.position[i] =
+        get_value(name_if_value_mapping_, joint_names_[i], HW_IF_POSITION);
+      joint_state_msg.velocity[i] =
+        get_value(name_if_value_mapping_, joint_names_[i], HW_IF_VELOCITY);
+      joint_state_msg.effort[i] = get_value(name_if_value_mapping_, joint_names_[i], HW_IF_EFFORT);
     }
+    realtime_joint_state_publisher_->unlockAndPublish();
   }
-  // publish
-  joint_state_publisher_->publish(joint_state_msg_);
-  dynamic_joint_state_publisher_->publish(dynamic_joint_state_msg_);
+
+  if (realtime_dynamic_joint_state_publisher_ && realtime_dynamic_joint_state_publisher_->trylock())
+  {
+    auto & dynamic_joint_state_msg = realtime_dynamic_joint_state_publisher_->msg_;
+    dynamic_joint_state_msg.header.stamp = get_node()->get_clock()->now();
+    for (size_t joint_index = 0; joint_index < dynamic_joint_state_msg.joint_names.size();
+         ++joint_index)
+    {
+      const auto & name = dynamic_joint_state_msg.joint_names[joint_index];
+      for (size_t interface_index = 0;
+           interface_index <
+           dynamic_joint_state_msg.interface_values[joint_index].interface_names.size();
+           ++interface_index)
+      {
+        const auto & interface_name =
+          dynamic_joint_state_msg.interface_values[joint_index].interface_names[interface_index];
+        dynamic_joint_state_msg.interface_values[joint_index].values[interface_index] =
+          name_if_value_mapping_[name][interface_name];
+      }
+    }
+    realtime_dynamic_joint_state_publisher_->unlockAndPublish();
+  }
 
   return controller_interface::return_type::OK;
 }

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -139,14 +139,11 @@ TEST_F(JointStateBroadcasterTest, ConfigureSuccessTest)
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_IFS));
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(joint_names_));
   ASSERT_THAT(
-    dynamic_joint_state_msg.interface_values[0].interface_names,
-    ElementsAreArray(IF_NAMES));
+    dynamic_joint_state_msg.interface_values[0].interface_names, ElementsAreArray(IF_NAMES));
   ASSERT_THAT(
-    dynamic_joint_state_msg.interface_values[1].interface_names,
-    ElementsAreArray(IF_NAMES));
+    dynamic_joint_state_msg.interface_values[1].interface_names, ElementsAreArray(IF_NAMES));
   ASSERT_THAT(
-    dynamic_joint_state_msg.interface_values[2].interface_names,
-    ElementsAreArray(IF_NAMES));
+    dynamic_joint_state_msg.interface_values[2].interface_names, ElementsAreArray(IF_NAMES));
 }
 
 TEST_F(JointStateBroadcasterTest, UpdateTest)
@@ -172,9 +169,7 @@ void JointStateBroadcasterTest::test_published_joint_state_message(const std::st
   auto subscription =
     test_node.create_subscription<sensor_msgs::msg::JointState>(topic, 10, subs_callback);
 
-  ASSERT_EQ(
-    state_broadcaster_->update(),
-    controller_interface::return_type::OK);
+  ASSERT_EQ(state_broadcaster_->update(), controller_interface::return_type::OK);
 
   // wait for message to be passed
   ASSERT_EQ(wait_for(subscription), rclcpp::WaitResultKind::Ready);

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -90,19 +90,9 @@ void JointStateBroadcasterTest::SetUpStateBroadcaster()
 
 TEST_F(JointStateBroadcasterTest, ConfigureErrorTest)
 {
-  // joint state not initialized yet
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.name.empty());
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.position.empty());
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.velocity.empty());
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.effort.empty());
-
-  // dynamic joint state not initialized yet
-  ASSERT_TRUE(state_broadcaster_->dynamic_joint_state_msg_.joint_names.empty());
-  ASSERT_TRUE(state_broadcaster_->dynamic_joint_state_msg_.interface_values.empty());
-
   // publishers not initialized yet
-  ASSERT_FALSE(state_broadcaster_->joint_state_publisher_);
-  ASSERT_FALSE(state_broadcaster_->dynamic_joint_state_publisher_);
+  ASSERT_FALSE(state_broadcaster_->realtime_joint_state_publisher_);
+  ASSERT_FALSE(state_broadcaster_->realtime_dynamic_joint_state_publisher_);
 
   // configure failed
   ASSERT_THROW(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), std::exception);
@@ -110,33 +100,13 @@ TEST_F(JointStateBroadcasterTest, ConfigureErrorTest)
   SetUpStateBroadcaster();
   // check state remains unchanged
 
-  // joint state still not initialized
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.name.empty());
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.position.empty());
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.velocity.empty());
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.effort.empty());
-
-  // dynamic joint state still not initialized
-  ASSERT_TRUE(state_broadcaster_->dynamic_joint_state_msg_.joint_names.empty());
-  ASSERT_TRUE(state_broadcaster_->dynamic_joint_state_msg_.interface_values.empty());
-
   // publishers still not initialized
-  ASSERT_FALSE(state_broadcaster_->joint_state_publisher_);
-  ASSERT_FALSE(state_broadcaster_->dynamic_joint_state_publisher_);
+  ASSERT_FALSE(state_broadcaster_->realtime_joint_state_publisher_);
+  ASSERT_FALSE(state_broadcaster_->realtime_dynamic_joint_state_publisher_);
 }
 
 TEST_F(JointStateBroadcasterTest, ConfigureSuccessTest)
 {
-  // joint state not initialized yet
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.name, IsEmpty());
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.position, IsEmpty());
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.velocity, IsEmpty());
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.effort, IsEmpty());
-
-  // dynamic joint state not initialized yet
-  ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.joint_names, IsEmpty());
-  ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.interface_values, IsEmpty());
-
   // publishers not initialized yet
   ASSERT_FALSE(state_broadcaster_->joint_state_publisher_);
   ASSERT_FALSE(state_broadcaster_->dynamic_joint_state_publisher_);
@@ -151,30 +121,32 @@ TEST_F(JointStateBroadcasterTest, ConfigureSuccessTest)
   const std::vector<std::string> IF_NAMES = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
   const size_t NUM_IFS = IF_NAMES.size();
 
+  // publishers initialized
+  ASSERT_TRUE(state_broadcaster_->realtime_joint_state_publisher_);
+  ASSERT_TRUE(state_broadcaster_->realtime_dynamic_joint_state_publisher_);
+
   // joint state initialized
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.name, ElementsAreArray(joint_names_));
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.position, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.velocity, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.effort, SizeIs(NUM_JOINTS));
+  const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
+  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(joint_names_));
+  ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
+  ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
+  ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));
 
   // dynamic joint state initialized
-  ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.joint_names, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.interface_values, SizeIs(NUM_IFS));
+  const auto & dynamic_joint_state_msg =
+    state_broadcaster_->realtime_dynamic_joint_state_publisher_->msg_;
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
+  ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_IFS));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(joint_names_));
   ASSERT_THAT(
-    state_broadcaster_->dynamic_joint_state_msg_.joint_names, ElementsAreArray(joint_names_));
-  ASSERT_THAT(
-    state_broadcaster_->dynamic_joint_state_msg_.interface_values[0].interface_names,
+    dynamic_joint_state_msg.interface_values[0].interface_names,
     ElementsAreArray(IF_NAMES));
   ASSERT_THAT(
-    state_broadcaster_->dynamic_joint_state_msg_.interface_values[1].interface_names,
+    dynamic_joint_state_msg.interface_values[1].interface_names,
     ElementsAreArray(IF_NAMES));
   ASSERT_THAT(
-    state_broadcaster_->dynamic_joint_state_msg_.interface_values[2].interface_names,
+    dynamic_joint_state_msg.interface_values[2].interface_names,
     ElementsAreArray(IF_NAMES));
-
-  // publishers initialized
-  ASSERT_TRUE(state_broadcaster_->joint_state_publisher_);
-  ASSERT_TRUE(state_broadcaster_->dynamic_joint_state_publisher_);
 }
 
 TEST_F(JointStateBroadcasterTest, UpdateTest)
@@ -200,7 +172,9 @@ void JointStateBroadcasterTest::test_published_joint_state_message(const std::st
   auto subscription =
     test_node.create_subscription<sensor_msgs::msg::JointState>(topic, 10, subs_callback);
 
-  ASSERT_EQ(state_broadcaster_->update(), controller_interface::return_type::OK);
+  ASSERT_EQ(
+    state_broadcaster_->update(),
+    controller_interface::return_type::OK);
 
   // wait for message to be passed
   ASSERT_EQ(wait_for(subscription), rclcpp::WaitResultKind::Ready);
@@ -267,7 +241,7 @@ void JointStateBroadcasterTest::test_published_dynamic_joint_state_message(
   // we only check that all values in this test are present in the message
   // and that it is the same across the interfaces
   // for test purposes they are mapped to the same doubles
-  for (auto i = 0ul; i < dynamic_joint_state_msg.joint_names.size(); ++i)
+  for (size_t i = 0; i < dynamic_joint_state_msg.joint_names.size(); ++i)
   {
     ASSERT_THAT(
       dynamic_joint_state_msg.interface_values[i].interface_names,
@@ -299,19 +273,9 @@ TEST_F(JointStateBroadcasterTest, DynamicJointStatePublishTestLocalTopic)
 
 TEST_F(JointStateBroadcasterTest, ExtraJointStatePublishTest)
 {
-  // joint state not initialized yet
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.name.empty());
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.position.empty());
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.velocity.empty());
-  ASSERT_TRUE(state_broadcaster_->joint_state_msg_.effort.empty());
-
-  // dynamic joint state not initialized yet
-  ASSERT_TRUE(state_broadcaster_->dynamic_joint_state_msg_.joint_names.empty());
-  ASSERT_TRUE(state_broadcaster_->dynamic_joint_state_msg_.interface_values.empty());
-
   // publishers not initialized yet
-  ASSERT_FALSE(state_broadcaster_->joint_state_publisher_);
-  ASSERT_FALSE(state_broadcaster_->dynamic_joint_state_publisher_);
+  ASSERT_FALSE(state_broadcaster_->realtime_joint_state_publisher_);
+  ASSERT_FALSE(state_broadcaster_->realtime_dynamic_joint_state_publisher_);
 
   SetUpStateBroadcaster();
 
@@ -330,11 +294,14 @@ TEST_F(JointStateBroadcasterTest, ExtraJointStatePublishTest)
   const std::vector<std::string> IF_NAMES = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
 
   // joint state initialized
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.name, ElementsAreArray(all_joint_names));
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.position, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.velocity, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(state_broadcaster_->joint_state_msg_.effort, SizeIs(NUM_JOINTS));
+  const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
+  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(all_joint_names));
+  ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
+  ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
+  ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));
 
   // dynamic joint state initialized
-  ASSERT_THAT(state_broadcaster_->dynamic_joint_state_msg_.joint_names, SizeIs(NUM_JOINTS));
+  const auto & dynamic_joint_state_msg =
+    state_broadcaster_->realtime_dynamic_joint_state_publisher_->msg_;
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
 }


### PR DESCRIPTION
This is a backport to Foxy of #276, "`joint_state_broadcaster` to use realtime tools".

In some tests in our Foxy-based project, before this patch, the controller manager `update()` function could take up to 33ms to return.

After backporting this patch, I see about 40µs max during normal operation and 80µs max when activating the controller.  Three orders of magnitude less!  Thanks for the original fix, @bmagyar .

