### PR TITLE
Lifecycle updates

### DIFF
--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -343,7 +343,7 @@ TEST_F(TestDiffDriveController, cleanup)
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
   assignResourcesPosFeedback();
 
-  state = controller_->activate();
+  state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
   waitForSetup();
@@ -358,13 +358,13 @@ TEST_F(TestDiffDriveController, cleanup)
     controller_->update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
 
-  state = controller_->deactivate();
+  state = controller_->get_node()->deactivate();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
 
-  state = controller_->cleanup();
+  state = controller_->get_node()->cleanup();
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
 
   // should be stopped
@@ -396,7 +396,7 @@ TEST_F(TestDiffDriveController, correct_initialization_using_parameters)
   EXPECT_EQ(0.01, left_wheel_vel_cmd_.get_value());
   EXPECT_EQ(0.02, right_wheel_vel_cmd_.get_value());
 
-  state = controller_->activate();
+  state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
   // send msg
@@ -415,7 +415,7 @@ TEST_F(TestDiffDriveController, correct_initialization_using_parameters)
   // deactivated
   // wait so controller process the second point when deactivated
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-  state = controller_->deactivate();
+  state = controller_->get_node()->deactivate();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01)),
@@ -425,7 +425,7 @@ TEST_F(TestDiffDriveController, correct_initialization_using_parameters)
   EXPECT_EQ(0.0, right_wheel_vel_cmd_.get_value()) << "Wheels are halted on deactivate()";
 
   // cleanup
-  state = controller_->cleanup();
+  state = controller_->get_node()->cleanup();
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(0.0, left_wheel_vel_cmd_.get_value());
   EXPECT_EQ(0.0, right_wheel_vel_cmd_.get_value());

--- a/effort_controllers/test/test_joint_group_effort_controller.cpp
+++ b/effort_controllers/test/test_joint_group_effort_controller.cpp
@@ -191,7 +191,7 @@ TEST_F(JointGroupEffortControllerTest, CommandCallbackTest)
   auto node_state = controller_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = controller_->activate();
+  node_state = controller_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   // send a new command

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -124,7 +124,8 @@ CallbackReturn ForwardCommandController::on_activate(
   }
 
   // reset command buffer if a command came through callback when controller was inactive
-  rt_command_ptr_= realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);;
+  rt_command_ptr_ = realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);
+  ;
 
   return CallbackReturn::SUCCESS;
 }
@@ -133,7 +134,8 @@ CallbackReturn ForwardCommandController::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
   // reset command buffer
-  rt_command_ptr_= realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);;
+  rt_command_ptr_ = realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);
+  ;
   return CallbackReturn::SUCCESS;
 }
 

--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -124,7 +124,7 @@ CallbackReturn ForwardCommandController::on_activate(
   }
 
   // reset command buffer if a command came through callback when controller was inactive
-  rt_command_ptr_.reset();
+  rt_command_ptr_= realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);;
 
   return CallbackReturn::SUCCESS;
 }
@@ -133,7 +133,7 @@ CallbackReturn ForwardCommandController::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
   // reset command buffer
-  rt_command_ptr_.reset();
+  rt_command_ptr_= realtime_tools::RealtimeBuffer<std::shared_ptr<CmdType>>(nullptr);;
   return CallbackReturn::SUCCESS;
 }
 

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -253,7 +253,7 @@ TEST_F(ForwardCommandControllerTest, CommandCallbackTest)
   auto node_state = controller_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = controller_->activate();
+  node_state = controller_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   // send a new command
@@ -296,7 +296,7 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
   auto node_state = controller_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = controller_->activate();
+  node_state = controller_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   auto command_msg = std::make_shared<std_msgs::msg::Float64MultiArray>();
@@ -314,7 +314,7 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
   ASSERT_EQ(joint_2_pos_cmd_.get_value(), 20);
   ASSERT_EQ(joint_3_pos_cmd_.get_value(), 30);
 
-  node_state = controller_->deactivate();
+  node_state = controller_->get_node()->deactivate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
   // command ptr should be reset (nullptr) after deactivation - same check as in `update`
@@ -338,7 +338,7 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
     controller_->rt_command_ptr_.readFromRT() && *(controller_->rt_command_ptr_.readFromRT()));
 
   // Now activate again
-  node_state = controller_->activate();
+  node_state = controller_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   // command ptr should be reset (nullptr) after activation - same check as in `update`

--- a/gripper_controllers/include/gripper_controllers/hardware_interface_adapter.hpp
+++ b/gripper_controllers/include/gripper_controllers/hardware_interface_adapter.hpp
@@ -46,7 +46,7 @@ public:
   bool init(
     std::experimental::optional<
       std::reference_wrapper<hardware_interface::LoanedCommandInterface>> /* joint_handle */,
-    const rclcpp::Node::SharedPtr & /* node */)
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & /* node */)
   {
     return false;
   }
@@ -73,7 +73,7 @@ public:
   bool init(
     std::experimental::optional<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
       joint_handle,
-    const rclcpp::Node::SharedPtr & /* node */)
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & /* node */)
   {
     joint_handle_ = joint_handle;
     return true;
@@ -116,7 +116,7 @@ class HardwareInterfaceAdapter<hardware_interface::HW_IF_EFFORT>
 public:
   template <typename ParameterT>
   auto auto_declare(
-    const rclcpp::Node::SharedPtr & node, const std::string & name,
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & node, const std::string & name,
     const ParameterT & default_value)
   {
     if (!node->has_parameter(name))
@@ -132,7 +132,7 @@ public:
   bool init(
     std::experimental::optional<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
       joint_handle,
-    const rclcpp::Node::SharedPtr & node)
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & node)
   {
     joint_handle_ = joint_handle;
     // Init PID gains from ROS parameter server

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -605,7 +605,7 @@ TEST_F(JointStateBroadcasterTest, UpdateTest)
   SetUpStateBroadcaster();
 
   auto node_state = state_broadcaster_->configure();
-  node_state = state_broadcaster_->activate();
+  node_state = state_broadcaster_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   ASSERT_EQ(
     state_broadcaster_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
@@ -617,7 +617,7 @@ void JointStateBroadcasterTest::test_published_joint_state_message(const std::st
   auto node_state = state_broadcaster_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = state_broadcaster_->activate();
+  node_state = state_broadcaster_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   rclcpp::Node test_node("test_node");
@@ -669,7 +669,7 @@ void JointStateBroadcasterTest::test_published_dynamic_joint_state_message(
   auto node_state = state_broadcaster_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = state_broadcaster_->activate();
+  node_state = state_broadcaster_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   rclcpp::Node test_node("test_node");

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -92,7 +92,7 @@ struct SegmentTolerances
  * \return Trajectory segment tolerances.
  */
 SegmentTolerances get_segment_tolerances(
-  const rclcpp::Node & node, const std::vector<std::string> & joint_names)
+  const rclcpp_lifecycle::LifecycleNode & node, const std::vector<std::string> & joint_names)
 {
   const auto n_joints = joint_names.size();
   SegmentTolerances tolerances;

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -243,11 +243,11 @@ TEST_P(TrajectoryControllerTestParameterized, cleanup)
   traj_controller_->wait_for_trajectory(executor);
   traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
 
-  auto state = traj_controller_->deactivate();
+  auto state = traj_controller_->get_node()->deactivate();
   ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
   traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
 
-  state = traj_controller_->cleanup();
+  state = traj_controller_->get_node()->cleanup();
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
   // update for 0.25 seconds
   const auto start_time = rclcpp::Clock().now();
@@ -298,7 +298,7 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   std::this_thread::sleep_for(FIRST_POINT_TIME);
   traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
   // deactivated
-  state = traj_controller_->deactivate();
+  state = traj_controller_->get_node()->deactivate();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 
   // TODO(denis): on my laptop I get delta of approx 0.1083. Is this me or is it something wrong?
@@ -310,7 +310,7 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   EXPECT_NEAR(5.5, joint_pos_[2], allowed_delta);
 
   // cleanup
-  state = traj_controller_->cleanup();
+  state = traj_controller_->get_node()->cleanup();
 
   // update loop receives a new msg and updates accordingly
   traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
@@ -761,7 +761,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_execute_partial_traj_in_futur
   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
   traj_node->set_parameter(partial_joints_parameters);
   traj_controller_->configure();
-  traj_controller_->activate();
+  traj_controller_->get_node()->activate();
 
   std::vector<std::vector<double>> full_traj{{{2., 3., 4.}, {4., 6., 8.}}};
   std::vector<std::vector<double>> partial_traj{

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -117,7 +117,7 @@ public:
     command_interface_types_ = {"position"};
     state_interface_types_ = {"position", "velocity"};
 
-    node_ = std::make_shared<rclcpp::Node>("trajectory_publisher_");
+    node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>("trajectory_publisher_");
     trajectory_publisher_ = node_->create_publisher<trajectory_msgs::msg::JointTrajectory>(
       controller_name_ + "/joint_trajectory", rclcpp::SystemDefaultsQoS());
   }
@@ -216,7 +216,7 @@ public:
     }
 
     traj_controller_->assign_interfaces(std::move(cmd_interfaces), std::move(state_interfaces));
-    traj_controller_->activate();
+    traj_controller_->get_node()->activate();
   }
 
   static void TearDownTestCase() { rclcpp::shutdown(); }
@@ -350,11 +350,11 @@ public:
   std::vector<std::string> command_interface_types_;
   std::vector<std::string> state_interface_types_;
 
-  rclcpp::Node::SharedPtr node_;
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node_;
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr trajectory_publisher_;
 
   std::shared_ptr<TestableJointTrajectoryController> traj_controller_;
-  std::shared_ptr<rclcpp::Node> traj_node_;
+  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> traj_node_;
   rclcpp::Subscription<control_msgs::msg::JointTrajectoryControllerState>::SharedPtr
     state_subscriber_;
   mutable std::mutex state_mutex_;

--- a/position_controllers/test/test_joint_group_position_controller.cpp
+++ b/position_controllers/test/test_joint_group_position_controller.cpp
@@ -191,7 +191,7 @@ TEST_F(JointGroupPositionControllerTest, CommandCallbackTest)
   auto node_state = controller_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = controller_->activate();
+  node_state = controller_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   // send a new command

--- a/velocity_controllers/test/test_joint_group_velocity_controller.cpp
+++ b/velocity_controllers/test/test_joint_group_velocity_controller.cpp
@@ -191,7 +191,7 @@ TEST_F(JointGroupVelocityControllerTest, CommandCallbackTest)
   auto node_state = controller_->configure();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  node_state = controller_->activate();
+  node_state = controller_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
   // send a new command


### PR DESCRIPTION
I was unable to build on the Galactic branch without updating the tests and nodes to lifecycle nodes. This PR should allow the ros2_controllers galactic branch to build in Galactic with ros2_control on the master branch. 

I also reverted #283 because the reset function was not being found. I'm sure there is a way to use that function still, but I haven't looked into it.