### PR TITLE
Fix linking of target `test_load_joint_trajectory_controller`

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -87,6 +87,7 @@ if(BUILD_TESTING)
     test/test_load_joint_trajectory_controller.cpp
   )
   target_include_directories(test_load_joint_trajectory_controller PRIVATE include)
+  target_link_libraries(test_load_joint_trajectory_controller joint_trajectory_controller)
   ament_target_dependencies(test_load_joint_trajectory_controller
     controller_manager
     realtime_tools


### PR DESCRIPTION
Fixes "No such file or directory" error:
`joint_trajectory_controller.hpp:27:10: fatal error: control_toolbox/pid.hpp: No such file or directory`

It needs `control_toolbox`, but depends on `joint_trajectory_controller` anyway. Hence the single-target linking, just as it is done for all other test-targets here as well.

fixup for 1fd8bc37f284098aed39d4e6bd324a8528a72ad4