### PR TITLE
Add an initialization of the gripper action command to load current joint position.

### DIFF
--- a/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
+++ b/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
@@ -298,6 +298,7 @@ controller_interface::CallbackReturn GripperActionController<HardwareInterface>:
   // Command - non RT version
   command_struct_.position_ = joint_position_state_interface_->get().get_value();
   command_struct_.max_effort_ = default_max_effort_;
+  command_.initRT(command_struct_);
 
   // Result
   pre_alloc_result_ = std::make_shared<control_msgs::action::GripperCommand::Result>();


### PR DESCRIPTION
The gripper action controller is missing an initialization of the `command_` instance to load current joint position.
This causes that the controller moves focely a joint to 0 position at startup.

This PR adds an initialization to fix it.

This PR solves same problem of https://github.com/ros-controls/ros2_controllers/pull/311 with differing approach.

Reference: the init implementation of ROS 1 gripper action controller:
https://github.com/ros-controls/ros_controllers/blob/252d6584b17ae88e614a6c9cd30ba76ef258a193/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h#L91-L97