### PR TITLE
Check for nans in JTC in command interface

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1064,7 +1064,8 @@ void JointTrajectoryController::fill_partial_goal(
         // Assume hold position with 0 velocity and acceleration for missing joints
         if (!it.positions.empty())
         {
-          if (has_position_command_interface_)
+          if (has_position_command_interface_ &&
+              !std::isnan(joint_command_interface_[0][index].get().get_value()))
           {
             // copy last command if cmd interface exists
             it.positions.push_back(joint_command_interface_[0][index].get().get_value());


### PR DESCRIPTION
I noticed that there was an edge case in the JTC when partial goals are filled that nans weren't checked in the command interface (for those joints not specified in the goal) when assigning the last commanded joint value (assuming a command interface was specified). This actually occurred in a project I was working on and led to undefined behavior. This PR fixes this by implementing the check.