### PR TITLE
Parameter loading fixup in diff_drive and gripper controllers

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -77,9 +77,9 @@ controller_interface::CallbackReturn DiffDriveController::on_init()
     auto_declare<bool>("enable_odom_tf", odom_params_.enable_odom_tf);
 
     auto_declare<double>("cmd_vel_timeout", cmd_vel_timeout_.count() / 1000.0);
-    auto_declare<bool>("publish_limited_velocity", publish_limited_velocity_);
+    publish_limited_velocity_ = auto_declare<bool>("publish_limited_velocity", publish_limited_velocity_);
     auto_declare<int>("velocity_rolling_window_size", 10);
-    auto_declare<bool>("use_stamped_vel", use_stamped_vel_);
+    use_stamped_vel_ = auto_declare<bool>("use_stamped_vel", use_stamped_vel_);
 
     auto_declare<bool>("linear.x.has_velocity_limits", false);
     auto_declare<bool>("linear.x.has_acceleration_limits", false);
@@ -100,7 +100,7 @@ controller_interface::CallbackReturn DiffDriveController::on_init()
     auto_declare<double>("angular.z.min_acceleration", NAN);
     auto_declare<double>("angular.z.max_jerk", NAN);
     auto_declare<double>("angular.z.min_jerk", NAN);
-    auto_declare<double>("publish_rate", publish_rate_);
+    publish_rate_ = auto_declare<double>("publish_rate", publish_rate_);
   }
   catch (const std::exception & e)
   {

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -77,7 +77,8 @@ controller_interface::CallbackReturn DiffDriveController::on_init()
     auto_declare<bool>("enable_odom_tf", odom_params_.enable_odom_tf);
 
     auto_declare<double>("cmd_vel_timeout", cmd_vel_timeout_.count() / 1000.0);
-    publish_limited_velocity_ = auto_declare<bool>("publish_limited_velocity", publish_limited_velocity_);
+    publish_limited_velocity_ = auto_declare<bool>("publish_limited_velocity",
+                                                   publish_limited_velocity_);
     auto_declare<int>("velocity_rolling_window_size", 10);
     use_stamped_vel_ = auto_declare<bool>("use_stamped_vel", use_stamped_vel_);
 

--- a/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
+++ b/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
@@ -43,7 +43,7 @@ controller_interface::CallbackReturn GripperActionController<HardwareInterface>:
   {
     // with the lifecycle node being initialized, we can declare parameters
     auto_declare<double>("action_monitor_rate", 20.0);
-    auto_declare<std::string>("joint", joint_name_);
+    joint_name_ = auto_declare<std::string>("joint", joint_name_);
     auto_declare<double>("goal_tolerance", 0.01);
     auto_declare<double>("max_effort", 0.0);
     auto_declare<bool>("allow_stalling", false);


### PR DESCRIPTION
A follow-up from #365. I think this fixes it everywhere