### PR TITLE
gripper_action_controller: Disable writing until action is active

### DIFF
--- a/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
+++ b/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
@@ -64,6 +64,11 @@ template <const char * HardwareInterface>
 controller_interface::return_type GripperActionController<HardwareInterface>::update(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {
+  if (!rt_active_goal_) {
+    set_hold_position();
+    return controller_interface::return_type::OK;
+  }
+
   command_struct_rt_ = *(command_.readFromRT());
 
   const double current_position = joint_position_state_interface_->get().get_value();

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -80,6 +80,7 @@ if(BUILD_TESTING)
     realtime_tools
     ros2_control_test_assets
     trajectory_msgs
+    control_toolbox
   )
 
   ament_add_gtest(
@@ -91,6 +92,7 @@ if(BUILD_TESTING)
     controller_manager
     realtime_tools
     ros2_control_test_assets
+    control_toolbox
   )
 
   ament_add_gtest(


### PR DESCRIPTION
When the gripper_action_controller starts it writes zero's to the gripper desired position, which causes the gripper to start moving on startup, which is not the behavior of the joint_trajectory_controller. I modified the gripper_action_controller to disable writing to the hardware unless an action goal is active.

I also had to link some of the tests to control_toolbox in order to build correctly.