### PR TITLE
Enable definition of all fields in JointTrajectory message when using test node.

### DIFF
--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
@@ -30,9 +30,8 @@ class PublisherJointTrajectory(Node):
         self.declare_parameter("controller_name", "position_trajectory_controller")
         self.declare_parameter("wait_sec_between_publish", 6)
         self.declare_parameter("goal_names", ["pos1", "pos2"])
-        self.declare_parameter("joints")
+        self.declare_parameter("joints", [""])
         self.declare_parameter("check_starting_point", False)
-        self.declare_parameter("starting_point_limits")
 
         # Read parameters
         controller_name = self.get_parameter("controller_name").value
@@ -65,25 +64,97 @@ class PublisherJointTrajectory(Node):
         self.joint_state_msg_received = False
 
         # Read all positions from parameters
-        self.goals = []
+        self.goals = []  # List of JointTrajectoryPoint
         for name in goal_names:
             self.declare_parameter(name)
             goal = self.get_parameter(name).value
-            if goal is None or len(goal) == 0:
-                raise Exception(f'Values for goal "{name}" not set!')
 
-            float_goal = []
-            for value in goal:
-                float_goal.append(float(value))
-            self.goals.append(float_goal)
+            # TODO(anyone): remove this "if" part in ROS Iron
+            if isinstance(goal, list):
+                self.get_logger().warn(
+                    f'Goal "{name}" is defined as a list. This is deprecated. '
+                    'Use the following structure:\n<goal_name>:\n  '
+                    'positions: [joint1, joint2, joint3, ...]\n  '
+                    'velocities: [v_joint1, v_joint2, ...]\n  '
+                    'accelerations: [a_joint1, a_joint2, ...]\n  '
+                    'effort: [eff_joint1, eff_joint2, ...]')
+
+                if goal is None or len(goal) == 0:
+                    raise Exception(f'Values for goal "{name}" not set!')
+
+                float_goal = []
+                for value in goal:
+                    float_goal.append(float(value))
+
+                point = JointTrajectoryPoint()
+                point.positions = float_goal
+                point.time_from_start = Duration(sec=4)
+
+                self.goals.append(point)
+
+            else:
+                point = JointTrajectoryPoint()
+
+                def get_sub_param(sub_param):
+                    param_name = name + '.' + sub_param
+                    self.declare_parameter(param_name, [float()])
+                    param_value = self.get_parameter(param_name).value
+
+                    float_values = []
+
+                    if len(param_value) != len(self.joints):
+                        return [False, float_values]
+
+                    for value in param_value:
+                        float_values.append(float(value))
+
+                    return [True, float_values]
+
+                one_ok = False
+
+                [ok, values] = get_sub_param('positions')
+                if ok:
+                    point.positions = values
+                    one_ok = True
+
+                [ok, values] = get_sub_param('velocities')
+                if ok:
+                    point.velocities = values
+                    one_ok = True
+
+                [ok, values] = get_sub_param('accelerations')
+                if ok:
+                    point.accelerations = values
+                    one_ok = True
+
+                [ok, values] = get_sub_param('effort')
+                if ok:
+                    point.effort = values
+                    one_ok = True
+
+                if one_ok:
+                    point.time_from_start = Duration(sec=4)
+                    self.goals.append(point)
+                    self.get_logger().info(f'Goal "{name}" has definition {point}')
+
+                else:
+                    self.get_logger().warn(
+                        f'Goal "{name}" definition is wrong. This goal will not be used. '
+                        'Use the following structure: \n<goal_name>:\n  '
+                        'positions: [joint1, joint2, joint3, ...]\n  '
+                        'velocities: [v_joint1, v_joint2, ...]\n  '
+                        'accelerations: [a_joint1, a_joint2, ...]\n  '
+                        'effort: [eff_joint1, eff_joint2, ...]')
+
+        if len(self.goals) < 1:
+            self.get_logger().error('No valid goal found. Exiting...')
+            exit(1)
 
         publish_topic = "/" + controller_name + "/" + "joint_trajectory"
 
         self.get_logger().info(
-            'Publishing {} goals on topic "{}" every {} s'.format(
-                len(goal_names), publish_topic, wait_sec_between_publish
-            )
-        )
+            f'Publishing {len(goal_names)} goals on topic "{publish_topic}" every '
+            '{wait_sec_between_publish} s')
 
         self.publisher_ = self.create_publisher(JointTrajectory, publish_topic, 1)
         self.timer = self.create_timer(wait_sec_between_publish, self.timer_callback)
@@ -93,13 +164,11 @@ class PublisherJointTrajectory(Node):
 
         if self.starting_point_ok:
 
+            self.get_logger().info(f'Sending goal {self.goals[self.i]}.')
+
             traj = JointTrajectory()
             traj.joint_names = self.joints
-            point = JointTrajectoryPoint()
-            point.positions = self.goals[self.i]
-            point.time_from_start = Duration(sec=4)
-
-            traj.points.append(point)
+            traj.points.append(self.goals[self.i])
             self.publisher_.publish(traj)
 
             self.i += 1

--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
@@ -73,11 +73,12 @@ class PublisherJointTrajectory(Node):
             if isinstance(goal, list):
                 self.get_logger().warn(
                     f'Goal "{name}" is defined as a list. This is deprecated. '
-                    'Use the following structure:\n<goal_name>:\n  '
-                    'positions: [joint1, joint2, joint3, ...]\n  '
-                    'velocities: [v_joint1, v_joint2, ...]\n  '
-                    'accelerations: [a_joint1, a_joint2, ...]\n  '
-                    'effort: [eff_joint1, eff_joint2, ...]')
+                    "Use the following structure:\n<goal_name>:\n  "
+                    "positions: [joint1, joint2, joint3, ...]\n  "
+                    "velocities: [v_joint1, v_joint2, ...]\n  "
+                    "accelerations: [a_joint1, a_joint2, ...]\n  "
+                    "effort: [eff_joint1, eff_joint2, ...]"
+                )
 
                 if goal is None or len(goal) == 0:
                     raise Exception(f'Values for goal "{name}" not set!')
@@ -94,7 +95,7 @@ class PublisherJointTrajectory(Node):
                 point = JointTrajectoryPoint()
 
                 def get_sub_param(sub_param):
-                    param_name = name + '.' + sub_param
+                    param_name = name + "." + sub_param
                     self.declare_parameter(param_name, [float()])
                     param_value = self.get_parameter(param_name).value
 
@@ -103,29 +104,28 @@ class PublisherJointTrajectory(Node):
                     if len(param_value) != len(self.joints):
                         return [False, float_values]
 
-                    
                     float_values = [float(value) for value in param_value]
 
                     return [True, float_values]
 
                 one_ok = False
 
-                [ok, values] = get_sub_param('positions')
+                [ok, values] = get_sub_param("positions")
                 if ok:
                     point.positions = values
                     one_ok = True
 
-                [ok, values] = get_sub_param('velocities')
+                [ok, values] = get_sub_param("velocities")
                 if ok:
                     point.velocities = values
                     one_ok = True
 
-                [ok, values] = get_sub_param('accelerations')
+                [ok, values] = get_sub_param("accelerations")
                 if ok:
                     point.accelerations = values
                     one_ok = True
 
-                [ok, values] = get_sub_param('effort')
+                [ok, values] = get_sub_param("effort")
                 if ok:
                     point.effort = values
                     one_ok = True
@@ -138,21 +138,23 @@ class PublisherJointTrajectory(Node):
                 else:
                     self.get_logger().warn(
                         f'Goal "{name}" definition is wrong. This goal will not be used. '
-                        'Use the following structure: \n<goal_name>:\n  '
-                        'positions: [joint1, joint2, joint3, ...]\n  '
-                        'velocities: [v_joint1, v_joint2, ...]\n  '
-                        'accelerations: [a_joint1, a_joint2, ...]\n  '
-                        'effort: [eff_joint1, eff_joint2, ...]')
+                        "Use the following structure: \n<goal_name>:\n  "
+                        "positions: [joint1, joint2, joint3, ...]\n  "
+                        "velocities: [v_joint1, v_joint2, ...]\n  "
+                        "accelerations: [a_joint1, a_joint2, ...]\n  "
+                        "effort: [eff_joint1, eff_joint2, ...]"
+                    )
 
         if len(self.goals) < 1:
-            self.get_logger().error('No valid goal found. Exiting...')
+            self.get_logger().error("No valid goal found. Exiting...")
             exit(1)
 
         publish_topic = "/" + controller_name + "/" + "joint_trajectory"
 
         self.get_logger().info(
             f'Publishing {len(goal_names)} goals on topic "{publish_topic}" every '
-            '{wait_sec_between_publish} s')
+            "{wait_sec_between_publish} s"
+        )
 
         self.publisher_ = self.create_publisher(JointTrajectory, publish_topic, 1)
         self.timer = self.create_timer(wait_sec_between_publish, self.timer_callback)
@@ -162,7 +164,7 @@ class PublisherJointTrajectory(Node):
 
         if self.starting_point_ok:
 
-            self.get_logger().info(f'Sending goal {self.goals[self.i]}.')
+            self.get_logger().info(f"Sending goal {self.goals[self.i]}.")
 
             traj = JointTrajectory()
             traj.joint_names = self.joints

--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
@@ -82,9 +82,7 @@ class PublisherJointTrajectory(Node):
                 if goal is None or len(goal) == 0:
                     raise Exception(f'Values for goal "{name}" not set!')
 
-                float_goal = []
-                for value in goal:
-                    float_goal.append(float(value))
+                float_goal = [float(value) for value in goal]
 
                 point = JointTrajectoryPoint()
                 point.positions = float_goal
@@ -105,8 +103,8 @@ class PublisherJointTrajectory(Node):
                     if len(param_value) != len(self.joints):
                         return [False, float_values]
 
-                    for value in param_value:
-                        float_values.append(float(value))
+                    
+                    float_values = [float(value) for value in param_value]
 
                     return [True, float_values]
 


### PR DESCRIPTION
This PR extends test node for JTC to enable definition of all fields in `JointTrajectory` message when testing a hardware.

This enables velocity, acceleration, and effort only inputs that JTC can handle but test node was unable to until now.
The goal of this work is to simplify testing of a controller for a specific hardware in a specific scenario. 
