### PR TITLE
[Interfaces] Update use of ```get_name()``` methods from hardware interfaces 

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -219,8 +219,7 @@ controller_interface::return_type DiffDriveController::update(
     else
     {
       odometry_.updateFromVelocity(
-        left_feedback_mean*period.seconds(), right_feedback_mean*period.seconds(),
-        time);
+        left_feedback_mean * period.seconds(), right_feedback_mean * period.seconds(), time);
     }
   }
 
@@ -626,7 +625,7 @@ controller_interface::CallbackReturn DiffDriveController::configure_side(
     const auto state_handle = std::find_if(
       state_interfaces_.cbegin(), state_interfaces_.cend(),
       [&wheel_name, &interface_name](const auto & interface) {
-        return interface.get_name() == wheel_name &&
+        return interface.get_prefix_name() == wheel_name &&
                interface.get_interface_name() == interface_name;
       });
 
@@ -639,7 +638,7 @@ controller_interface::CallbackReturn DiffDriveController::configure_side(
     const auto command_handle = std::find_if(
       command_interfaces_.begin(), command_interfaces_.end(),
       [&wheel_name](const auto & interface) {
-        return interface.get_name() == wheel_name &&
+        return interface.get_prefix_name() == wheel_name &&
                interface.get_interface_name() == HW_IF_VELOCITY;
       });
 

--- a/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
+++ b/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
@@ -232,11 +232,11 @@ controller_interface::CallbackReturn GripperActionController<HardwareInterface>:
     RCLCPP_ERROR(get_node()->get_logger(), "Expected 1 position command interface");
     return controller_interface::CallbackReturn::ERROR;
   }
-  if (position_command_interface_it->get_name() != joint_name_)
+  if (position_command_interface_it->get_prefix_name() != joint_name_)
   {
     RCLCPP_ERROR_STREAM(
       get_node()->get_logger(), "Position command interface is different than joint name `"
-                                  << position_command_interface_it->get_name() << "` != `"
+                                  << position_command_interface_it->get_prefix_name() << "` != `"
                                   << joint_name_ << "`");
     return controller_interface::CallbackReturn::ERROR;
   }
@@ -250,11 +250,11 @@ controller_interface::CallbackReturn GripperActionController<HardwareInterface>:
     RCLCPP_ERROR(get_node()->get_logger(), "Expected 1 position state interface");
     return controller_interface::CallbackReturn::ERROR;
   }
-  if (position_state_interface_it->get_name() != joint_name_)
+  if (position_state_interface_it->get_prefix_name() != joint_name_)
   {
     RCLCPP_ERROR_STREAM(
       get_node()->get_logger(), "Position state interface is different than joint name `"
-                                  << position_state_interface_it->get_name() << "` != `"
+                                  << position_state_interface_it->get_prefix_name() << "` != `"
                                   << joint_name_ << "`");
     return controller_interface::CallbackReturn::ERROR;
   }
@@ -268,11 +268,11 @@ controller_interface::CallbackReturn GripperActionController<HardwareInterface>:
     RCLCPP_ERROR(get_node()->get_logger(), "Expected 1 velocity state interface");
     return controller_interface::CallbackReturn::ERROR;
   }
-  if (velocity_state_interface_it->get_name() != joint_name_)
+  if (velocity_state_interface_it->get_prefix_name() != joint_name_)
   {
     RCLCPP_ERROR_STREAM(
       get_node()->get_logger(), "Velocity command interface is different than joint name `"
-                                  << velocity_state_interface_it->get_name() << "` != `"
+                                  << velocity_state_interface_it->get_prefix_name() << "` != `"
                                   << joint_name_ << "`");
     return controller_interface::CallbackReturn::ERROR;
   }

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -237,9 +237,9 @@ bool JointStateBroadcaster::init_joint_data()
   for (auto si = state_interfaces_.crbegin(); si != state_interfaces_.crend(); si++)
   {
     // initialize map if name is new
-    if (name_if_value_mapping_.count(si->get_name()) == 0)
+    if (name_if_value_mapping_.count(si->get_prefix_name()) == 0)
     {
-      name_if_value_mapping_[si->get_name()] = {};
+      name_if_value_mapping_[si->get_prefix_name()] = {};
     }
     // add interface name
     std::string interface_name = si->get_interface_name();
@@ -247,7 +247,7 @@ bool JointStateBroadcaster::init_joint_data()
     {
       interface_name = map_interface_to_joint_state_[interface_name];
     }
-    name_if_value_mapping_[si->get_name()][interface_name] = kUninitializedValue;
+    name_if_value_mapping_[si->get_prefix_name()][interface_name] = kUninitializedValue;
   }
 
   // filter state interfaces that have at least one of the joint_states fields,
@@ -345,10 +345,10 @@ controller_interface::return_type JointStateBroadcaster::update(
     {
       interface_name = map_interface_to_joint_state_[interface_name];
     }
-    name_if_value_mapping_[state_interface.get_name()][interface_name] =
+    name_if_value_mapping_[state_interface.get_prefix_name()][interface_name] =
       state_interface.get_value();
     RCLCPP_DEBUG(
-      get_node()->get_logger(), "%s: %f\n", state_interface.get_full_name().c_str(),
+      get_node()->get_logger(), "%s: %f\n", state_interface.get_name().c_str(),
       state_interface.get_value());
   }
 


### PR DESCRIPTION
Hello everyone.

Accordingly to open issue ros-controls/ros2_control#691 and PR ros-controls/ros2_control#737, this PR modifies the use of methods related to getting the name associated to the hardware interface. 

Let me know if I forgot any necessary modification.

Thank you.