### PR TITLE
Add Ruckig jerk-limited smoothing to the joint trajectory controller

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -21,6 +21,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     rclcpp
     rclcpp_lifecycle
     realtime_tools
+    ruckig
     trajectory_msgs
 )
 
@@ -35,6 +36,9 @@ add_library(${PROJECT_NAME} SHARED
 )
 target_include_directories(${PROJECT_NAME} PRIVATE include)
 ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(joint_trajectory_controller
+  ruckig::ruckig
+)
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "JOINT_TRAJECTORY_CONTROLLER_BUILDING_DLL" "_USE_MATH_DEFINES")

--- a/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
@@ -29,13 +29,14 @@ namespace interpolation_methods
 enum class InterpolationMethod
 {
   NONE,
-  VARIABLE_DEGREE_SPLINE
+  VARIABLE_DEGREE_SPLINE,
+  RUCKIG
 };
 
 const InterpolationMethod DEFAULT_INTERPOLATION = InterpolationMethod::VARIABLE_DEGREE_SPLINE;
 
 const std::unordered_map<InterpolationMethod, std::string> InterpolationMethodMap(
-  {{InterpolationMethod::NONE, "none"}, {InterpolationMethod::VARIABLE_DEGREE_SPLINE, "splines"}});
+  {{InterpolationMethod::NONE, "none"}, {InterpolationMethod::VARIABLE_DEGREE_SPLINE, "splines"}, {InterpolationMethod::RUCKIG, "ruckig"}});
 
 [[nodiscard]] inline InterpolationMethod from_string(const std::string & interpolation_method)
 {
@@ -49,13 +50,19 @@ const std::unordered_map<InterpolationMethod, std::string> InterpolationMethodMa
   {
     return InterpolationMethod::VARIABLE_DEGREE_SPLINE;
   }
+  else if (
+    !interpolation_method.compare(
+      InterpolationMethodMap.at(InterpolationMethod::RUCKIG)) == 0)
+  {
+    return InterpolationMethod::RUCKIG;
+  }
   // Default
   else
   {
     RCLCPP_INFO_STREAM(
       LOGGER,
       "No interpolation method parameter was given. Using the default, VARIABLE_DEGREE_SPLINE.");
-    return InterpolationMethod::VARIABLE_DEGREE_SPLINE;
+    return DEFAULT_INTERPOLATION;
   }
 }
 }  // namespace interpolation_methods

--- a/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
@@ -36,7 +36,8 @@ enum class InterpolationMethod
 const InterpolationMethod DEFAULT_INTERPOLATION = InterpolationMethod::VARIABLE_DEGREE_SPLINE;
 
 const std::unordered_map<InterpolationMethod, std::string> InterpolationMethodMap(
-  {{InterpolationMethod::NONE, "none"}, {InterpolationMethod::VARIABLE_DEGREE_SPLINE, "splines"}, {InterpolationMethod::RUCKIG, "ruckig"}});
+  {{InterpolationMethod::NONE, "none"}, {InterpolationMethod::VARIABLE_DEGREE_SPLINE, "splines"},
+  {InterpolationMethod::RUCKIG, "ruckig"}});
 
 [[nodiscard]] inline InterpolationMethod from_string(const std::string & interpolation_method)
 {
@@ -45,13 +46,13 @@ const std::unordered_map<InterpolationMethod, std::string> InterpolationMethodMa
     return InterpolationMethod::NONE;
   }
   else if (
-    !interpolation_method.compare(
+    interpolation_method.compare(
       InterpolationMethodMap.at(InterpolationMethod::VARIABLE_DEGREE_SPLINE)) == 0)
   {
     return InterpolationMethod::VARIABLE_DEGREE_SPLINE;
   }
   else if (
-    !interpolation_method.compare(
+    interpolation_method.compare(
       InterpolationMethodMap.at(InterpolationMethod::RUCKIG)) == 0)
   {
     return InterpolationMethod::RUCKIG;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -137,6 +137,7 @@ protected:
   // Run the controller in open-loop, i.e., read hardware states only when starting controller.
   // This is useful when robot is not exactly following the commanded trajectory.
   bool open_loop_control_ = false;
+
   trajectory_msgs::msg::JointTrajectoryPoint last_commanded_state_;
   /// Allow integration in goal trajectories to accept goals without position or velocity specified
   bool allow_integration_in_goal_trajectories_ = false;
@@ -173,7 +174,7 @@ protected:
   // reserved storage for result of the command when closed loop pid adapter is used
   std::vector<double> tmp_command_;
 
-  // TODO(karsten1987): eventually activate and deactivate subscriber directly when its supported
+  // TODO(karsten1987): eventually activate and deactivate subscriber directly when it's supported
   bool subscriber_is_active_ = false;
   rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr joint_command_subscriber_ =
     nullptr;

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -25,6 +25,7 @@
   <depend>hardware_interface</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>ruckig</depend>
   <depend>trajectory_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -72,6 +72,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
       "interpolation_method", interpolation_methods::InterpolationMethodMap.at(
                                 interpolation_methods::DEFAULT_INTERPOLATION));
     interpolation_method_ = interpolation_methods::from_string(interpolation_string);
+    auto_declare<double>("constraints.stopped_velocity_tolerance", 0.01);
+    auto_declare<double>("constraints.goal_time", 0.0);
   }
   catch (const std::exception & e)
   {
@@ -181,6 +183,9 @@ controller_interface::return_type JointTrajectoryController::update(
     if (!(*traj_point_active_ptr_)->is_sampled_already())
     {
       first_sample = true;
+      // Reset Ruckig vel/accel/jerk smoothing
+      (*traj_point_active_ptr_)->reset_ruckig_smoothing();
+
       if (open_loop_control_)
       {
         (*traj_point_active_ptr_)->set_point_before_trajectory_msg(time, last_commanded_state_);
@@ -197,88 +202,91 @@ controller_interface::return_type JointTrajectoryController::update(
       (*traj_point_active_ptr_)
         ->sample(time, interpolation_method_, state_desired_, start_segment_itr, end_segment_itr);
 
-    if (valid_point)
+    if (!valid_point)
     {
-      bool tolerance_violated_while_moving = false;
-      bool outside_goal_tolerance = false;
-      bool within_goal_time = true;
-      double time_difference = 0.0;
-      const bool before_last_point = end_segment_itr != (*traj_point_active_ptr_)->end();
+      return controller_interface::return_type::ERROR;
+    }
 
-      // Check state/goal tolerance
-      for (size_t index = 0; index < dof_; ++index)
+    bool tolerance_violated_while_moving = false;
+    bool outside_goal_tolerance = false;
+    bool within_goal_time = true;
+    double time_difference = 0.0;
+    const bool before_last_point = end_segment_itr != (*traj_point_active_ptr_)->end();
+
+    // Check state/goal tolerance
+    for (size_t index = 0; index < dof_; ++index)
+    {
+      compute_error_for_joint(state_error_, index, state_current_, state_desired_);
+
+      // Always check the state tolerance on the first sample in case the first sample
+      // is the last point
+      if (
+        (before_last_point || first_sample) &&
+        !check_state_tolerance_per_joint(
+          state_error_, index, default_tolerances_.state_tolerance[index], false))
       {
-        compute_error_for_joint(state_error_, index, state_current_, state_desired_);
+        tolerance_violated_while_moving = true;
+      }
+      // past the final point, check that we end up inside goal tolerance
+      if (
+        !before_last_point &&
+        !check_state_tolerance_per_joint(
+          state_error_, index, default_tolerances_.goal_state_tolerance[index], false))
+      {
+        outside_goal_tolerance = true;
 
-        // Always check the state tolerance on the first sample in case the first sample
-        // is the last point
-        if (
-          (before_last_point || first_sample) &&
-          !check_state_tolerance_per_joint(
-            state_error_, index, default_tolerances_.state_tolerance[index], false))
+        if (default_tolerances_.goal_time_tolerance != 0.0)
         {
-          tolerance_violated_while_moving = true;
-        }
-        // past the final point, check that we end up inside goal tolerance
-        if (
-          !before_last_point &&
-          !check_state_tolerance_per_joint(
-            state_error_, index, default_tolerances_.goal_state_tolerance[index], false))
-        {
-          outside_goal_tolerance = true;
+          // if we exceed goal_time_tolerance set it to aborted
+          const rclcpp::Time traj_start = (*traj_point_active_ptr_)->get_trajectory_start_time();
+          const rclcpp::Time traj_end = traj_start + start_segment_itr->time_from_start;
 
-          if (default_tolerances_.goal_time_tolerance != 0.0)
+          time_difference = get_node()->now().seconds() - traj_end.seconds();
+
+          if (time_difference > default_tolerances_.goal_time_tolerance)
           {
-            // if we exceed goal_time_tolerance set it to aborted
-            const rclcpp::Time traj_start = (*traj_point_active_ptr_)->get_trajectory_start_time();
-            const rclcpp::Time traj_end = traj_start + start_segment_itr->time_from_start;
-
-            time_difference = get_node()->now().seconds() - traj_end.seconds();
-
-            if (time_difference > default_tolerances_.goal_time_tolerance)
-            {
-              within_goal_time = false;
-            }
+            within_goal_time = false;
           }
         }
       }
+    }
 
-      // set values for next hardware write() if tolerance is met
-      if (!tolerance_violated_while_moving && within_goal_time)
+    // set values for next hardware write() if tolerance is met
+    if (!tolerance_violated_while_moving && within_goal_time)
+    {
+      if (use_closed_loop_pid_adapter_)
+      {
+        // Update PIDs
+        for (auto i = 0ul; i < dof_; ++i)
+        {
+          tmp_command_[i] = (state_desired_.velocities[i] * ff_velocity_scale_[i]) +
+                            pids_[i]->computeCommand(
+                              state_desired_.positions[i] - state_current_.positions[i],
+                              state_desired_.velocities[i] - state_current_.velocities[i],
+                              (uint64_t)period.nanoseconds());
+        }
+      }
+
+      // set values for next hardware write()
+      if (has_position_command_interface_)
+      {
+        assign_interface_from_point(joint_command_interface_[0], state_desired_.positions);
+      }
+      if (has_velocity_command_interface_)
       {
         if (use_closed_loop_pid_adapter_)
         {
-          // Update PIDs
-          for (auto i = 0ul; i < dof_; ++i)
-          {
-            tmp_command_[i] = (state_desired_.velocities[i] * ff_velocity_scale_[i]) +
-                              pids_[i]->computeCommand(
-                                state_desired_.positions[i] - state_current_.positions[i],
-                                state_desired_.velocities[i] - state_current_.velocities[i],
-                                (uint64_t)period.nanoseconds());
-          }
+          assign_interface_from_point(joint_command_interface_[1], tmp_command_);
         }
-
-        // set values for next hardware write()
-        if (has_position_command_interface_)
+        else
         {
-          assign_interface_from_point(joint_command_interface_[0], state_desired_.positions);
+          assign_interface_from_point(joint_command_interface_[1], state_desired_.velocities);
         }
-        if (has_velocity_command_interface_)
-        {
-          if (use_closed_loop_pid_adapter_)
-          {
-            assign_interface_from_point(joint_command_interface_[1], tmp_command_);
-          }
-          else
-          {
-            assign_interface_from_point(joint_command_interface_[1], state_desired_.velocities);
-          }
-        }
-        if (has_acceleration_command_interface_)
-        {
-          assign_interface_from_point(joint_command_interface_[2], state_desired_.accelerations);
-        }
+      }
+      if (has_acceleration_command_interface_)
+      {
+        assign_interface_from_point(joint_command_interface_[2], state_desired_.accelerations);
+      }
         if (has_effort_command_interface_)
         {
           if (use_closed_loop_pid_adapter_)
@@ -293,65 +301,64 @@ controller_interface::return_type JointTrajectoryController::update(
 
         // store the previous command. Used in open-loop control mode
         last_commanded_state_ = state_desired_;
-      }
+          assign_interface_from_point(joint_command_interface_[3], state_desired_.effort);
+        }
 
-      const auto active_goal = *rt_active_goal_.readFromRT();
-      if (active_goal)
+    const auto active_goal = *rt_active_goal_.readFromRT();
+    if (active_goal)
+    {
+      // send feedback
+      auto feedback = std::make_shared<FollowJTrajAction::Feedback>();
+      feedback->header.stamp = time;
+      feedback->joint_names = joint_names_;
+
+      feedback->actual = state_current_;
+      feedback->desired = state_desired_;
+      feedback->error = state_error_;
+      active_goal->setFeedback(feedback);
+
+      // check abort
+      if (tolerance_violated_while_moving)
       {
-        // send feedback
-        auto feedback = std::make_shared<FollowJTrajAction::Feedback>();
-        feedback->header.stamp = time;
-        feedback->joint_names = joint_names_;
+        set_hold_position();
+        auto result = std::make_shared<FollowJTrajAction::Result>();
+        RCLCPP_WARN(get_node()->get_logger(), "Aborted due to state tolerance violation");
+        result->set__error_code(FollowJTrajAction::Result::PATH_TOLERANCE_VIOLATED);
+        active_goal->setAborted(result);
+        // TODO(matthew-reynolds): Need a lock-free write here
+        // See https://github.com/ros-controls/ros2_controllers/issues/168
+        rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
 
-        feedback->actual = state_current_;
-        feedback->desired = state_desired_;
-        feedback->error = state_error_;
-        active_goal->setFeedback(feedback);
-
-        // check abort
-        if (tolerance_violated_while_moving)
+        // check goal tolerance
+      }
+      else if (!before_last_point)
+      {
+        if (!outside_goal_tolerance)
         {
-          set_hold_position();
-          auto result = std::make_shared<FollowJTrajAction::Result>();
-
-          RCLCPP_WARN(get_node()->get_logger(), "Aborted due to state tolerance violation");
-          result->set__error_code(FollowJTrajAction::Result::PATH_TOLERANCE_VIOLATED);
-          active_goal->setAborted(result);
+          auto res = std::make_shared<FollowJTrajAction::Result>();
+          res->set__error_code(FollowJTrajAction::Result::SUCCESSFUL);
+          active_goal->setSucceeded(res);
           // TODO(matthew-reynolds): Need a lock-free write here
           // See https://github.com/ros-controls/ros2_controllers/issues/168
           rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
 
-          // check goal tolerance
+          RCLCPP_INFO(get_node()->get_logger(), "Goal reached, success!");
         }
-        else if (!before_last_point)
+        else if (!within_goal_time)
         {
-          if (!outside_goal_tolerance)
-          {
-            auto res = std::make_shared<FollowJTrajAction::Result>();
-            res->set__error_code(FollowJTrajAction::Result::SUCCESSFUL);
-            active_goal->setSucceeded(res);
-            // TODO(matthew-reynolds): Need a lock-free write here
-            // See https://github.com/ros-controls/ros2_controllers/issues/168
-            rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-
-            RCLCPP_INFO(get_node()->get_logger(), "Goal reached, success!");
-          }
-          else if (!within_goal_time)
-          {
-            set_hold_position();
-            auto result = std::make_shared<FollowJTrajAction::Result>();
-            result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
-            active_goal->setAborted(result);
-            // TODO(matthew-reynolds): Need a lock-free write here
-            // See https://github.com/ros-controls/ros2_controllers/issues/168
-            rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-            RCLCPP_WARN(
-              get_node()->get_logger(), "Aborted due goal_time_tolerance exceeding by %f seconds",
-              time_difference);
-          }
-          // else, run another cycle while waiting for outside_goal_tolerance
-          // to be satisfied or violated within the goal_time_tolerance
+          set_hold_position();
+          auto result = std::make_shared<FollowJTrajAction::Result>();
+          result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
+          active_goal->setAborted(result);
+          // TODO(matthew-reynolds): Need a lock-free write here
+          // See https://github.com/ros-controls/ros2_controllers/issues/168
+          rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
+          RCLCPP_WARN(
+            get_node()->get_logger(), "Aborted due goal_time_tolerance exceeding by %f seconds",
+            time_difference);
         }
+        // else, run another cycle while waiting for outside_goal_tolerance
+        // to be satisfied or violated within the goal_time_tolerance
       }
     }
   }

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -46,10 +46,11 @@ TEST(TestTrajectory, initialize_trajectory)
     empty_msg->header.stamp.nanosec = 2;
     const rclcpp::Time empty_time = empty_msg->header.stamp;
     auto traj = joint_trajectory_controller::Trajectory(empty_msg);
+    rclcpp::Duration period = rclcpp::Duration::from_nanoseconds(1e7);
 
-    trajectory_msgs::msg::JointTrajectoryPoint expected_point;
+    trajectory_msgs::msg::JointTrajectoryPoint output_point;
     joint_trajectory_controller::TrajectoryPointConstIter start, end;
-    traj.sample(rclcpp::Clock().now(), DEFAULT_INTERPOLATION, expected_point, start, end);
+    traj.sample(rclcpp::Clock().now(), DEFAULT_INTERPOLATION, output_point, start, end);
 
     EXPECT_EQ(traj.end(), start);
     EXPECT_EQ(traj.end(), end);
@@ -62,10 +63,11 @@ TEST(TestTrajectory, initialize_trajectory)
     const auto now = rclcpp::Clock().now();
     auto traj = joint_trajectory_controller::Trajectory(empty_msg);
     const auto traj_starttime = traj.time_from_start();
+    rclcpp::Duration period = rclcpp::Duration::from_nanoseconds(1e7);
 
-    trajectory_msgs::msg::JointTrajectoryPoint expected_point;
+    trajectory_msgs::msg::JointTrajectoryPoint output_point;
     joint_trajectory_controller::TrajectoryPointConstIter start, end;
-    traj.sample(rclcpp::Clock().now(), DEFAULT_INTERPOLATION, expected_point, start, end);
+    traj.sample(rclcpp::Clock().now(), DEFAULT_INTERPOLATION, output_point, start, end);
 
     EXPECT_EQ(traj.end(), start);
     EXPECT_EQ(traj.end(), end);
@@ -102,26 +104,27 @@ TEST(TestTrajectory, sample_trajectory_positions)
   const rclcpp::Time time_now = rclcpp::Clock().now();
   auto traj = joint_trajectory_controller::Trajectory(time_now, point_before_msg, full_msg);
 
-  trajectory_msgs::msg::JointTrajectoryPoint expected_state;
+  trajectory_msgs::msg::JointTrajectoryPoint output_point;
   joint_trajectory_controller::TrajectoryPointConstIter start, end;
+  rclcpp::Duration period = rclcpp::Duration::from_nanoseconds(1e7);
 
   double duration_first_seg = 1.0;
   double velocity = (p1.positions[0] - point_before_msg.positions[0]) / duration_first_seg;
 
   // sample at trajectory starting time
   {
-    traj.sample(time_now, DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(time_now, DEFAULT_INTERPOLATION, output_point, start, end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ(traj.begin(), end);
-    EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
-    EXPECT_NEAR(velocity, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(0.0, expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(point_before_msg.positions[0], output_point.positions[0], EPS);
+    EXPECT_NEAR(velocity, output_point.velocities[0], EPS);
+    EXPECT_NEAR(0.0, output_point.accelerations[0], EPS);
   }
 
   // sample before time_now
   {
     bool result = traj.sample(
-      time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start,
+      time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, output_point, start,
       end);
     ASSERT_EQ(result, false);
   }
@@ -129,64 +132,64 @@ TEST(TestTrajectory, sample_trajectory_positions)
   // sample 0.5s after msg
   {
     traj.sample(
-      time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start,
+      time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, output_point, start,
       end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ(traj.begin(), end);
     double half_current_to_p1 = (point_before_msg.positions[0] + p1.positions[0]) * 0.5;
-    EXPECT_NEAR(half_current_to_p1, expected_state.positions[0], EPS);
-    EXPECT_NEAR(velocity, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(0.0, expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(half_current_to_p1, output_point.positions[0], EPS);
+    EXPECT_NEAR(velocity, output_point.velocities[0], EPS);
+    EXPECT_NEAR(0.0, output_point.accelerations[0], EPS);
   }
 
   // sample 1s after msg
   {
     traj.sample(
-      time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start,
+      time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, output_point, start,
       end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ((++traj.begin()), end);
-    EXPECT_NEAR(p1.positions[0], expected_state.positions[0], EPS);
-    EXPECT_NEAR(velocity, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(0.0, expected_state.accelerations[0], EPS);
+    EXPECT_NEAR(p1.positions[0], output_point.positions[0], EPS);
+    EXPECT_NEAR(velocity, output_point.velocities[0], EPS);
+    EXPECT_NEAR(0.0, output_point.accelerations[0], EPS);
   }
 
   // sample 1.5s after msg
   {
     traj.sample(
-      time_now + rclcpp::Duration::from_seconds(1.5), DEFAULT_INTERPOLATION, expected_state, start,
+      time_now + rclcpp::Duration::from_seconds(1.5), DEFAULT_INTERPOLATION, output_point, start,
       end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ((++traj.begin()), end);
     double half_p1_to_p2 = (p1.positions[0] + p2.positions[0]) * 0.5;
-    EXPECT_NEAR(half_p1_to_p2, expected_state.positions[0], EPS);
+    EXPECT_NEAR(half_p1_to_p2, output_point.positions[0], EPS);
   }
 
   // sample 2.5s after msg
   {
     traj.sample(
-      time_now + rclcpp::Duration::from_seconds(2.5), DEFAULT_INTERPOLATION, expected_state, start,
+      time_now + rclcpp::Duration::from_seconds(2.5), DEFAULT_INTERPOLATION, output_point, start,
       end);
     double half_p2_to_p3 = (p2.positions[0] + p3.positions[0]) * 0.5;
-    EXPECT_NEAR(half_p2_to_p3, expected_state.positions[0], EPS);
+    EXPECT_NEAR(half_p2_to_p3, output_point.positions[0], EPS);
   }
 
   // sample 3s after msg
   {
     traj.sample(
-      time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start,
+      time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, output_point, start,
       end);
-    EXPECT_NEAR(p3.positions[0], expected_state.positions[0], EPS);
+    EXPECT_NEAR(p3.positions[0], output_point.positions[0], EPS);
   }
 
   // sample past given points
   {
     traj.sample(
-      time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state,
+      time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, output_point,
       start, end);
     ASSERT_EQ((--traj.end()), start);
     ASSERT_EQ(traj.end(), end);
-    EXPECT_NEAR(p3.positions[0], expected_state.positions[0], EPS);
+    EXPECT_NEAR(p3.positions[0], output_point.positions[0], EPS);
   }
 }
 
@@ -209,17 +212,19 @@ TEST(TestTrajectory, interpolation_pos_vel)
 
   auto traj = joint_trajectory_controller::Trajectory();
   rclcpp::Time time_now(0);
+  rclcpp::Duration period = rclcpp::Duration::from_nanoseconds(1e7);
+  const bool do_ruckig_smoothing = false;
 
-  trajectory_msgs::msg::JointTrajectoryPoint expected_state;
+  trajectory_msgs::msg::JointTrajectoryPoint output_point;
 
   // sample at start_time
   {
     traj.interpolate_between_points(
       time_now + start_state.time_from_start, start_state, time_now + end_state.time_from_start,
-      end_state, time_now + start_state.time_from_start, expected_state);
-    EXPECT_NEAR(start_state.positions[0], expected_state.positions[0], EPS);
-    EXPECT_NEAR(start_state.velocities[0], expected_state.velocities[0], EPS);
-    EXPECT_NEAR(0.0, expected_state.accelerations[0], EPS);
+      end_state, time_now + start_state.time_from_start, do_ruckig_smoothing, output_point);
+    EXPECT_NEAR(start_state.positions[0], output_point.positions[0], EPS);
+    EXPECT_NEAR(start_state.velocities[0], output_point.velocities[0], EPS);
+    EXPECT_NEAR(0.0, output_point.accelerations[0], EPS);
   }
 
   // Sample at mid-segment: Zero-crossing
@@ -227,20 +232,20 @@ TEST(TestTrajectory, interpolation_pos_vel)
     auto t = rclcpp::Duration::from_seconds(std::sqrt(2.0));
     traj.interpolate_between_points(
       time_now + start_state.time_from_start, start_state, time_now + end_state.time_from_start,
-      end_state, time_now + start_state.time_from_start + t, expected_state);
-    EXPECT_NEAR(0.0, expected_state.positions[0], EPS);
-    EXPECT_NEAR(4.0, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(6.0 * std::sqrt(2.0), expected_state.accelerations[0], EPS);
+      end_state, time_now + start_state.time_from_start + t, do_ruckig_smoothing, output_point);
+    EXPECT_NEAR(0.0, output_point.positions[0], EPS);
+    EXPECT_NEAR(4.0, output_point.velocities[0], EPS);
+    EXPECT_NEAR(6.0 * std::sqrt(2.0), output_point.accelerations[0], EPS);
   }
 
   // sample at end_time
   {
     traj.interpolate_between_points(
       time_now + start_state.time_from_start, start_state, time_now + end_state.time_from_start,
-      end_state, time_now + end_state.time_from_start, expected_state);
-    EXPECT_NEAR(end_state.positions[0], expected_state.positions[0], EPS);
-    EXPECT_NEAR(end_state.velocities[0], expected_state.velocities[0], EPS);
-    EXPECT_NEAR(12.0, expected_state.accelerations[0], EPS);
+      end_state, time_now + end_state.time_from_start, do_ruckig_smoothing, output_point);
+    EXPECT_NEAR(end_state.positions[0], output_point.positions[0], EPS);
+    EXPECT_NEAR(end_state.velocities[0], output_point.velocities[0], EPS);
+    EXPECT_NEAR(12.0, output_point.accelerations[0], EPS);
   }
 }
 
@@ -263,17 +268,19 @@ TEST(TestTrajectory, interpolation_pos_vel_accel)
 
   auto traj = joint_trajectory_controller::Trajectory();
   rclcpp::Time time_now(0);
+  rclcpp::Duration period = rclcpp::Duration::from_nanoseconds(1e7);
+  bool do_ruckig_smoothing = false;
 
-  trajectory_msgs::msg::JointTrajectoryPoint expected_state;
+  trajectory_msgs::msg::JointTrajectoryPoint output_point;
 
   // sample at start_time
   {
     traj.interpolate_between_points(
       time_now + start_state.time_from_start, start_state, time_now + end_state.time_from_start,
-      end_state, time_now + start_state.time_from_start, expected_state);
-    EXPECT_NEAR(start_state.positions[0], expected_state.positions[0], EPS);
-    EXPECT_NEAR(start_state.velocities[0], expected_state.velocities[0], EPS);
-    EXPECT_NEAR(start_state.accelerations[0], expected_state.accelerations[0], EPS);
+      end_state, time_now + start_state.time_from_start, do_ruckig_smoothing, output_point);
+    EXPECT_NEAR(start_state.positions[0], output_point.positions[0], EPS);
+    EXPECT_NEAR(start_state.velocities[0], output_point.velocities[0], EPS);
+    EXPECT_NEAR(start_state.accelerations[0], output_point.accelerations[0], EPS);
   }
 
   // Sample at mid-segment: Zero-crossing
@@ -281,20 +288,54 @@ TEST(TestTrajectory, interpolation_pos_vel_accel)
     auto t = rclcpp::Duration::from_seconds(1.0);
     traj.interpolate_between_points(
       time_now + start_state.time_from_start, start_state, time_now + end_state.time_from_start,
-      end_state, time_now + start_state.time_from_start + t, expected_state);
-    EXPECT_NEAR(0.0, expected_state.positions[0], EPS);
-    EXPECT_NEAR(-6.0, expected_state.velocities[0], EPS);
-    EXPECT_NEAR(10.0, expected_state.accelerations[0], EPS);
+      end_state, time_now + start_state.time_from_start + t, do_ruckig_smoothing, output_point);
+    EXPECT_NEAR(0.0, output_point.positions[0], EPS);
+    EXPECT_NEAR(-6.0, output_point.velocities[0], EPS);
+    EXPECT_NEAR(10.0, output_point.accelerations[0], EPS);
   }
 
   // sample at end_time
   {
     traj.interpolate_between_points(
       time_now + start_state.time_from_start, start_state, time_now + end_state.time_from_start,
-      end_state, time_now + end_state.time_from_start, expected_state);
-    EXPECT_NEAR(end_state.positions[0], expected_state.positions[0], EPS);
-    EXPECT_NEAR(end_state.velocities[0], expected_state.velocities[0], EPS);
-    EXPECT_NEAR(end_state.accelerations[0], expected_state.accelerations[0], EPS);
+      end_state, time_now + end_state.time_from_start, do_ruckig_smoothing, output_point);
+    EXPECT_NEAR(end_state.positions[0], output_point.positions[0], EPS);
+    EXPECT_NEAR(end_state.velocities[0], output_point.velocities[0], EPS);
+    EXPECT_NEAR(end_state.accelerations[0], output_point.accelerations[0], EPS);
+  }
+
+  // Repeat the same tests with Ruckig smoothing enabled
+  do_ruckig_smoothing = true;
+
+  // sample at start_time
+  {
+    traj.interpolate_between_points(
+      time_now + start_state.time_from_start, start_state, time_now + end_state.time_from_start,
+      end_state, time_now + start_state.time_from_start, do_ruckig_smoothing, output_point);
+    EXPECT_NEAR(start_state.positions[0], output_point.positions[0], EPS);
+    EXPECT_NEAR(start_state.velocities[0], output_point.velocities[0], EPS);
+    EXPECT_NEAR(start_state.accelerations[0], output_point.accelerations[0], EPS);
+  }
+
+  // Sample at mid-segment: Zero-crossing
+  {
+    auto t = rclcpp::Duration::from_seconds(1.0);
+    traj.interpolate_between_points(
+      time_now + start_state.time_from_start, start_state, time_now + end_state.time_from_start,
+      end_state, time_now + start_state.time_from_start + t, do_ruckig_smoothing, output_point);
+    EXPECT_NEAR(0.0, output_point.positions[0], EPS);
+    EXPECT_NEAR(-6.0, output_point.velocities[0], EPS);
+    EXPECT_NEAR(10.0, output_point.accelerations[0], EPS);
+  }
+
+  // sample at end_time
+  {
+    traj.interpolate_between_points(
+      time_now + start_state.time_from_start, start_state, time_now + end_state.time_from_start,
+      end_state, time_now + end_state.time_from_start, do_ruckig_smoothing, output_point);
+    EXPECT_NEAR(end_state.positions[0], output_point.positions[0], EPS);
+    EXPECT_NEAR(end_state.velocities[0], output_point.velocities[0], EPS);
+    EXPECT_NEAR(end_state.accelerations[0], output_point.accelerations[0], EPS);
   }
 }
 
@@ -674,6 +715,7 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
 
   // sample past given points - movement virtually stops
   {
+
     traj.sample(
       time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state,
       start, end);

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -266,8 +266,14 @@ TEST(TestTrajectory, interpolation_pos_vel_accel)
   end_state.velocities.push_back(4.0);
   end_state.accelerations.push_back(0.0);
 
-  auto traj = joint_trajectory_controller::Trajectory();
+  auto traj_data = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+  traj_data->header.stamp = rclcpp::Time{0, 0};
+  traj_data->joint_names.push_back("test_joint");
+  traj_data->points.push_back(start_state);
+  traj_data->points.push_back(end_state);
+
   rclcpp::Time time_now(0);
+  auto traj = joint_trajectory_controller::Trajectory(time_now, start_state, std::move(traj_data));
   rclcpp::Duration period = rclcpp::Duration::from_nanoseconds(1e7);
   bool do_ruckig_smoothing = false;
 
@@ -715,7 +721,6 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
 
   // sample past given points - movement virtually stops
   {
-
     traj.sample(
       time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state,
       start, end);


### PR DESCRIPTION
Optionally smooth one outgoing command at a time. This is nice because the trajectories will now obey velocity, acceleration, and jerk limits.

Depends on the `joint_limits` PR in the ros2_control repo:  https://github.com/ros-controls/ros2_control/pull/462

To use this optional feature, you just need to add a parameter to the yaml file for the controller, e.g. `ros2_controllers.yaml`:

```
panda_arm_controller:
  ros__parameters:
    command_interfaces:
      - position
    state_interfaces:
      - position
      - velocity
    joints:
      - panda_joint1
...
      - panda_joint7

    ruckig_jerk_smoothing: true
```

TODO:
- [x] Make this optional
- [ ] Read velocity/accel/jerk limits, likely from `joint_limits.yaml`  (I'm aware of https://github.com/ros-controls/ros2_control/pull/462)

This work is sponsored by RE2 Robotics.