### PR TITLE
Fix a gtest deprecation warning

### DIFF
--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1278,7 +1278,7 @@ INSTANTIATE_TEST_SUITE_P(
       std::vector<std::string>({"position", "velocity", "acceleration"}))));
 
 // only effort controller
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   OnlyEffortTrajectoryControllers, TrajectoryControllerTestParameterized,
   ::testing::Values(
     std::make_tuple(


### PR DESCRIPTION
Fix this warning:

```
--- stderr: joint_trajectory_controller
In file included from /opt/ros/rolling/src/gtest_vendor/include/gtest/gtest.h:67,
                 from /home/andy/ws_ros2/src/ros2_controllers/joint_trajectory_controller/test/test_trajectory_controller.cpp:28:
/opt/ros/rolling/src/gtest_vendor/include/gtest/gtest-param-test.h:496:38: warning: ‘constexpr bool testing::internal::InstantiateTestCase_P_IsDeprecated()’ is deprecated: INSTANTIATE_TEST_CASE_P is deprecated, please use INSTANTIATE_TEST_SUITE_P [-Wdeprecated-declarations]
  496 |   static_assert(::testing::internal::InstantiateTestCase_P_IsDeprecated(), \
```