### PR TITLE
CMakeLists.txt: added missing control_toolbox dependencies

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -77,6 +77,7 @@ if(BUILD_TESTING)
     hardware_interface
     rclcpp
     rclcpp_lifecycle
+    control_toolbox
     realtime_tools
     ros2_control_test_assets
     trajectory_msgs
@@ -89,6 +90,7 @@ if(BUILD_TESTING)
   target_include_directories(test_load_joint_trajectory_controller PRIVATE include)
   ament_target_dependencies(test_load_joint_trajectory_controller
     controller_manager
+    control_toolbox
     realtime_tools
     ros2_control_test_assets
   )


### PR DESCRIPTION
The tests of joint_trajectory_controller need to depend on
control_toolbox, oherwise, the
(which should imho be in <> instead of "") will report
No such file or directory when building against ros2_rolling
source compile.

Signed-off-by: Matthias Schoepfer <m.schoepfer@rethinkrobotics.com>