### PR TITLE
joint_trajectory_controller: Export control_toolbox as a dependency

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -115,6 +115,7 @@ endif()
 ament_export_dependencies(
   controller_interface
   control_msgs
+  control_toolbox
   hardware_interface
   rclcpp
   rclcpp_lifecycle


### PR DESCRIPTION
One of `control_toolbox` headers is being included in `joint_trajectory_controller.hpp`