### PR TITLE
[JTC] Hold position if tolerance is violated even during non-active goal

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -347,7 +347,7 @@ controller_interface::return_type JointTrajectoryController::update(
           // to be satisfied or violated within the goal_time_tolerance
         }
       }
-      else if (abort)
+      else if (tolerance_violated_while_moving)
       {
         set_hold_position();
         RCLCPP_ERROR(get_node()->get_logger(), "Holding position due to state tolerance violation");

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -347,6 +347,11 @@ controller_interface::return_type JointTrajectoryController::update(
           // to be satisfied or violated within the goal_time_tolerance
         }
       }
+      else if (abort)
+      {
+        set_hold_position();
+        RCLCPP_ERROR(get_node()->get_logger(), "Holding position due to state tolerance violation");
+      }
     }
   }
 


### PR DESCRIPTION
This PR handles tolerance-checking logic for when non-active goals are running. This is specifically relevant if a trajectory is published to the joint_trajectory topic (instead of using the action server) as they are considered to be non-active goals.