### PR TITLE
Properly retrieve parameters in the Joint Trajectory Controller

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -132,6 +132,9 @@ protected:
   /// Allow integration in goal trajectories to accept goals without position or velocity specified
   bool allow_integration_in_goal_trajectories_ = false;
 
+  double state_publish_rate_;
+  double action_monitor_rate_;
+
   // The interfaces are defined as the types in 'allowed_interface_types_' member.
   // For convenience, for each type the interfaces are ordered so that i-th position
   // matches i-th index in joint_names_

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -55,17 +55,18 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
   try
   {
     // with the lifecycle node being initialized, we can declare parameters
-    auto_declare<std::vector<std::string>>("joints", joint_names_);
-    auto_declare<std::vector<std::string>>("command_interfaces", command_interface_types_);
-    auto_declare<std::vector<std::string>>("state_interfaces", state_interface_types_);
-    auto_declare<double>("state_publish_rate", 50.0);
-    auto_declare<double>("action_monitor_rate", 20.0);
-    auto_declare<bool>("allow_partial_joints_goal", allow_partial_joints_goal_);
-    auto_declare<bool>("open_loop_control", open_loop_control_);
-    auto_declare<bool>(
+    joint_names_ = auto_declare<std::vector<std::string>>("joints", joint_names_);
+    command_interface_types_ =
+      auto_declare<std::vector<std::string>>("command_interfaces", command_interface_types_);
+    state_interface_types_ =
+      auto_declare<std::vector<std::string>>("state_interfaces", state_interface_types_);
+    allow_partial_joints_goal_ =
+      auto_declare<bool>("allow_partial_joints_goal", allow_partial_joints_goal_);
+    open_loop_control_ = auto_declare<bool>("open_loop_control", open_loop_control_);
+    allow_integration_in_goal_trajectories_ = auto_declare<bool>(
       "allow_integration_in_goal_trajectories", allow_integration_in_goal_trajectories_);
-    auto_declare<double>("constraints.stopped_velocity_tolerance", 0.01);
-    auto_declare<double>("constraints.goal_time", 0.0);
+    state_publish_rate_ = auto_declare<double>("state_publish_rate", 50.0);
+    action_monitor_rate_ = auto_declare<double>("action_monitor_rate", 20.0);
   }
   catch (const std::exception & e)
   {
@@ -700,12 +701,10 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
   // joint_command_subscriber_->on_activate();
 
   // State publisher
-  const double state_publish_rate =
-    get_node()->get_parameter("state_publish_rate").get_value<double>();
-  RCLCPP_INFO(logger, "Controller state will be published at %.2f Hz.", state_publish_rate);
-  if (state_publish_rate > 0.0)
+  RCLCPP_INFO(logger, "Controller state will be published at %.2f Hz.", state_publish_rate_);
+  if (state_publish_rate_ > 0.0)
   {
-    state_publisher_period_ = rclcpp::Duration::from_seconds(1.0 / state_publish_rate);
+    state_publisher_period_ = rclcpp::Duration::from_seconds(1.0 / state_publish_rate_);
   }
   else
   {
@@ -747,11 +746,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
     RCLCPP_INFO(logger, "Goals with partial set of joints are allowed");
   }
 
-  const double action_monitor_rate =
-    get_node()->get_parameter("action_monitor_rate").get_value<double>();
-
-  RCLCPP_INFO(logger, "Action status changes will be monitored at %.2f Hz.", action_monitor_rate);
-  action_monitor_period_ = rclcpp::Duration::from_seconds(1.0 / action_monitor_rate);
+  RCLCPP_INFO(logger, "Action status changes will be monitored at %.2f Hz.", action_monitor_rate_);
+  action_monitor_period_ = rclcpp::Duration::from_seconds(1.0 / action_monitor_rate_);
 
   using namespace std::placeholders;
   action_server_ = rclcpp_action::create_server<FollowJTrajAction>(
@@ -1064,8 +1060,9 @@ void JointTrajectoryController::fill_partial_goal(
         // Assume hold position with 0 velocity and acceleration for missing joints
         if (!it.positions.empty())
         {
-          if (has_position_command_interface_ &&
-              !std::isnan(joint_command_interface_[0][index].get().get_value()))
+          if (
+            has_position_command_interface_ &&
+            !std::isnan(joint_command_interface_[0][index].get().get_value()))
           {
             // copy last command if cmd interface exists
             it.positions.push_back(joint_command_interface_[0][index].get().get_value());


### PR DESCRIPTION
Fixes #364.

There are probably similar fixes that should be made for the other controller types.

I looked into adding the [[nodiscard]] attribute to `auto_declare` but it doesn't work with templates.  :(