### PR TITLE
Add an option to skip interpolation in the joint trajectory controller

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef JOINT_TRAJECTORY_CONTROLLER_INTERPOLATION_METHODS_HPP_
-#define JOINT_TRAJECTORY_CONTROLLER_INTERPOLATION_METHODS_HPP_
+#ifndef JOINT_TRAJECTORY_CONTROLLER__INTERPOLATION_METHODS_HPP_
+#define JOINT_TRAJECTORY_CONTROLLER__INTERPOLATION_METHODS_HPP_
 
 namespace joint_trajectory_controller
 {
-enum class InterpolationMethod {NONE, SPLINE};
+enum class InterpolationMethod
+{
+  NONE,
+  SPLINE
+};
 }  // namespace joint_trajectory_controller
 
-#endif  // JOINT_TRAJECTORY_CONTROLLER_INTERPOLATION_METHODS_HPP_
+#endif  // JOINT_TRAJECTORY_CONTROLLER__INTERPOLATION_METHODS_HPP_

--- a/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 ros2_control Development Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef JOINT_TRAJECTORY_CONTROLLER_INTERPOLATION_METHODS_HPP_
+#define JOINT_TRAJECTORY_CONTROLLER_INTERPOLATION_METHODS_HPP_
+
+namespace joint_trajectory_controller
+{
+enum class InterpolationMethod {NONE, SPLINE};
+}  // namespace joint_trajectory_controller
+
+#endif  // JOINT_TRAJECTORY_CONTROLLER_INTERPOLATION_METHODS_HPP_

--- a/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
@@ -15,9 +15,16 @@
 #ifndef JOINT_TRAJECTORY_CONTROLLER__INTERPOLATION_METHODS_HPP_
 #define JOINT_TRAJECTORY_CONTROLLER__INTERPOLATION_METHODS_HPP_
 
+#include <rclcpp/rclcpp.hpp>
 #include <string>
+#include <unordered_map>
 
 namespace joint_trajectory_controller
+{
+static const rclcpp::Logger LOGGER =
+  rclcpp::get_logger("joint_trajectory_controller.interpolation_methods");
+
+namespace interpolation_methods
 {
 enum class InterpolationMethod
 {
@@ -25,22 +32,33 @@ enum class InterpolationMethod
   VARIABLE_DEGREE_SPLINE
 };
 
+const InterpolationMethod DEFAULT_INTERPOLATION = InterpolationMethod::VARIABLE_DEGREE_SPLINE;
+
+const std::unordered_map<InterpolationMethod, std::string> InterpolationMethodMap(
+  {{InterpolationMethod::NONE, "none"}, {InterpolationMethod::VARIABLE_DEGREE_SPLINE, "splines"}});
+
 [[nodiscard]] inline InterpolationMethod from_string(const std::string & interpolation_method)
 {
-  if (interpolation_method.compare("none") == 0)
+  if (interpolation_method.compare(InterpolationMethodMap.at(InterpolationMethod::NONE)) == 0)
   {
     return InterpolationMethod::NONE;
   }
-  else if (!interpolation_method.compare("splines") == 0)
+  else if (
+    !interpolation_method.compare(
+      InterpolationMethodMap.at(InterpolationMethod::VARIABLE_DEGREE_SPLINE)) == 0)
   {
     return InterpolationMethod::VARIABLE_DEGREE_SPLINE;
   }
   // Default
   else
   {
+    RCLCPP_INFO_STREAM(
+      LOGGER,
+      "No interpolation method parameter was given. Using the default, VARIABLE_DEGREE_SPLINE.");
     return InterpolationMethod::VARIABLE_DEGREE_SPLINE;
   }
 }
+}  // namespace interpolation_methods
 }  // namespace joint_trajectory_controller
 
 #endif  // JOINT_TRAJECTORY_CONTROLLER__INTERPOLATION_METHODS_HPP_

--- a/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
@@ -15,13 +15,32 @@
 #ifndef JOINT_TRAJECTORY_CONTROLLER__INTERPOLATION_METHODS_HPP_
 #define JOINT_TRAJECTORY_CONTROLLER__INTERPOLATION_METHODS_HPP_
 
+#include <string>
+
 namespace joint_trajectory_controller
 {
 enum class InterpolationMethod
 {
   NONE,
-  SPLINE
+  VARIABLE_DEGREE_SPLINE
 };
+
+[[nodiscard]] inline InterpolationMethod from_string(const std::string & interpolation_method)
+{
+  if (interpolation_method.compare("none") == 0)
+  {
+    return InterpolationMethod::NONE;
+  }
+  else if (!interpolation_method.compare("splines") == 0)
+  {
+    return InterpolationMethod::VARIABLE_DEGREE_SPLINE;
+  }
+  // Default
+  else
+  {
+    return InterpolationMethod::VARIABLE_DEGREE_SPLINE;
+  }
+}
 }  // namespace joint_trajectory_controller
 
 #endif  // JOINT_TRAJECTORY_CONTROLLER__INTERPOLATION_METHODS_HPP_

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -27,6 +27,7 @@
 #include "control_toolbox/pid.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "joint_trajectory_controller/interpolation_methods.hpp"
 #include "joint_trajectory_controller/tolerances.hpp"
 #include "joint_trajectory_controller/visibility_control.h"
 #include "rclcpp/duration.hpp"
@@ -139,6 +140,8 @@ protected:
   trajectory_msgs::msg::JointTrajectoryPoint last_commanded_state_;
   /// Allow integration in goal trajectories to accept goals without position or velocity specified
   bool allow_integration_in_goal_trajectories_ = false;
+  /// Specify interpolation method. Default to splines.
+  InterpolationMethod interpolation_method_ { InterpolationMethod::SPLINE };
 
   double state_publish_rate_;
   double action_monitor_rate_;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -141,7 +141,8 @@ protected:
   /// Allow integration in goal trajectories to accept goals without position or velocity specified
   bool allow_integration_in_goal_trajectories_ = false;
   /// Specify interpolation method. Default to splines.
-  InterpolationMethod interpolation_method_{InterpolationMethod::VARIABLE_DEGREE_SPLINE};
+  interpolation_methods::InterpolationMethod interpolation_method_{
+    interpolation_methods::DEFAULT_INTERPOLATION};
 
   double state_publish_rate_;
   double action_monitor_rate_;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -141,7 +141,7 @@ protected:
   /// Allow integration in goal trajectories to accept goals without position or velocity specified
   bool allow_integration_in_goal_trajectories_ = false;
   /// Specify interpolation method. Default to splines.
-  InterpolationMethod interpolation_method_ { InterpolationMethod::SPLINE };
+  InterpolationMethod interpolation_method_{InterpolationMethod::VARIABLE_DEGREE_SPLINE};
 
   double state_publish_rate_;
   double action_monitor_rate_;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <vector>
 
+#include "joint_trajectory_controller/interpolation_methods.hpp"
 #include "joint_trajectory_controller/visibility_control.h"
 #include "rclcpp/time.hpp"
 #include "trajectory_msgs/msg/joint_trajectory.hpp"
@@ -75,13 +76,15 @@ public:
    *    return false
    *
    * \param[in] sample_time Time at which trajectory will be sampled.
+   * \param[in] interpolation_method Specify whether splines, another method, or no interpolation at all.
    * \param[out] expected_state Calculated new at \p sample_time.
    * \param[out] start_segment_itr Iterator to the start segment for given \p sample_time. See description above.
    * \param[out] end_segment_itr Iterator to the end segment for given \p sample_time. See description above.
    */
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   bool sample(
-    const rclcpp::Time & sample_time, trajectory_msgs::msg::JointTrajectoryPoint & output_state,
+    const rclcpp::Time & sample_time, const InterpolationMethod interpolation_method,
+    trajectory_msgs::msg::JointTrajectoryPoint & output_state,
     TrajectoryPointConstIter & start_segment_itr, TrajectoryPointConstIter & end_segment_itr);
 
   /**

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -83,7 +83,8 @@ public:
    */
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   bool sample(
-    const rclcpp::Time & sample_time, const InterpolationMethod interpolation_method,
+    const rclcpp::Time & sample_time,
+    const interpolation_methods::InterpolationMethod interpolation_method,
     trajectory_msgs::msg::JointTrajectoryPoint & output_state,
     TrajectoryPointConstIter & start_segment_itr, TrajectoryPointConstIter & end_segment_itr);
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -69,8 +69,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
     action_monitor_rate_ = auto_declare<double>("action_monitor_rate", 20.0);
 
     std::string interpolation_method = "";
-    interpolation_method =
-      auto_declare<std::string>("interpolation_method", "splines");
+    interpolation_method = auto_declare<std::string>("interpolation_method", "splines");
     if (interpolation_method == "none")
     {
       interpolation_method_ = InterpolationMethod::NONE;
@@ -206,7 +205,8 @@ controller_interface::return_type JointTrajectoryController::update(
     // find segment for current timestamp
     TrajectoryPointConstIter start_segment_itr, end_segment_itr;
     const bool valid_point =
-      (*traj_point_active_ptr_)->sample(time, interpolation_method_, state_desired, start_segment_itr, end_segment_itr);
+      (*traj_point_active_ptr_)
+        ->sample(time, interpolation_method_, state_desired, start_segment_itr, end_segment_itr);
 
     if (valid_point)
     {

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -68,21 +68,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
     state_publish_rate_ = auto_declare<double>("state_publish_rate", 50.0);
     action_monitor_rate_ = auto_declare<double>("action_monitor_rate", 20.0);
 
-    std::string interpolation_method = "";
-    interpolation_method = auto_declare<std::string>("interpolation_method", "splines");
-    if (interpolation_method == "none")
-    {
-      interpolation_method_ = InterpolationMethod::NONE;
-    }
-    else if (interpolation_method == "splines")
-    {
-      interpolation_method_ = InterpolationMethod::SPLINE;
-    }
-    else
-    {
-      fprintf(stderr, "Unexpected `interpolation_method` parameter.");
-      return CallbackReturn::ERROR;
-    }
+    std::string interpolation_string = auto_declare<std::string>("interpolation_method", "splines");
+    interpolation_method_ = from_string(interpolation_string);
   }
   catch (const std::exception & e)
   {
@@ -206,7 +193,7 @@ controller_interface::return_type JointTrajectoryController::update(
     TrajectoryPointConstIter start_segment_itr, end_segment_itr;
     const bool valid_point =
       (*traj_point_active_ptr_)
-        ->sample(time, interpolation_method_, state_desired, start_segment_itr, end_segment_itr);
+        ->sample(time, interpolation_method_, state_desired_, start_segment_itr, end_segment_itr);
 
     if (valid_point)
     {

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -67,6 +67,23 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
       "allow_integration_in_goal_trajectories", allow_integration_in_goal_trajectories_);
     state_publish_rate_ = auto_declare<double>("state_publish_rate", 50.0);
     action_monitor_rate_ = auto_declare<double>("action_monitor_rate", 20.0);
+
+    std::string interpolation_method = "";
+    interpolation_method =
+      auto_declare<std::string>("interpolation_method", "splines");
+    if (interpolation_method == "none")
+    {
+      interpolation_method_ = InterpolationMethod::NONE;
+    }
+    else if (interpolation_method == "splines")
+    {
+      interpolation_method_ = InterpolationMethod::SPLINE;
+    }
+    else
+    {
+      fprintf(stderr, "Unexpected `interpolation_method` parameter.");
+      return CallbackReturn::ERROR;
+    }
   }
   catch (const std::exception & e)
   {
@@ -189,7 +206,7 @@ controller_interface::return_type JointTrajectoryController::update(
     // find segment for current timestamp
     TrajectoryPointConstIter start_segment_itr, end_segment_itr;
     const bool valid_point =
-      (*traj_point_active_ptr_)->sample(time, state_desired_, start_segment_itr, end_segment_itr);
+      (*traj_point_active_ptr_)->sample(time, interpolation_method_, state_desired, start_segment_itr, end_segment_itr);
 
     if (valid_point)
     {

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -68,8 +68,10 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
     state_publish_rate_ = auto_declare<double>("state_publish_rate", 50.0);
     action_monitor_rate_ = auto_declare<double>("action_monitor_rate", 20.0);
 
-    std::string interpolation_string = auto_declare<std::string>("interpolation_method", "splines");
-    interpolation_method_ = from_string(interpolation_string);
+    std::string interpolation_string = auto_declare<std::string>(
+      "interpolation_method", interpolation_methods::InterpolationMethodMap.at(
+                                interpolation_methods::DEFAULT_INTERPOLATION));
+    interpolation_method_ = interpolation_methods::from_string(interpolation_string);
   }
   catch (const std::exception & e)
   {

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -58,7 +58,8 @@ void Trajectory::update(std::shared_ptr<trajectory_msgs::msg::JointTrajectory> j
 }
 
 bool Trajectory::sample(
-  const rclcpp::Time & sample_time, trajectory_msgs::msg::JointTrajectoryPoint & output_state,
+  const rclcpp::Time & sample_time, const InterpolationMethod interpolation_method,
+  trajectory_msgs::msg::JointTrajectoryPoint & output_state,
   TrajectoryPointConstIter & start_segment_itr, TrajectoryPointConstIter & end_segment_itr)
 {
   THROW_ON_NULLPTR(trajectory_msg_)
@@ -88,14 +89,14 @@ bool Trajectory::sample(
     return false;
   }
 
-  // current time hasn't reached traj time of the first point in the msg yet
   auto & first_point_in_msg = trajectory_msg_->points[0];
   const rclcpp::Time first_point_timestamp =
     trajectory_start_time_ + first_point_in_msg.time_from_start;
 
+  // current time hasn't reached traj time of the first point in the msg yet
   if (sample_time < first_point_timestamp)
   {
-    // it changes points only if position and velocity are not exist, but their derivatives
+    // it changes points only if position and velocity do not exist, but their derivatives
     deduce_from_derivatives(
       state_before_traj_msg_, first_point_in_msg, state_before_traj_msg_.positions.size(),
       (first_point_timestamp - time_before_traj_msg_).seconds());

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -58,7 +58,8 @@ void Trajectory::update(std::shared_ptr<trajectory_msgs::msg::JointTrajectory> j
 }
 
 bool Trajectory::sample(
-  const rclcpp::Time & sample_time, const InterpolationMethod interpolation_method,
+  const rclcpp::Time & sample_time,
+  const interpolation_methods::InterpolationMethod interpolation_method,
   trajectory_msgs::msg::JointTrajectoryPoint & output_state,
   TrajectoryPointConstIter & start_segment_itr, TrajectoryPointConstIter & end_segment_itr)
 {
@@ -97,7 +98,7 @@ bool Trajectory::sample(
   if (sample_time < first_point_timestamp)
   {
     // If interpolation is disabled, just forward the next waypoint
-    if (interpolation_method == joint_trajectory_controller::InterpolationMethod::NONE)
+    if (interpolation_method == interpolation_methods::InterpolationMethod::NONE)
     {
       output_state = state_before_traj_msg_;
     }
@@ -130,7 +131,7 @@ bool Trajectory::sample(
     if (sample_time >= t0 && sample_time < t1)
     {
       // If interpolation is disabled, just forward the next waypoint
-      if (interpolation_method == InterpolationMethod::NONE)
+      if (interpolation_method == interpolation_methods::InterpolationMethod::NONE)
       {
         output_state = next_point;
       }

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -14,7 +14,6 @@
 
 #include "joint_trajectory_controller/trajectory.hpp"
 
-#include <iostream>
 #include <memory>
 
 #include "hardware_interface/macros.hpp"
@@ -130,17 +129,14 @@ bool Trajectory::sample(
 
     if (sample_time >= t0 && sample_time < t1)
     {
-      std::cout << "Somewhere prior to the first point" << std::endl;
       // If interpolation is disabled, just forward the next waypoint
-      if (interpolation_method == joint_trajectory_controller::InterpolationMethod::NONE)
+      if (interpolation_method == InterpolationMethod::NONE)
       {
-        std::cout << "Traj pass-through" << std::endl;
         output_state = next_point;
       }
       // Do interpolation
       else
       {
-        std::cout << "Spline interpolation" << std::endl;
         // it changes points only if position and velocity do not exist, but their derivatives
         deduce_from_derivatives(
           point, next_point, state_before_traj_msg_.positions.size(), (t1 - t0).seconds());

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -31,8 +31,11 @@
 
 using namespace std::chrono_literals;
 
+namespace{
 // Floating-point value comparison threshold
 const double EPS = 1e-8;
+const joint_trajectory_controller::InterpolationMethod DEFAULT_INTERPOLATION = joint_trajectory_controller::InterpolationMethod::SPLINE;
+}
 
 TEST(TestTrajectory, initialize_trajectory)
 {
@@ -45,7 +48,7 @@ TEST(TestTrajectory, initialize_trajectory)
 
     trajectory_msgs::msg::JointTrajectoryPoint expected_point;
     joint_trajectory_controller::TrajectoryPointConstIter start, end;
-    traj.sample(rclcpp::Clock().now(), expected_point, start, end);
+    traj.sample(rclcpp::Clock().now(), DEFAULT_INTERPOLATION, expected_point, start, end);
 
     EXPECT_EQ(traj.end(), start);
     EXPECT_EQ(traj.end(), end);
@@ -61,7 +64,7 @@ TEST(TestTrajectory, initialize_trajectory)
 
     trajectory_msgs::msg::JointTrajectoryPoint expected_point;
     joint_trajectory_controller::TrajectoryPointConstIter start, end;
-    traj.sample(rclcpp::Clock().now(), expected_point, start, end);
+    traj.sample(rclcpp::Clock().now(), DEFAULT_INTERPOLATION, expected_point, start, end);
 
     EXPECT_EQ(traj.end(), start);
     EXPECT_EQ(traj.end(), end);
@@ -106,7 +109,7 @@ TEST(TestTrajectory, sample_trajectory_positions)
 
   // sample at trajectory starting time
   {
-    traj.sample(time_now, expected_state, start, end);
+    traj.sample(time_now, DEFAULT_INTERPOLATION, expected_state, start, end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ(traj.begin(), end);
     EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
@@ -117,13 +120,13 @@ TEST(TestTrajectory, sample_trajectory_positions)
   // sample before time_now
   {
     bool result =
-      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
+      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     ASSERT_EQ(result, false);
   }
 
   // sample 0.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ(traj.begin(), end);
     double half_current_to_p1 = (point_before_msg.positions[0] + p1.positions[0]) * 0.5;
@@ -134,7 +137,7 @@ TEST(TestTrajectory, sample_trajectory_positions)
 
   // sample 1s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start, end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ((++traj.begin()), end);
     EXPECT_NEAR(p1.positions[0], expected_state.positions[0], EPS);
@@ -144,7 +147,7 @@ TEST(TestTrajectory, sample_trajectory_positions)
 
   // sample 1.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ((++traj.begin()), end);
     double half_p1_to_p2 = (p1.positions[0] + p2.positions[0]) * 0.5;
@@ -153,20 +156,20 @@ TEST(TestTrajectory, sample_trajectory_positions)
 
   // sample 2.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     double half_p2_to_p3 = (p2.positions[0] + p3.positions[0]) * 0.5;
     EXPECT_NEAR(half_p2_to_p3, expected_state.positions[0], EPS);
   }
 
   // sample 3s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_NEAR(p3.positions[0], expected_state.positions[0], EPS);
   }
 
   // sample past given points
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state, start, end);
     ASSERT_EQ((--traj.end()), start);
     ASSERT_EQ(traj.end(), end);
     EXPECT_NEAR(p3.positions[0], expected_state.positions[0], EPS);
@@ -323,7 +326,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
 
   // sample at trajectory starting time
   {
-    traj.sample(time_now, expected_state, start, end);
+    traj.sample(time_now, DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ(traj.begin(), end);
     EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
@@ -334,13 +337,13 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
   // sample before time_now
   {
     bool result =
-      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
+      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(result, false);
   }
 
   // sample 0.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ(traj.begin(), end);
     double half_current_to_p1 =
@@ -358,7 +361,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
   double position_first_seg =
     point_before_msg.positions[0] + (0.0 + p1.velocities[0]) / 2 * time_first_seg;
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ((++traj.begin()), end);
     EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
@@ -370,7 +373,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
 
   // sample 1.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ((++traj.begin()), end);
     double half_p1_to_p2 =
@@ -388,7 +391,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
   double position_second_seg = position_first_seg + (p1.velocities[0] + p2.velocities[0]) / 2 *
                                                       (time_second_seg - time_first_seg);
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(2), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(2), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ((++traj.begin()), start);
     EXPECT_EQ((--traj.end()), end);
     EXPECT_NEAR(position_second_seg, expected_state.positions[0], EPS);
@@ -400,7 +403,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
 
   // sample 2.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ((++traj.begin()), start);
     EXPECT_EQ((--traj.end()), end);
     double half_p2_to_p3 =
@@ -418,7 +421,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
   double position_third_seg = position_second_seg + (p2.velocities[0] + p3.velocities[0]) / 2 *
                                                       (time_third_seg - time_second_seg);
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ((--traj.end()), start);
     EXPECT_EQ(traj.end(), end);
     EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
@@ -429,7 +432,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
 
   // sample past given points - movement virtually stops
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ((--traj.end()), start);
     EXPECT_EQ(traj.end(), end);
     EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
@@ -481,7 +484,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_witho
 
   // sample at trajectory starting time
   {
-    traj.sample(time_now, expected_state, start, end);
+    traj.sample(time_now, DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ(traj.begin(), end);
     EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
@@ -493,13 +496,13 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_witho
   // sample before time_now
   {
     bool result =
-      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
+      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(result, false);
   }
 
   // sample 0.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ(traj.begin(), end);
     //     double half_current_to_p1 = point_before_msg.positions[0] +
@@ -517,7 +520,7 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_witho
   double position_first_seg =
     point_before_msg.positions[0] + (0.0 + p1.velocities[0]) / 2 * time_first_seg;
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ((++traj.begin()), end);
     EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
@@ -568,7 +571,7 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
 
   // sample at trajectory starting time
   {
-    traj.sample(time_now, expected_state, start, end);
+    traj.sample(time_now, DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ(traj.begin(), end);
     EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
@@ -580,7 +583,7 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
   // sample before time_now
   {
     bool result =
-      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), expected_state, start, end);
+      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(result, false);
   }
 
@@ -592,7 +595,7 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
   double position_first_seg =
     point_before_msg.positions[0] + (0.0 + velocity_first_seg) / 2 * time_first_seg;
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ((++traj.begin()), end);
     EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
@@ -606,7 +609,7 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
   double position_second_seg = position_first_seg + (velocity_first_seg + velocity_second_seg) / 2 *
                                                       (time_second_seg - time_first_seg);
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(2), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(2), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ((++traj.begin()), start);
     EXPECT_EQ((--traj.end()), end);
     EXPECT_NEAR(position_second_seg, expected_state.positions[0], EPS);
@@ -620,7 +623,7 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
   double position_third_seg = position_second_seg + (velocity_second_seg + velocity_third_seg) / 2 *
                                                       (time_third_seg - time_second_seg);
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ((--traj.end()), start);
     EXPECT_EQ(traj.end(), end);
     EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
@@ -630,7 +633,7 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
 
   // sample past given points - movement virtually stops
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), expected_state, start, end);
+    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state, start, end);
     EXPECT_EQ((--traj.end()), start);
     EXPECT_EQ(traj.end(), end);
     EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -29,14 +29,13 @@
 #include "trajectory_msgs/msg/joint_trajectory.hpp"
 #include "trajectory_msgs/msg/joint_trajectory_point.hpp"
 
+using namespace joint_trajectory_controller::interpolation_methods;  // NOLINT
 using namespace std::chrono_literals;
 
 namespace
 {
 // Floating-point value comparison threshold
 const double EPS = 1e-8;
-const joint_trajectory_controller::InterpolationMethod DEFAULT_INTERPOLATION =
-  joint_trajectory_controller::InterpolationMethod::VARIABLE_DEGREE_SPLINE;
 }  // namespace
 
 TEST(TestTrajectory, initialize_trajectory)
@@ -690,8 +689,7 @@ TEST(TestTrajectory, skip_interpolation)
 {
   // Simple passthrough without extra interpolation
   {
-    const joint_trajectory_controller::InterpolationMethod no_interpolation =
-      joint_trajectory_controller::InterpolationMethod::NONE;
+    const InterpolationMethod no_interpolation = InterpolationMethod::NONE;
 
     auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
     full_msg->header.stamp = rclcpp::Time(0);

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -36,7 +36,7 @@ namespace
 // Floating-point value comparison threshold
 const double EPS = 1e-8;
 const joint_trajectory_controller::InterpolationMethod DEFAULT_INTERPOLATION =
-  joint_trajectory_controller::InterpolationMethod::SPLINE;
+  joint_trajectory_controller::InterpolationMethod::VARIABLE_DEGREE_SPLINE;
 }  // namespace
 
 TEST(TestTrajectory, initialize_trajectory)

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -31,11 +31,13 @@
 
 using namespace std::chrono_literals;
 
-namespace{
+namespace
+{
 // Floating-point value comparison threshold
 const double EPS = 1e-8;
-const joint_trajectory_controller::InterpolationMethod DEFAULT_INTERPOLATION = joint_trajectory_controller::InterpolationMethod::SPLINE;
-}
+const joint_trajectory_controller::InterpolationMethod DEFAULT_INTERPOLATION =
+  joint_trajectory_controller::InterpolationMethod::SPLINE;
+}  // namespace
 
 TEST(TestTrajectory, initialize_trajectory)
 {
@@ -119,14 +121,17 @@ TEST(TestTrajectory, sample_trajectory_positions)
 
   // sample before time_now
   {
-    bool result =
-      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    bool result = traj.sample(
+      time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     ASSERT_EQ(result, false);
   }
 
   // sample 0.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ(traj.begin(), end);
     double half_current_to_p1 = (point_before_msg.positions[0] + p1.positions[0]) * 0.5;
@@ -137,7 +142,9 @@ TEST(TestTrajectory, sample_trajectory_positions)
 
   // sample 1s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ((++traj.begin()), end);
     EXPECT_NEAR(p1.positions[0], expected_state.positions[0], EPS);
@@ -147,7 +154,9 @@ TEST(TestTrajectory, sample_trajectory_positions)
 
   // sample 1.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(1.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     ASSERT_EQ(traj.begin(), start);
     ASSERT_EQ((++traj.begin()), end);
     double half_p1_to_p2 = (p1.positions[0] + p2.positions[0]) * 0.5;
@@ -156,20 +165,26 @@ TEST(TestTrajectory, sample_trajectory_positions)
 
   // sample 2.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(2.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     double half_p2_to_p3 = (p2.positions[0] + p3.positions[0]) * 0.5;
     EXPECT_NEAR(half_p2_to_p3, expected_state.positions[0], EPS);
   }
 
   // sample 3s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_NEAR(p3.positions[0], expected_state.positions[0], EPS);
   }
 
   // sample past given points
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state,
+      start, end);
     ASSERT_EQ((--traj.end()), start);
     ASSERT_EQ(traj.end(), end);
     EXPECT_NEAR(p3.positions[0], expected_state.positions[0], EPS);
@@ -336,14 +351,17 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
 
   // sample before time_now
   {
-    bool result =
-      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    bool result = traj.sample(
+      time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ(result, false);
   }
 
   // sample 0.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ(traj.begin(), end);
     double half_current_to_p1 =
@@ -361,7 +379,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
   double position_first_seg =
     point_before_msg.positions[0] + (0.0 + p1.velocities[0]) / 2 * time_first_seg;
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ((++traj.begin()), end);
     EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
@@ -373,7 +393,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
 
   // sample 1.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(1.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ((++traj.begin()), end);
     double half_p1_to_p2 =
@@ -391,7 +413,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
   double position_second_seg = position_first_seg + (p1.velocities[0] + p2.velocities[0]) / 2 *
                                                       (time_second_seg - time_first_seg);
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(2), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(2), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ((++traj.begin()), start);
     EXPECT_EQ((--traj.end()), end);
     EXPECT_NEAR(position_second_seg, expected_state.positions[0], EPS);
@@ -403,7 +427,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
 
   // sample 2.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(2.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(2.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ((++traj.begin()), start);
     EXPECT_EQ((--traj.end()), end);
     double half_p2_to_p3 =
@@ -421,7 +447,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
   double position_third_seg = position_second_seg + (p2.velocities[0] + p3.velocities[0]) / 2 *
                                                       (time_third_seg - time_second_seg);
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ((--traj.end()), start);
     EXPECT_EQ(traj.end(), end);
     EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
@@ -432,7 +460,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation)
 
   // sample past given points - movement virtually stops
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state,
+      start, end);
     EXPECT_EQ((--traj.end()), start);
     EXPECT_EQ(traj.end(), end);
     EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
@@ -495,14 +525,17 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_witho
 
   // sample before time_now
   {
-    bool result =
-      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    bool result = traj.sample(
+      time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ(result, false);
   }
 
   // sample 0.5s after msg
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ(traj.begin(), end);
     //     double half_current_to_p1 = point_before_msg.positions[0] +
@@ -520,7 +553,9 @@ TEST(TestTrajectory, sample_trajectory_velocity_with_interpolation_strange_witho
   double position_first_seg =
     point_before_msg.positions[0] + (0.0 + p1.velocities[0]) / 2 * time_first_seg;
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ((++traj.begin()), end);
     EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
@@ -582,8 +617,9 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
 
   // sample before time_now
   {
-    bool result =
-      traj.sample(time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start, end);
+    bool result = traj.sample(
+      time_now - rclcpp::Duration::from_seconds(0.5), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ(result, false);
   }
 
@@ -595,7 +631,9 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
   double position_first_seg =
     point_before_msg.positions[0] + (0.0 + velocity_first_seg) / 2 * time_first_seg;
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(1.0), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ(traj.begin(), start);
     EXPECT_EQ((++traj.begin()), end);
     EXPECT_NEAR(position_first_seg, expected_state.positions[0], EPS);
@@ -609,7 +647,9 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
   double position_second_seg = position_first_seg + (velocity_first_seg + velocity_second_seg) / 2 *
                                                       (time_second_seg - time_first_seg);
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(2), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(2), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ((++traj.begin()), start);
     EXPECT_EQ((--traj.end()), end);
     EXPECT_NEAR(position_second_seg, expected_state.positions[0], EPS);
@@ -623,7 +663,9 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
   double position_third_seg = position_second_seg + (velocity_second_seg + velocity_third_seg) / 2 *
                                                       (time_third_seg - time_second_seg);
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, expected_state, start,
+      end);
     EXPECT_EQ((--traj.end()), start);
     EXPECT_EQ(traj.end(), end);
     EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
@@ -633,11 +675,139 @@ TEST(TestTrajectory, sample_trajectory_acceleration_with_interpolation)
 
   // sample past given points - movement virtually stops
   {
-    traj.sample(time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state, start, end);
+    traj.sample(
+      time_now + rclcpp::Duration::from_seconds(3.125), DEFAULT_INTERPOLATION, expected_state,
+      start, end);
     EXPECT_EQ((--traj.end()), start);
     EXPECT_EQ(traj.end(), end);
     EXPECT_NEAR(position_third_seg, expected_state.positions[0], EPS);
     EXPECT_NEAR(velocity_third_seg, expected_state.velocities[0], EPS);
     EXPECT_NEAR(p3.accelerations[0], expected_state.accelerations[0], EPS);
+  }
+}
+
+TEST(TestTrajectory, skip_interpolation)
+{
+  // Simple passthrough without extra interpolation
+  {
+    const joint_trajectory_controller::InterpolationMethod no_interpolation =
+      joint_trajectory_controller::InterpolationMethod::NONE;
+
+    auto full_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+    full_msg->header.stamp = rclcpp::Time(0);
+
+    trajectory_msgs::msg::JointTrajectoryPoint p1;
+    p1.positions.push_back(1.0);
+    p1.time_from_start = rclcpp::Duration::from_seconds(1.0);
+    full_msg->points.push_back(p1);
+
+    trajectory_msgs::msg::JointTrajectoryPoint p2;
+    p2.positions.push_back(2.0);
+    p2.time_from_start = rclcpp::Duration::from_seconds(2.0);
+    full_msg->points.push_back(p2);
+
+    trajectory_msgs::msg::JointTrajectoryPoint p3;
+    p3.positions.push_back(3.0);
+    p3.time_from_start = rclcpp::Duration::from_seconds(3.0);
+    full_msg->points.push_back(p3);
+
+    trajectory_msgs::msg::JointTrajectoryPoint point_before_msg;
+    point_before_msg.time_from_start = rclcpp::Duration::from_seconds(0.0);
+    point_before_msg.positions.push_back(0.0);
+
+    // set current state before trajectory msg was sent
+    const rclcpp::Time time_now = rclcpp::Clock().now();
+    auto traj = joint_trajectory_controller::Trajectory(time_now, point_before_msg, full_msg);
+
+    trajectory_msgs::msg::JointTrajectoryPoint expected_state;
+    joint_trajectory_controller::TrajectoryPointConstIter start, end;
+
+    // sample at trajectory starting time
+    {
+      traj.sample(time_now, no_interpolation, expected_state, start, end);
+      ASSERT_EQ(traj.begin(), start);
+      ASSERT_EQ(traj.begin(), end);
+      EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
+      // There were no vels/accels in the input, so they should remain empty
+      EXPECT_EQ(
+        static_cast<std::make_unsigned<decltype(0)>::type>(0), expected_state.velocities.size());
+      EXPECT_EQ(
+        static_cast<std::make_unsigned<decltype(0)>::type>(0), expected_state.accelerations.size());
+    }
+
+    // sample before time_now
+    {
+      bool result = traj.sample(
+        time_now - rclcpp::Duration::from_seconds(0.5), no_interpolation, expected_state, start,
+        end);
+      ASSERT_EQ(result, false);
+    }
+
+    // sample 0.5s after msg
+    {
+      traj.sample(
+        time_now + rclcpp::Duration::from_seconds(0.5), no_interpolation, expected_state, start,
+        end);
+      ASSERT_EQ(traj.begin(), start);
+      ASSERT_EQ(traj.begin(), end);
+      // For passthrough, this should just return the first waypoint
+      EXPECT_NEAR(point_before_msg.positions[0], expected_state.positions[0], EPS);
+      // There were no vels/accels in the input, so they should remain empty
+      EXPECT_EQ(
+        static_cast<std::make_unsigned<decltype(0)>::type>(0), expected_state.velocities.size());
+      EXPECT_EQ(
+        static_cast<std::make_unsigned<decltype(0)>::type>(0), expected_state.accelerations.size());
+    }
+
+    // sample 1s after msg
+    {
+      traj.sample(
+        time_now + rclcpp::Duration::from_seconds(1.0), no_interpolation, expected_state, start,
+        end);
+      ASSERT_EQ(traj.begin(), start);
+      ASSERT_EQ((++traj.begin()), end);
+      EXPECT_NEAR(p2.positions[0], expected_state.positions[0], EPS);
+      // There were no vels/accels in the input, so they should remain empty
+      EXPECT_EQ(
+        static_cast<std::make_unsigned<decltype(0)>::type>(0), expected_state.velocities.size());
+      EXPECT_EQ(
+        static_cast<std::make_unsigned<decltype(0)>::type>(0), expected_state.accelerations.size());
+    }
+
+    // sample 1.5s after msg
+    {
+      traj.sample(
+        time_now + rclcpp::Duration::from_seconds(1.5), no_interpolation, expected_state, start,
+        end);
+      ASSERT_EQ(traj.begin(), start);
+      ASSERT_EQ((++traj.begin()), end);
+      EXPECT_NEAR(p2.positions[0], expected_state.positions[0], EPS);
+    }
+
+    // sample 2.5s after msg
+    {
+      traj.sample(
+        time_now + rclcpp::Duration::from_seconds(2.5), no_interpolation, expected_state, start,
+        end);
+      EXPECT_NEAR(p3.positions[0], expected_state.positions[0], EPS);
+    }
+
+    // sample 3s after msg
+    {
+      traj.sample(
+        time_now + rclcpp::Duration::from_seconds(3.0), no_interpolation, expected_state, start,
+        end);
+      EXPECT_NEAR(p3.positions[0], expected_state.positions[0], EPS);
+    }
+
+    // sample past given points
+    {
+      traj.sample(
+        time_now + rclcpp::Duration::from_seconds(3.125), no_interpolation, expected_state, start,
+        end);
+      ASSERT_EQ((--traj.end()), start);
+      ASSERT_EQ(traj.end(), end);
+      EXPECT_NEAR(p3.positions[0], expected_state.positions[0], EPS);
+    }
   }
 }


### PR DESCRIPTION
This should be useful if a user has a trajectory that is already interpolated to a fine degree, or if the low-level controllers just don't handle fine waypoint spacing well.

To use, just set the parameter in the yaml file. If the parameter is unset, it defaults to the previous method (which is spline-based). The default spline-based method doesn't obey joint limits (position/vel/accel/jerk), which is another reason to use this.

```
panda_arm_controller:
  ros__parameters:
    command_interfaces:
      - position
      - velocity
      - acceleration
    state_interfaces:
      - position
      - velocity
      - acceleration
    joints:
      - panda_joint1
      - panda_joint2
      - panda_joint3
      - panda_joint4
      - panda_joint5
      - panda_joint6
      - panda_joint7
    interpolation_method: none   # (or "splines")
    joint_limits:
      panda_joint1:
        has_velocity_limits: true
        max_velocity: 2.1750
        has_acceleration_limits: true
        max_acceleration: 3.75
      panda_joint2:
        ...
```