### PR TITLE
Add parameter to disable closed loop PID adapter manually

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -164,6 +164,8 @@ protected:
   bool has_acceleration_command_interface_ = false;
   bool has_effort_command_interface_ = false;
 
+  bool disable_closed_loop_pid_adapter_ = false;
+
   /// If true, a velocity feedforward term plus corrective PID term is used
   bool use_closed_loop_pid_adapter_ = false;
   using PidPtr = std::shared_ptr<control_toolbox::Pid>;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -60,6 +60,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
       auto_declare<std::vector<std::string>>("command_interfaces", command_interface_types_);
     state_interface_types_ =
       auto_declare<std::vector<std::string>>("state_interfaces", state_interface_types_);
+    disable_closed_loop_pid_adapter_ =
+      auto_declare<bool>("disable_closed_loop_pid_adapter", disable_closed_loop_pid_adapter_);
     allow_partial_joints_goal_ =
       auto_declare<bool>("allow_partial_joints_goal", allow_partial_joints_goal_);
     open_loop_control_ = auto_declare<bool>("open_loop_control", open_loop_control_);
@@ -515,6 +517,9 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
     return CallbackReturn::FAILURE;
   }
 
+  disable_closed_loop_pid_adapter_ =
+    get_node()->get_parameter("disable_closed_loop_pid_adapter").as_bool();
+
   // Check if only allowed interface types are used and initialize storage to avoid memory
   // allocation during activation
   joint_command_interface_.resize(allowed_interface_types_.size());
@@ -548,7 +553,17 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
     // if there is only velocity then use also PID adapter
     if (command_interface_types_.size() == 1)
     {
-      use_closed_loop_pid_adapter_ = true;
+      if (!disable_closed_loop_pid_adapter_)
+      {
+        use_closed_loop_pid_adapter_ = true;
+      }
+      else
+      {
+        RCLCPP_WARN(
+          logger,
+          "Using only 'velocity' command interface without closed loop PID adapter because it is "
+          "disabled.");
+      }
     }
     else if (!has_position_command_interface_)
     {
@@ -574,7 +589,17 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
   {
     if (command_interface_types_.size() == 1)
     {
-      use_closed_loop_pid_adapter_ = true;
+      if (!disable_closed_loop_pid_adapter_)
+      {
+        use_closed_loop_pid_adapter_ = true;
+      }
+      else
+      {
+        RCLCPP_WARN(
+          logger,
+          "Using only 'effort' command interface without closed loop PID adapter because it is "
+          "disabled.");
+      }
     }
     else
     {
@@ -1137,7 +1162,7 @@ void JointTrajectoryController::sort_to_local_joint_order(
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg)
 {
   // rearrange all points in the trajectory message based on mapping
-  std::vector<size_t> mapping_vector = mapping(trajectory_msg->joint_names, joint_names_);
+  std::vector<size_t> mapping_vector = mapping(trajectory_msg->joint_names, command_joint_names_);
   auto remap = [this](
                  const std::vector<double> & to_remap,
                  const std::vector<size_t> & mapping) -> std::vector<double>
@@ -1149,7 +1174,9 @@ void JointTrajectoryController::sort_to_local_joint_order(
     if (to_remap.size() != mapping.size())
     {
       RCLCPP_WARN(
-        get_node()->get_logger(), "Invalid input size (%zu) for sorting", to_remap.size());
+        get_node()->get_logger(),
+        "Invalid input size for sorting. Values have size %zu and mapping size %zu",
+        to_remap.size(), mapping.size());
       return to_remap;
     }
     std::vector<double> output;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1162,7 +1162,7 @@ void JointTrajectoryController::sort_to_local_joint_order(
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg)
 {
   // rearrange all points in the trajectory message based on mapping
-  std::vector<size_t> mapping_vector = mapping(trajectory_msg->joint_names, command_joint_names_);
+  std::vector<size_t> mapping_vector = mapping(trajectory_msg->joint_names, joint_names_);
   auto remap = [this](
                  const std::vector<double> & to_remap,
                  const std::vector<size_t> & mapping) -> std::vector<double>

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -95,6 +95,48 @@ TEST_P(TrajectoryControllerTestParameterized, configure_state_ignores_commands)
   executor.cancel();
 }
 
+TEST_P(TrajectoryControllerTestParameterized, check_use_of_closed_loop_pid_adapter)
+{
+  SetUpTrajectoryController();
+
+  const auto state = traj_controller_->get_node()->configure();
+  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+
+  EXPECT_FALSE(traj_controller_->get_disable_closed_loop_pid_adapter());  // default value
+
+  // closed loop PID adapter will be use when velocity- or effort-only interfaces are used
+  if (
+    command_interface_types_.size() == 1 &&
+    (std::find(command_interface_types_.begin(), command_interface_types_.end(), "velocity") !=
+       command_interface_types_.end() ||
+     std::find(command_interface_types_.begin(), command_interface_types_.end(), "effort") !=
+       command_interface_types_.end()))
+  {
+    EXPECT_TRUE(traj_controller_->get_use_closed_loop_pid_adapter());
+  }
+  else
+  {
+    EXPECT_FALSE(traj_controller_->get_use_closed_loop_pid_adapter());
+  }
+}
+
+TEST_P(TrajectoryControllerTestParameterized, check_disabling_of_closed_loop_pid_adapter)
+{
+  SetUpTrajectoryController();
+
+  // set command_joints parameter
+  const rclcpp::Parameter disable_param("disable_closed_loop_pid_adapter", true);
+  traj_controller_->get_node()->set_parameter({disable_param});
+
+  const auto state = traj_controller_->get_node()->configure();
+  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+
+  EXPECT_TRUE(traj_controller_->get_disable_closed_loop_pid_adapter());
+
+  // closed loop PID adapter is always disabled, independently from the used interfaces
+  EXPECT_FALSE(traj_controller_->get_use_closed_loop_pid_adapter());
+}
+
 TEST_P(TrajectoryControllerTestParameterized, activate)
 {
   SetUpTrajectoryController();

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -102,6 +102,10 @@ public:
 
   bool has_effort_command_interface() { return has_effort_command_interface_; }
 
+  bool get_disable_closed_loop_pid_adapter() { return disable_closed_loop_pid_adapter_; }
+
+  bool get_use_closed_loop_pid_adapter() { return use_closed_loop_pid_adapter_; }
+
   rclcpp::WaitSet joint_cmd_sub_wait_set_;
 };
 


### PR DESCRIPTION
Enable disabling closed-loop PID in JTC when velocity-only interfaces are used.

This is useful in cases where only velocity output should be used but closed-loop PID should not be used. 
For example when there are no state interfaces available or cotroller is used in a chain and state interfaces can not be directly used for calculation.
