### PR TITLE
Fix joint_state_broadcaster test

### DIFF
--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -683,7 +683,7 @@ void JointStateBroadcasterTest::test_published_dynamic_joint_state_message(
   ASSERT_TRUE(subscription->take(dynamic_joint_state_msg, msg_info));
 
   const size_t NUM_JOINTS = 3;
-  const auto INTERFACE_NAMES = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
+  auto INTERFACE_NAMES = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   // the order in the message may be different
   // we only check that all values in this test are present in the message


### PR DESCRIPTION
I am not sure why, but building joint_state_broadcaster on galactic, Ubuntu 18 fails. I found that this simple change in the PR fixes it. Feel free to propose a better fix

```
root@amr47:/code/ros2_ws/src/ros2_controllers# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.5 LTS
Release:	18.04
Codename:	bionic

```


```
Starting >>> joint_state_broadcaster
--- stderr: joint_state_broadcaster                               
In file included from /usr/include/aarch64-linux-gnu/c++/7/bits/c++allocator.h:33:0,
                 from /usr/include/c++/7/bits/allocator.h:46,
                 from /usr/include/c++/7/string:41,
                 from /usr/include/c++/7/stdexcept:39,
                 from /usr/include/c++/7/array:39,
                 from /usr/include/c++/7/tuple:39,
                 from /usr/include/c++/7/functional:54,
                 from /code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:17:
/usr/include/c++/7/ext/new_allocator.h: In instantiation of ‘class __gnu_cxx::new_allocator<const char* const>’:
/usr/include/c++/7/bits/allocator.h:108:11:   required from ‘class std::allocator<const char* const>’
/usr/include/c++/7/bits/stl_vector.h:81:14:   required from ‘struct std::_Vector_base<const char* const, std::allocator<const char* const> >::_Vector_impl’
/usr/include/c++/7/bits/stl_vector.h:166:20:   required from ‘struct std::_Vector_base<const char* const, std::allocator<const char* const> >’
/usr/include/c++/7/bits/stl_vector.h:216:11:   required from ‘class std::vector<const char* const, std::allocator<const char* const> >’
/opt/ros/galactic/install/src/gmock_vendor/include/gmock/gmock-matchers.h:3147:26:   required from ‘class testing::internal::ElementsAreArrayMatcher<const char* const>’
/code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:701:5:   required from here
/usr/include/c++/7/ext/new_allocator.h:93:7: error: ‘const _Tp* __gnu_cxx::new_allocator<_Tp>::address(__gnu_cxx::new_allocator<_Tp>::const_reference) const [with _Tp = const char* const; __gnu_cxx::new_allocator<_Tp>::const_pointer = const char* const*; __gnu_cxx::new_allocator<_Tp>::const_reference = const char* const&]’ cannot be overloaded
       address(const_reference __x) const _GLIBCXX_NOEXCEPT
       ^~~~~~~
/usr/include/c++/7/ext/new_allocator.h:89:7: error: with ‘_Tp* __gnu_cxx::new_allocator<_Tp>::address(__gnu_cxx::new_allocator<_Tp>::reference) const [with _Tp = const char* const; __gnu_cxx::new_allocator<_Tp>::pointer = const char* const*; __gnu_cxx::new_allocator<_Tp>::reference = const char* const&]’
       address(reference __x) const _GLIBCXX_NOEXCEPT
       ^~~~~~~
In file included from /opt/ros/galactic/install/src/gmock_vendor/include/gmock/gmock-spec-builders.h:75:0,
                 from /opt/ros/galactic/install/src/gmock_vendor/include/gmock/gmock-generated-function-mockers.h:47,
                 from /opt/ros/galactic/install/src/gmock_vendor/include/gmock/gmock-function-mocker.h:39,
                 from /opt/ros/galactic/install/src/gmock_vendor/include/gmock/gmock.h:61,
                 from /code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:23:
/opt/ros/galactic/install/src/gmock_vendor/include/gmock/gmock-matchers.h: In instantiation of ‘testing::internal::ElementsAreArrayMatcher<T> testing::ElementsAreArray(std::initializer_list<_Tp>) [with T = const char* const]’:
/code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:701:5:   required from here
/opt/ros/galactic/install/src/gmock_vendor/include/gmock/gmock-matchers.h:3533:47: error: could not convert ‘testing::ElementsAreArray(Iter, Iter) [with Iter = const char* const*; typename std::iterator_traits<_Iterator>::value_type = const char*](xs.std::initializer_list<const char* const>::end())’ from ‘testing::internal::ElementsAreArrayMatcher<const char*>’ to ‘testing::internal::ElementsAreArrayMatcher<const char* const>’
   return ElementsAreArray(xs.begin(), xs.end());
                                               ^
In file included from /usr/include/aarch64-linux-gnu/c++/7/bits/c++allocator.h:33:0,
                 from /usr/include/c++/7/bits/allocator.h:46,
                 from /usr/include/c++/7/string:41,
                 from /usr/include/c++/7/stdexcept:39,
                 from /usr/include/c++/7/array:39,
                 from /usr/include/c++/7/tuple:39,
                 from /usr/include/c++/7/functional:54,
                 from /code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:17:
/usr/include/c++/7/ext/new_allocator.h: In instantiation of ‘void __gnu_cxx::new_allocator<_Tp>::deallocate(__gnu_cxx::new_allocator<_Tp>::pointer, __gnu_cxx::new_allocator<_Tp>::size_type) [with _Tp = const char* const; __gnu_cxx::new_allocator<_Tp>::pointer = const char* const*; __gnu_cxx::new_allocator<_Tp>::size_type = long unsigned int]’:
/usr/include/c++/7/bits/alloc_traits.h:462:9:   required from ‘static void std::allocator_traits<std::allocator<_CharT> >::deallocate(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, std::allocator_traits<std::allocator<_CharT> >::pointer, std::allocator_traits<std::allocator<_CharT> >::size_type) [with _Tp = const char* const; std::allocator_traits<std::allocator<_CharT> >::allocator_type = std::allocator<const char* const>; std::allocator_traits<std::allocator<_CharT> >::pointer = const char* const*; std::allocator_traits<std::allocator<_CharT> >::size_type = long unsigned int]’
/usr/include/c++/7/bits/stl_vector.h:180:19:   required from ‘void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(std::_Vector_base<_Tp, _Alloc>::pointer, std::size_t) [with _Tp = const char* const; _Alloc = std::allocator<const char* const>; std::_Vector_base<_Tp, _Alloc>::pointer = const char* const*; std::size_t = long unsigned int]’
/usr/include/c++/7/bits/stl_vector.h:162:22:   required from ‘std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = const char* const; _Alloc = std::allocator<const char* const>]’
/usr/include/c++/7/bits/stl_vector.h:435:33:   required from ‘std::vector<_Tp, _Alloc>::~vector() [with _Tp = const char* const; _Alloc = std::allocator<const char* const>]’
/opt/ros/galactic/install/src/gmock_vendor/include/gmock/gmock-matchers.h:3131:7:   required from here
/usr/include/c++/7/ext/new_allocator.h:121:23: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
      ::operator delete(__p, std::align_val_t(alignof(_Tp)));
      ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/7/functional:53:0,
                 from /code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:17:
/usr/include/c++/7/new:147:6: note:   initializing argument 1 of ‘void operator delete(void*, std::align_val_t)’
 void operator delete(void*, std::align_val_t)
      ^~~~~~~~
In file included from /usr/include/aarch64-linux-gnu/c++/7/bits/c++allocator.h:33:0,
                 from /usr/include/c++/7/bits/allocator.h:46,
                 from /usr/include/c++/7/string:41,
                 from /usr/include/c++/7/stdexcept:39,
                 from /usr/include/c++/7/array:39,
                 from /usr/include/c++/7/tuple:39,
                 from /usr/include/c++/7/functional:54,
                 from /code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:17:
/usr/include/c++/7/ext/new_allocator.h:125:19: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
  ::operator delete(__p);
  ~~~~~~~~~~~~~~~~~^~~~~
In file included from /usr/include/c++/7/functional:53:0,
                 from /code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:17:
/usr/include/c++/7/new:124:6: note:   initializing argument 1 of ‘void operator delete(void*)’
 void operator delete(void*) _GLIBCXX_USE_NOEXCEPT
      ^~~~~~~~
In file included from /usr/include/c++/7/vector:62:0,
                 from /usr/include/c++/7/functional:61,
                 from /code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:17:
/usr/include/c++/7/bits/stl_construct.h: In instantiation of ‘void std::_Construct(_T1*, _Args&& ...) [with _T1 = const char* const; _Args = {const char* const&}]’:
/usr/include/c++/7/bits/stl_uninitialized.h:83:18:   required from ‘static _ForwardIterator std::__uninitialized_copy<_TrivialValueTypes>::__uninit_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<const char* const*, std::vector<const char* const, std::allocator<const char* const> > >; _ForwardIterator = const char* const*; bool _TrivialValueTypes = false]’
/usr/include/c++/7/bits/stl_uninitialized.h:134:15:   required from ‘_ForwardIterator std::uninitialized_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<const char* const*, std::vector<const char* const, std::allocator<const char* const> > >; _ForwardIterator = const char* const*]’
/usr/include/c++/7/bits/stl_uninitialized.h:289:37:   required from ‘_ForwardIterator std::__uninitialized_copy_a(_InputIterator, _InputIterator, _ForwardIterator, std::allocator<_Tp>&) [with _InputIterator = __gnu_cxx::__normal_iterator<const char* const*, std::vector<const char* const, std::allocator<const char* const> > >; _ForwardIterator = const char* const*; _Tp = const char* const]’
/usr/include/c++/7/bits/stl_vector.h:331:31:   required from ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = const char* const; _Alloc = std::allocator<const char* const>]’
/opt/ros/galactic/install/src/gmock_vendor/include/gmock/gmock-matchers.h:3131:7:   required from ‘testing::internal::PredicateFormatterFromMatcher<M> testing::internal::MakePredicateFormatterFromMatcher(M) [with M = testing::internal::ElementsAreArrayMatcher<const char* const>]’
/code/ros2_ws/src/ros2_controllers/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp:701:5:   required from here
/usr/include/c++/7/bits/stl_construct.h:75:13: error: invalid static_cast from type ‘const char* const*’ to type ‘void*’
     { ::new(static_cast<void*>(__p)) _T1(std::forward<_Args>(__args)...); }
             ^~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/test_joint_state_broadcaster.dir/test/test_joint_state_broadcaster.cpp.o] Error 1
make[1]: *** [CMakeFiles/test_joint_state_broadcaster.dir/all] Error 2
make: *** [all] Error 2
---
Failed   <<< joint_state_broadcaster [24.4s, exited with code 2]

Summary: 0 packages finished [26.5s]
  1 package failed: joint_state_broadcaster
  1 package had stderr output: joint_state_broadcaster
```