### PR TITLE
Use explicit type in joint_state_broadcaster test

### DIFF
--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -683,7 +683,7 @@ void JointStateBroadcasterTest::test_published_dynamic_joint_state_message(
   ASSERT_TRUE(subscription->take(dynamic_joint_state_msg, msg_info));
 
   const size_t NUM_JOINTS = 3;
-  const auto INTERFACE_NAMES = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
+  const std::vector<std::string> INTERFACE_NAMES = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   // the order in the message may be different
   // we only check that all values in this test are present in the message


### PR DESCRIPTION
This use of `auto` is causing a static assert on RHEL. Explicitly specifying the type seems to resolve the failure and allow the test to be compiled.

Example failure: https://build.ros2.org/view/Gbin_rhel_el864/job/Gbin_rhel_el864__joint_state_broadcaster__rhel_8_x86_64__binary/325/console

This bug is blocking `ros2_controllers` builds on RHEL for all of Galactic, Humble, and Rolling.

<details>

```
DEBUG: /usr/bin/c++ -DDEFAULT_RMW_IMPLEMENTATION=rmw_cyclonedds_cpp -DRCUTILS_ENABLE_FAULT_INJECTION -I/opt/ros/galactic/src/gmock_vendor/include -I/opt/ros/galactic/src/gtest_vendor/include -I/builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/include -isystem /opt/ros/galactic/include -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wall -Wextra -std=gnu++17 -MD -MT CMakeFiles/test_joint_state_broadcaster.dir/test/test_joint_state_broadcaster.cpp.o -MF CMakeFiles/test_joint_state_broadcaster.dir/test/test_joint_state_broadcaster.cpp.o.d -o CMakeFiles/test_joint_state_broadcaster.dir/test/test_joint_state_broadcaster.cpp.o -c /builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/test/test_joint_state_broadcaster.cpp
DEBUG: In file included from /usr/include/c++/8/vector:64,
DEBUG:                  from /usr/include/c++/8/functional:62,
DEBUG:                  from /builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/test/test_joint_state_broadcaster.cpp:17:
DEBUG: /usr/include/c++/8/bits/stl_vector.h: In instantiation of 'class std::vector<const char* const, std::allocator<const char* const> >':
DEBUG: /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock-matchers.h:3147:26:   required from 'class testing::internal::ElementsAreArrayMatcher<const char* const>'
DEBUG: /builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/test/test_joint_state_broadcaster.cpp:701:5:   required from here
DEBUG: /usr/include/c++/8/bits/stl_vector.h:351:21: error: static assertion failed: std::vector must have a non-const, non-volatile value_type
DEBUG:        static_assert(is_same<typename remove_cv<_Tp>::type, _Tp>::value,
DEBUG:                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DEBUG: In file included from /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock-spec-builders.h:75,
DEBUG:                  from /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock-generated-function-mockers.h:47,
DEBUG:                  from /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock-function-mocker.h:39,
DEBUG:                  from /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock.h:61,
DEBUG:                  from /builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/test/test_joint_state_broadcaster.cpp:23:
DEBUG: /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock-matchers.h: In instantiation of 'testing::internal::ElementsAreArrayMatcher<T> testing::ElementsAreArray(std::initializer_list<_Tp>) [with T = const char* const]':
DEBUG: /builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/test/test_joint_state_broadcaster.cpp:701:5:   required from here
DEBUG: /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock-matchers.h:3533:47: error: could not convert 'testing::ElementsAreArray(Iter, Iter) [with Iter = const char* const*; typename std::iterator_traits<_Iterator>::value_type = const char*](xs.std::initializer_list<const char* const>::end())' from 'ElementsAreArrayMatcher<const char*>' to 'ElementsAreArrayMatcher<const char* const>'
DEBUG:    return ElementsAreArray(xs.begin(), xs.end());
DEBUG:                                                ^
DEBUG: In file included from /usr/include/c++/8/ext/alloc_traits.h:36,
DEBUG:                  from /usr/include/c++/8/bits/basic_string.h:40,
DEBUG:                  from /usr/include/c++/8/string:52,
DEBUG:                  from /usr/include/c++/8/stdexcept:39,
DEBUG:                  from /usr/include/c++/8/array:39,
DEBUG:                  from /usr/include/c++/8/tuple:39,
DEBUG:                  from /usr/include/c++/8/functional:54,
DEBUG:                  from /builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/test/test_joint_state_broadcaster.cpp:17:
DEBUG: /usr/include/c++/8/bits/alloc_traits.h: In instantiation of 'static void std::allocator_traits<std::allocator<_CharT> >::deallocate(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, std::allocator_traits<std::allocator<_CharT> >::pointer, std::allocator_traits<std::allocator<_CharT> >::size_type) [with _Tp = const char* const; std::allocator_traits<std::allocator<_CharT> >::allocator_type = std::allocator<const char* const>; std::allocator_traits<std::allocator<_CharT> >::pointer = const char* const*; std::allocator_traits<std::allocator<_CharT> >::size_type = long unsigned int]':
DEBUG: /usr/include/c++/8/bits/stl_vector.h:304:19:   required from 'void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(std::_Vector_base<_Tp, _Alloc>::pointer, std::size_t) [with _Tp = const char* const; _Alloc = std::allocator<const char* const>; std::_Vector_base<_Tp, _Alloc>::pointer = const char* const*; std::size_t = long unsigned int]'
DEBUG: /usr/include/c++/8/bits/stl_vector.h:285:2:   required from 'std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = const char* const; _Alloc = std::allocator<const char* const>]'
DEBUG: /usr/include/c++/8/bits/stl_vector.h:570:7:   required from 'std::vector<_Tp, _Alloc>::~vector() [with _Tp = const char* const; _Alloc = std::allocator<const char* const>]'
DEBUG: /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock-matchers.h:3131:7:   required from here
DEBUG: /usr/include/c++/8/bits/alloc_traits.h:462:13: error: 'using allocator_type = class std::allocator<const char* const>' {aka 'class std::allocator<const char* const>'} has no member named 'deallocate'; did you mean 'allocator'?
DEBUG:        { __a.deallocate(__p, __n); }
DEBUG:          ~~~~^~~~~~~~~~
DEBUG:          allocator
DEBUG: /usr/include/c++/8/bits/alloc_traits.h: In instantiation of 'static _Tp* std::allocator_traits<std::allocator<_CharT> >::allocate(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, std::allocator_traits<std::allocator<_CharT> >::size_type) [with _Tp = const char* const; std::allocator_traits<std::allocator<_CharT> >::pointer = const char* const*; std::allocator_traits<std::allocator<_CharT> >::allocator_type = std::allocator<const char* const>; std::allocator_traits<std::allocator<_CharT> >::size_type = long unsigned int]':
DEBUG: /usr/include/c++/8/bits/stl_vector.h:296:33:   required from 'std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = const char* const; _Alloc = std::allocator<const char* const>; std::_Vector_base<_Tp, _Alloc>::pointer = const char* const*; std::size_t = long unsigned int]'
DEBUG: /usr/include/c++/8/bits/stl_vector.h:311:33:   required from 'void std::_Vector_base<_Tp, _Alloc>::_M_create_storage(std::size_t) [with _Tp = const char* const; _Alloc = std::allocator<const char* const>; std::size_t = long unsigned int]'
DEBUG: /usr/include/c++/8/bits/stl_vector.h:260:9:   required from 'std::_Vector_base<_Tp, _Alloc>::_Vector_base(std::size_t, const allocator_type&) [with _Tp = const char* const; _Alloc = std::allocator<const char* const>; std::size_t = long unsigned int; std::_Vector_base<_Tp, _Alloc>::allocator_type = std::allocator<const char* const>]'
DEBUG: /usr/include/c++/8/bits/stl_vector.h:460:61:   required from 'std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = const char* const; _Alloc = std::allocator<const char* const>]'
DEBUG: /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock-matchers.h:3131:7:   required from 'testing::internal::PredicateFormatterFromMatcher<M> testing::internal::MakePredicateFormatterFromMatcher(M) [with M = testing::internal::ElementsAreArrayMatcher<const char* const>]'
DEBUG: /builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/test/test_joint_state_broadcaster.cpp:701:5:   required from here
DEBUG: /usr/include/c++/8/bits/alloc_traits.h:436:20: error: 'using allocator_type = class std::allocator<const char* const>' {aka 'class std::allocator<const char* const>'} has no member named 'allocate'; did you mean 'allocator'?
DEBUG:        { return __a.allocate(__n); }
DEBUG:                 ~~~~^~~~~~~~
DEBUG:                 allocator
DEBUG: In file included from /usr/include/c++/8/vector:62,
DEBUG:                  from /usr/include/c++/8/functional:62,
DEBUG:                  from /builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/test/test_joint_state_broadcaster.cpp:17:
DEBUG: /usr/include/c++/8/bits/stl_construct.h: In instantiation of 'void std::_Construct(_T1*, _Args&& ...) [with _T1 = const char* const; _Args = {const char* const&}]':
DEBUG: /usr/include/c++/8/bits/stl_uninitialized.h:83:18:   required from 'static _ForwardIterator std::__uninitialized_copy<_TrivialValueTypes>::__uninit_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<const char* const*, std::vector<const char* const, std::allocator<const char* const> > >; _ForwardIterator = const char* const*; bool _TrivialValueTypes = false]'
DEBUG: /usr/include/c++/8/bits/stl_uninitialized.h:134:15:   required from '_ForwardIterator std::uninitialized_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<const char* const*, std::vector<const char* const, std::allocator<const char* const> > >; _ForwardIterator = const char* const*]'
DEBUG: /usr/include/c++/8/bits/stl_uninitialized.h:289:37:   required from '_ForwardIterator std::__uninitialized_copy_a(_InputIterator, _InputIterator, _ForwardIterator, std::allocator<_Tp>&) [with _InputIterator = __gnu_cxx::__normal_iterator<const char* const*, std::vector<const char* const, std::allocator<const char* const> > >; _ForwardIterator = const char* const*; _Tp = const char* const]'
DEBUG: /usr/include/c++/8/bits/stl_vector.h:463:31:   required from 'std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = const char* const; _Alloc = std::allocator<const char* const>]'
DEBUG: /opt/ros/galactic/src/gmock_vendor/include/gmock/gmock-matchers.h:3131:7:   required from 'testing::internal::PredicateFormatterFromMatcher<M> testing::internal::MakePredicateFormatterFromMatcher(M) [with M = testing::internal::ElementsAreArrayMatcher<const char* const>]'
DEBUG: /builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/test/test_joint_state_broadcaster.cpp:701:5:   required from here
DEBUG: /usr/include/c++/8/bits/stl_construct.h:75:13: error: invalid static_cast from type 'const char* const*' to type 'void*'
DEBUG:      { ::new(static_cast<void*>(__p)) _T1(std::forward<_Args>(__args)...); }
DEBUG:              ^~~~~~~~~~~~~~~~~~~~~~~
DEBUG: make[2]: Leaving directory '/builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/obj-x86_64-redhat-linux-gnu'
DEBUG: make[1]: Leaving directory '/builddir/build/BUILD/ros-galactic-joint-state-broadcaster-1.4.0/obj-x86_64-redhat-linux-gnu'
DEBUG: make[2]: *** [CMakeFiles/test_joint_state_broadcaster.dir/build.make:79: CMakeFiles/test_joint_state_broadcaster.dir/test/test_joint_state_broadcaster.cpp.o] Error 1
DEBUG: make[1]: *** [CMakeFiles/Makefile2:236: CMakeFiles/test_joint_state_broadcaster.dir/all] Error 2
DEBUG: make: *** [Makefile:149: all] Error 2
```

</details>