### PR TITLE
feat: :construction_worker: add gtests to ctest

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -63,6 +63,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(controller_manager REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
+  include(GoogleTest)
 
   ament_add_gmock(test_diff_drive_controller
     test/test_diff_drive_controller.cpp
@@ -71,6 +72,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_diff_drive_controller
     diff_drive_controller
   )
+  gtest_discover_tests(test_diff_drive_controller)
 
   ament_target_dependencies(test_diff_drive_controller
     geometry_msgs
@@ -92,6 +94,7 @@ if(BUILD_TESTING)
     controller_manager
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_load_diff_drive_controller)
 
 endif()
 

--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -48,6 +48,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(controller_manager REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
+  include(GoogleTest)
 
   ament_add_gmock(
     test_load_joint_group_effort_controller
@@ -58,6 +59,7 @@ if(BUILD_TESTING)
     controller_manager
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_load_joint_group_effort_controller)
 
   ament_add_gmock(
     test_joint_group_effort_controller
@@ -67,6 +69,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_joint_group_effort_controller
     effort_controllers
   )
+  gtest_discover_tests(test_joint_group_effort_controller)
 endif()
 
 ament_export_dependencies(

--- a/force_torque_sensor_broadcaster/CMakeLists.txt
+++ b/force_torque_sensor_broadcaster/CMakeLists.txt
@@ -93,6 +93,8 @@ if(BUILD_TESTING)
     hardware_interface
     ros2_control_test_assets
   )
+  include(GoogleTest)
+  gtest_discover_tests(test_force_torque_sensor_broadcaster)
 endif()
 
 ament_export_include_directories(

--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -58,6 +58,7 @@ if(BUILD_TESTING)
   find_package(controller_manager REQUIRED)
   find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
+  include(GoogleTest)
 
   ament_add_gmock(
     test_load_forward_command_controller
@@ -69,6 +70,7 @@ if(BUILD_TESTING)
     hardware_interface
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_load_forward_command_controller)
 
   ament_add_gmock(
     test_forward_command_controller
@@ -78,6 +80,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_forward_command_controller
     forward_command_controller
   )
+  gtest_discover_tests(test_forward_command_controller)
 endif()
 
 ament_export_dependencies(

--- a/gripper_controllers/CMakeLists.txt
+++ b/gripper_controllers/CMakeLists.txt
@@ -63,6 +63,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(controller_manager REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
+  include(GoogleTest)
 
   ament_add_gmock(
     test_load_gripper_action_controllers
@@ -72,6 +73,7 @@ if(BUILD_TESTING)
     controller_manager
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_load_gripper_action_controllers)
 endif()
 
 ament_package()

--- a/imu_sensor_broadcaster/CMakeLists.txt
+++ b/imu_sensor_broadcaster/CMakeLists.txt
@@ -65,6 +65,7 @@ if(BUILD_TESTING)
   find_package(controller_manager REQUIRED)
   find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
+  include(GoogleTest)
 
   ament_add_gmock(
     test_load_imu_sensor_broadcaster
@@ -76,6 +77,7 @@ if(BUILD_TESTING)
     hardware_interface
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_load_imu_sensor_broadcaster)
 
   ament_add_gmock(
     test_imu_sensor_broadcaster
@@ -93,6 +95,7 @@ if(BUILD_TESTING)
     hardware_interface
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_imu_sensor_broadcaster)
 endif()
 
 ament_export_include_directories(

--- a/joint_state_broadcaster/CMakeLists.txt
+++ b/joint_state_broadcaster/CMakeLists.txt
@@ -58,6 +58,7 @@ if(BUILD_TESTING)
   find_package(hardware_interface REQUIRED)
   find_package(rclcpp REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
+  include(GoogleTest)
 
   ament_add_gmock(
     test_load_joint_state_broadcaster
@@ -69,6 +70,7 @@ if(BUILD_TESTING)
     hardware_interface
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_load_joint_state_broadcaster)
 
   ament_add_gmock(
     test_joint_state_broadcaster
@@ -78,6 +80,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_joint_state_broadcaster
     joint_state_broadcaster
   )
+  gtest_discover_tests(test_joint_state_broadcaster)
 endif()
 
 ament_export_dependencies(

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -59,10 +59,12 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(controller_manager REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
+  include(GoogleTest)
 
   ament_add_gtest(test_trajectory test/test_trajectory.cpp)
   target_include_directories(test_trajectory PRIVATE include)
   target_link_libraries(test_trajectory joint_trajectory_controller)
+  gtest_discover_tests(test_trajectory)
 
   ament_add_gtest(test_trajectory_controller
     test/test_trajectory_controller.cpp
@@ -82,6 +84,7 @@ if(BUILD_TESTING)
     ros2_control_test_assets
     trajectory_msgs
   )
+  gtest_discover_tests(test_trajectory_controller)
 
   ament_add_gtest(
     test_load_joint_trajectory_controller
@@ -94,6 +97,7 @@ if(BUILD_TESTING)
     realtime_tools
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_load_joint_trajectory_controller)
 
   ament_add_gtest(
     test_trajectory_actions
@@ -112,6 +116,7 @@ if(BUILD_TESTING)
     trajectory_msgs
     realtime_tools
   )
+  gtest_discover_tests(test_trajectory_actions)
 endif()
 
 ament_export_dependencies(

--- a/position_controllers/CMakeLists.txt
+++ b/position_controllers/CMakeLists.txt
@@ -48,6 +48,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(controller_manager REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
+  include(GoogleTest)
 
   ament_add_gmock(
     test_load_joint_group_position_controller
@@ -58,6 +59,7 @@ if(BUILD_TESTING)
     controller_manager
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_load_joint_group_position_controller)
 
   ament_add_gmock(
     test_joint_group_position_controller
@@ -67,6 +69,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_joint_group_position_controller
     position_controllers
   )
+  gtest_discover_tests(test_joint_group_position_controller)
 endif()
 
 ament_export_dependencies(

--- a/velocity_controllers/CMakeLists.txt
+++ b/velocity_controllers/CMakeLists.txt
@@ -49,6 +49,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(controller_manager REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
+  include(GoogleTest)
 
   ament_add_gmock(
     test_load_joint_group_velocity_controller
@@ -59,6 +60,7 @@ if(BUILD_TESTING)
     controller_manager
     ros2_control_test_assets
   )
+  gtest_discover_tests(test_load_joint_group_velocity_controller)
 
   ament_add_gmock(
     test_joint_group_velocity_controller
@@ -68,6 +70,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_joint_group_velocity_controller
     velocity_controllers
   )
+  gtest_discover_tests(test_joint_group_velocity_controller)
 endif()
 
 ament_export_dependencies(


### PR DESCRIPTION
Adds support for `ctest` by adding `gtest_discover_tests` to all of the `CMakeLists.txt` files. This allows one to use `colcon test --ctest-args ...`. I have been using this a lot to filter tests so I thought I'd share it case others want to use it.