### PR TITLE
[JTC] Account for edge case

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -165,9 +165,11 @@ controller_interface::return_type JointTrajectoryController::update(
   // currently carrying out a trajectory
   if (traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_trajectory_msg())
   {
+    bool first_sample = false;
     // if sampling the first time, set the point before you sample
     if (!(*traj_point_active_ptr_)->is_sampled_already())
     {
+      first_sample = true;
       if (open_loop_control_)
       {
         (*traj_point_active_ptr_)->set_point_before_trajectory_msg(time, last_commanded_state_);
@@ -197,8 +199,10 @@ controller_interface::return_type JointTrajectoryController::update(
       {
         compute_error_for_joint(state_error, index, state_current, state_desired);
 
+        // Always check the state tolerance on the first sample in case the first sample
+        // is the last point
         if (
-          before_last_point &&
+          (before_last_point || first_sample) &&
           !check_state_tolerance_per_joint(
             state_error, index, default_tolerances_.state_tolerance[index], false))
         {

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -472,6 +472,53 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_fail)
   EXPECT_NEAR(init_pos3, joint_pos_[2], COMMON_THRESHOLD);
 }
 
+TEST_F(TestTrajectoryActions, test_no_time_from_start_state_tolerance_fail)
+{
+  // set joint tolerance parameters
+  const double state_tol = 0.0001;
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("constraints.joint1.trajectory", state_tol),
+    rclcpp::Parameter("constraints.joint2.trajectory", state_tol),
+    rclcpp::Parameter("constraints.joint3.trajectory", state_tol)};
+
+  SetUpExecutor(params);
+  SetUpControllerHardware();
+
+  const double init_pos1 = joint_pos_[0];
+  const double init_pos2 = joint_pos_[1];
+  const double init_pos3 = joint_pos_[2];
+
+  std::shared_future<typename GoalHandle::SharedPtr> gh_future;
+  // send goal
+  {
+    std::vector<JointTrajectoryPoint> points;
+    JointTrajectoryPoint point;
+    point.time_from_start = rclcpp::Duration::from_seconds(0.0);
+    point.positions.resize(joint_names_.size());
+
+    point.positions[0] = 4.0;
+    point.positions[1] = 5.0;
+    point.positions[2] = 6.0;
+    points.push_back(point);
+
+    gh_future = sendActionGoal(points, 1.0, goal_options_);
+  }
+  controller_hw_thread_.join();
+
+  EXPECT_TRUE(gh_future.get());
+  EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, common_resultcode_);
+  EXPECT_EQ(
+    control_msgs::action::FollowJointTrajectory_Result::PATH_TOLERANCE_VIOLATED,
+    common_action_result_code_);
+
+  // run an update, it should be holding
+  traj_controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+
+  EXPECT_NEAR(init_pos1, joint_pos_[0], COMMON_THRESHOLD);
+  EXPECT_NEAR(init_pos2, joint_pos_[1], COMMON_THRESHOLD);
+  EXPECT_NEAR(init_pos3, joint_pos_[2], COMMON_THRESHOLD);
+}
+
 TEST_F(TestTrajectoryActions, test_cancel_hold_position)
 {
   SetUpExecutor();


### PR DESCRIPTION
I noticed an edge case (probably rare, though I have seen it happen) where if a trajectory point has a zero time-from-start duration, JTC will sample it and output a command that can only ever get checked by goal tolerances but never state tolerances since it's considered to be the last point. I think goal tolerances (and goal_time) are mainly designed for accounting for slight timing error between hardware and commands at the end of a trajectory, but not for handling the first sampled point which can be very off the current joint position in this scenario and could potentially lead to unexpected motion. This PR fixes this by always checking the state tolerance of the first sampled point. I have created a test case that shows this as well.

Before the fix

> [ RUN      ] TestTrajectoryActions.test_no_time_from_start_state_tolerance_fail
[INFO] [1651618255.484381928] [test_joint_trajectory_controller]: Command interfaces are [position] and and state interfaces are [position velocity].
[INFO] [1651618255.484616674] [test_joint_trajectory_controller]: Controller state will be published at 50.00 Hz.
[INFO] [1651618255.484817827] [test_joint_trajectory_controller]: Action status changes will be monitored at 20.00 Hz.
[INFO] [1651618255.786766016] [test_joint_trajectory_controller]: Received new action goal
[INFO] [1651618255.786813400] [test_joint_trajectory_controller]: Accepted new action goal
[INFO] [1651618255.786991848] [test_joint_trajectory_controller]: Goal reached, success!
/opt/colcon_ws/src/bro_system/ros2_controllers/joint_trajectory_controller/test/test_trajectory_actions.cpp:509: Failure
Expected equality of these values:
  rclcpp_action::ResultCode::ABORTED
    Which is: 1-byte object <06>
  common_resultcode_
    Which is: 1-byte object <04>
/opt/colcon_ws/src/bro_system/ros2_controllers/joint_trajectory_controller/test/test_trajectory_actions.cpp:510: Failure
Expected equality of these values:
  control_msgs::action::FollowJointTrajectory_Result::PATH_TOLERANCE_VIOLATED
    Which is: -4
  common_action_result_code_
    Which is: 0
/opt/colcon_ws/src/bro_system/ros2_controllers/joint_trajectory_controller/test/test_trajectory_actions.cpp:517: Failure
The difference between init_pos1 and joint_pos_[0] is 2.8999999999999999, which exceeds COMMON_THRESHOLD, where
init_pos1 evaluates to 1.1000000000000001,
joint_pos_[0] evaluates to 4, and
COMMON_THRESHOLD evaluates to 0.0011000000000000001.
/opt/colcon_ws/src/bro_system/ros2_controllers/joint_trajectory_controller/test/test_trajectory_actions.cpp:518: Failure
The difference between init_pos2 and joint_pos_[1] is 2.8999999999999999, which exceeds COMMON_THRESHOLD, where
init_pos2 evaluates to 2.1000000000000001,
joint_pos_[1] evaluates to 5, and
COMMON_THRESHOLD evaluates to 0.0011000000000000001.
/opt/colcon_ws/src/bro_system/ros2_controllers/joint_trajectory_controller/test/test_trajectory_actions.cpp:519: Failure
The difference between init_pos3 and joint_pos_[2] is 2.8999999999999999, which exceeds COMMON_THRESHOLD, where
init_pos3 evaluates to 3.1000000000000001,
joint_pos_[2] evaluates to 6, and
COMMON_THRESHOLD evaluates to 0.0011000000000000001.
[  FAILED  ] TestTrajectoryActions.test_no_time_from_start_state_tolerance_fail (2010 ms)

After the fix

> [ RUN      ] TestTrajectoryActions.test_no_time_from_start_state_tolerance_fail
[INFO] [1651618407.385751183] [test_joint_trajectory_controller]: Command interfaces are [position] and and state interfaces are [position velocity].
[INFO] [1651618407.386022047] [test_joint_trajectory_controller]: Controller state will be published at 50.00 Hz.
[INFO] [1651618407.386248723] [test_joint_trajectory_controller]: Action status changes will be monitored at 20.00 Hz.
[INFO] [1651618407.688211079] [test_joint_trajectory_controller]: Received new action goal
[INFO] [1651618407.688264209] [test_joint_trajectory_controller]: Accepted new action goal
[WARN] [1651618407.688413821] [test_joint_trajectory_controller]: Aborted due to state tolerance violation
[       OK ] TestTrajectoryActions.test_no_time_from_start_state_tolerance_fail (2011 ms)
