### PR TITLE
Use system time in all tests to avoid error with different time sources.

### DIFF
--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -279,7 +279,7 @@ public:
    */
   void publish(
     const builtin_interfaces::msg::Duration & delay_btwn_points,
-    const std::vector<std::vector<double>> & points, rclcpp::Time start_time = rclcpp::Time(),
+    const std::vector<std::vector<double>> & points, rclcpp::Time start_time,
     const std::vector<std::string> & joint_names = {},
     const std::vector<std::vector<double>> & points_velocities = {})
   {


### PR DESCRIPTION
This PR solves (a new) issues caused by difference in time source (probably some changes in rclcpp cause that). 
An example of the issue can be found [here](https://github.com/ros-controls/ros2_controllers/runs/6030141354?check_suite_focus=true#step:6:6121).
