### PR TITLE
Fix JTC state tolerance and goal_time tolerance check bug

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -278,6 +278,7 @@ controller_interface::return_type JointTrajectoryController::update(
         // check abort
         if (abort || outside_goal_tolerance)
         {
+          set_hold_position();
           auto result = std::make_shared<FollowJTrajAction::Result>();
 
           if (abort)
@@ -319,6 +320,7 @@ controller_interface::return_type JointTrajectoryController::update(
             const double difference = time.seconds() - traj_end.seconds();
             if (difference > default_tolerances_.goal_time_tolerance)
             {
+              set_hold_position();
               auto result = std::make_shared<FollowJTrajAction::Result>();
               result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
               active_goal->setAborted(result);
@@ -1229,6 +1231,7 @@ void JointTrajectoryController::preempt_active_goal()
   const auto active_goal = *rt_active_goal_.readFromNonRT();
   if (active_goal)
   {
+    set_hold_position();
     auto action_res = std::make_shared<FollowJTrajAction::Result>();
     action_res->set__error_code(FollowJTrajAction::Result::INVALID_GOAL);
     action_res->set__error_string("Current goal cancelled due to new incoming action.");

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -212,7 +212,7 @@ controller_interface::return_type JointTrajectoryController::update(
 
           if (default_tolerances_.goal_time_tolerance != 0.0)
           {
-            // if we exceed goal_time_toleralance set it to aborted
+            // if we exceed goal_time_tolerance set it to aborted
             const rclcpp::Time traj_start = (*traj_point_active_ptr_)->get_trajectory_start_time();
             const rclcpp::Time traj_end = traj_start + start_segment_itr->time_from_start;
 
@@ -332,6 +332,8 @@ controller_interface::return_type JointTrajectoryController::update(
               node_->get_logger(), "Aborted due goal_time_tolerance exceeding by %f seconds",
               time_difference);
           }
+          // else, run another cycle while waiting for outside_goal_tolerance
+          // to be satisfied or violated within the goal_time_tolerance
         }
       }
     }

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -382,10 +382,6 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail)
   SetUpExecutor(params);
   SetUpControllerHardware();
 
-  const double init_pos1 = joint_pos_[0];
-  const double init_pos2 = joint_pos_[1];
-  const double init_pos3 = joint_pos_[2];
-
   std::shared_future<typename GoalHandle::SharedPtr> gh_future;
   // send goal
   {
@@ -421,9 +417,9 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail)
   // run an update, it should be holding
   traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
 
-  EXPECT_NEAR(init_pos1, joint_pos_[0], COMMON_THRESHOLD);
-  EXPECT_NEAR(init_pos2, joint_pos_[1], COMMON_THRESHOLD);
-  EXPECT_NEAR(init_pos3, joint_pos_[2], COMMON_THRESHOLD);
+  EXPECT_NEAR(INITIAL_POS_JOINT1, joint_pos_[0], COMMON_THRESHOLD);
+  EXPECT_NEAR(INITIAL_POS_JOINT2, joint_pos_[1], COMMON_THRESHOLD);
+  EXPECT_NEAR(INITIAL_POS_JOINT3, joint_pos_[2], COMMON_THRESHOLD);
 }
 
 TEST_F(TestTrajectoryActions, test_goal_tolerances_fail)

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -391,7 +391,7 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail)
   {
     std::vector<JointTrajectoryPoint> points;
     JointTrajectoryPoint point;
-    point.time_from_start = rclcpp::Duration::from_seconds(0.1);
+    point.time_from_start = rclcpp::Duration::from_seconds(0.0001);
     point.positions.resize(joint_names_.size());
 
     point.positions[0] = 4.0;
@@ -407,6 +407,53 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail)
   EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, common_resultcode_);
   EXPECT_EQ(
     control_msgs::action::FollowJointTrajectory_Result::PATH_TOLERANCE_VIOLATED,
+    common_action_result_code_);
+
+  // run an update, it should be holding
+  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+
+  EXPECT_NEAR(init_pos1, joint_pos_[0], COMMON_THRESHOLD);
+  EXPECT_NEAR(init_pos2, joint_pos_[1], COMMON_THRESHOLD);
+  EXPECT_NEAR(init_pos3, joint_pos_[2], COMMON_THRESHOLD);
+}
+
+TEST_F(TestTrajectoryActions, test_goal_tolerances_fail)
+{
+  // set joint tolerance parameters
+  const double goal_tol = 0.1;
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("constraints.joint1.goal", goal_tol),
+    rclcpp::Parameter("constraints.joint2.goal", goal_tol),
+    rclcpp::Parameter("constraints.joint3.goal", goal_tol)};
+
+  SetUpExecutor(params);
+  SetUpControllerHardware();
+
+  const double init_pos1 = joint_pos_[0];
+  const double init_pos2 = joint_pos_[1];
+  const double init_pos3 = joint_pos_[2];
+
+  std::shared_future<typename GoalHandle::SharedPtr> gh_future;
+  // send goal
+  {
+    std::vector<JointTrajectoryPoint> points;
+    JointTrajectoryPoint point;
+    point.time_from_start = rclcpp::Duration::from_seconds(0.0);
+    point.positions.resize(joint_names_.size());
+
+    point.positions[0] = 4.0;
+    point.positions[1] = 5.0;
+    point.positions[2] = 6.0;
+    points.push_back(point);
+
+    gh_future = sendActionGoal(points, 1.0, goal_options_);
+  }
+  controller_hw_thread_.join();
+
+  EXPECT_TRUE(gh_future.get());
+  EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, common_resultcode_);
+  EXPECT_EQ(
+    control_msgs::action::FollowJointTrajectory_Result::GOAL_TOLERANCE_VIOLATED,
     common_action_result_code_);
 
   // run an update, it should be holding

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -382,12 +382,16 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail)
   SetUpExecutor(params);
   SetUpControllerHardware();
 
+  const double init_pos1 = joint_pos_[0];
+  const double init_pos2 = joint_pos_[1];
+  const double init_pos3 = joint_pos_[2];
+
   std::shared_future<typename GoalHandle::SharedPtr> gh_future;
   // send goal
   {
     std::vector<JointTrajectoryPoint> points;
     JointTrajectoryPoint point;
-    point.time_from_start = rclcpp::Duration::from_seconds(1.0);
+    point.time_from_start = rclcpp::Duration::from_seconds(0.1);
     point.positions.resize(joint_names_.size());
 
     point.positions[0] = 4.0;
@@ -404,6 +408,13 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail)
   EXPECT_EQ(
     control_msgs::action::FollowJointTrajectory_Result::PATH_TOLERANCE_VIOLATED,
     common_action_result_code_);
+
+  // run an update, it should be holding
+  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+
+  EXPECT_NEAR(init_pos1, joint_pos_[0], COMMON_THRESHOLD);
+  EXPECT_NEAR(init_pos2, joint_pos_[1], COMMON_THRESHOLD);
+  EXPECT_NEAR(init_pos3, joint_pos_[2], COMMON_THRESHOLD);
 }
 
 TEST_F(TestTrajectoryActions, test_cancel_hold_position)

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -426,10 +426,13 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_fail)
 {
   // set joint tolerance parameters
   const double goal_tol = 0.1;
+  // set very small goal_time so that goal_time is violated
+  const double goal_time = 0.000001;
   std::vector<rclcpp::Parameter> params = {
     rclcpp::Parameter("constraints.joint1.goal", goal_tol),
     rclcpp::Parameter("constraints.joint2.goal", goal_tol),
-    rclcpp::Parameter("constraints.joint3.goal", goal_tol)};
+    rclcpp::Parameter("constraints.joint3.goal", goal_tol),
+    rclcpp::Parameter("constraints.goal_time", goal_time)};
 
   SetUpExecutor(params);
   SetUpControllerHardware();

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -390,14 +390,23 @@ TEST_F(TestTrajectoryActions, test_state_tolerances_fail)
   // send goal
   {
     std::vector<JointTrajectoryPoint> points;
-    JointTrajectoryPoint point;
-    point.time_from_start = rclcpp::Duration::from_seconds(0.0001);
-    point.positions.resize(joint_names_.size());
+    JointTrajectoryPoint point1;
+    point1.time_from_start = rclcpp::Duration::from_seconds(0.0);
+    point1.positions.resize(joint_names_.size());
 
-    point.positions[0] = 4.0;
-    point.positions[1] = 5.0;
-    point.positions[2] = 6.0;
-    points.push_back(point);
+    point1.positions[0] = 4.0;
+    point1.positions[1] = 5.0;
+    point1.positions[2] = 6.0;
+    points.push_back(point1);
+
+    JointTrajectoryPoint point2;
+    point2.time_from_start = rclcpp::Duration::from_seconds(0.1);
+    point2.positions.resize(joint_names_.size());
+
+    point2.positions[0] = 7.0;
+    point2.positions[1] = 8.0;
+    point2.positions[2] = 9.0;
+    points.push_back(point2);
 
     gh_future = sendActionGoal(points, 1.0, goal_options_);
   }


### PR DESCRIPTION
Hey all,

I noticed a bug in the JTC where if a joint trajectory tolerance was specified (usually done using the `constraints.<joint_name>.trajectory` param in the ros_controllers.yaml file) for a given joint, the trajectory point being processed still gets set to the relevant command interfaces **before** getting tolerance checked. If in fact the tolerance is violated (which is determined afterwards), the offending joint command still gets sent out which we don't want. The fix is simply to tolerance check first and then set the command interfaces if the tolerance is met. 

I came across this bug specifically for the first point in the trajectory (but I think this could happen to subsequent points depending on how the trajectory was made). Usually the first point is checked to be within the "allowed_start_tolerance" defined in MoveIt (so the tolerance is usually met when it gets to the JTC) but in this scenario, the "allowed_start_tolerance" was set to be relatively high so it was now upon the JTC to verify that the deviation was within tolerance.

EDIT

This PR also fixes a goal_time tolerance check bug in a scenario when the goal_tolerance was set. It seems that after the last point in a trajectory is commanded, `outside_goal_tolerance` would get set to `true` if the goal_tolerance was violated causing an abort to occur even though `goal_time` was not set! If the goal_time is not set, then by default JTC should wait to complete that the move was successful until the goal_tolerance is reached. This PR fixes this bug by only aborting a violation of the goal tolerance if the `goal_time` has passed and the tolerance has not yet been met as I think was originally intended.