### PR TITLE
Remove unused include to fix test_load_joint_trajectory_controller

### DIFF
--- a/joint_trajectory_controller/test/test_load_joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_load_joint_trajectory_controller.cpp
@@ -21,7 +21,6 @@
 #include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/utilities.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
-#include "test_trajectory_controller_utils.hpp"
 
 TEST(TestLoadJointStateController, load_controller)
 {


### PR DESCRIPTION
Replace https://github.com/ros-controls/ros2_controllers/pull/309

This header file isn't used and forces the test to depend on JTC