### PR TITLE
fix: :bug: make bare exceptions more narrow

### DIFF
--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_limits_urdf.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_limits_urdf.py
@@ -66,7 +66,7 @@ def get_joint_limits(node, key="robot_description", use_smallest_joint_limits=Tr
                 name = child.getAttribute("name")
                 try:
                     limit = child.getElementsByTagName("limit")[0]
-                except:
+                except IndexError:
                     continue
                 if jtype == "continuous":
                     minval = -pi
@@ -75,11 +75,11 @@ def get_joint_limits(node, key="robot_description", use_smallest_joint_limits=Tr
                     try:
                         minval = float(limit.getAttribute("lower"))
                         maxval = float(limit.getAttribute("upper"))
-                    except:
+                    except ValueError:
                         continue
                 try:
                     maxvel = float(limit.getAttribute("velocity"))
-                except:
+                except ValueError:
                     continue
                 safety_tags = child.getElementsByTagName("safety_controller")
                 if use_small and len(safety_tags) == 1:

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -321,7 +321,7 @@ class JointTrajectoryController(Plugin):
 
                 par = partial(self._update_single_cmd_cb, name=name)
                 joint_widget.valueChanged.connect(par)
-        except:
+        except Exception:
             # TODO: Can we do better than swallow the exception?
             from sys import exc_info
 
@@ -350,7 +350,7 @@ class JointTrajectoryController(Plugin):
         # Stop updating the joint positions
         try:
             self.jointStateChanged.disconnect(self._on_joint_state_change)
-        except:
+        except Exception:
             pass
 
         # Reset ROS interfaces


### PR DESCRIPTION
- fixes pre-commit pipeline

For `joint_limits_urdf.py`, I was able to determine the exception they were looking for and put those but for `joint_trajectory_controller.py` it was unclear to me if they were just trying to do a general exception or were looking for something specific and just didn't put it. For the second case, the fix is still better because it will ignore exceptions not based on `Exception` (ex. SigInt) and fail those how one would expect. If anyone knows what exactly the excepts are looking for or if it was just a general catch, feel free to comment what your know, especially @Noel215 since you ported it (though I understand if you don't know either).