### PR TITLE
[joint_state_broadcaster] Duplication while switching controllers

### DIFF
--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -207,6 +207,8 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
 controller_interface::CallbackReturn JointStateBroadcaster::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  joint_names_.clear();
+
   return CallbackReturn::SUCCESS;
 }
 
@@ -229,7 +231,7 @@ bool has_any_key(
 
 bool JointStateBroadcaster::init_joint_data()
 {
-  joint_names_.clear()
+  joint_names_.clear();
   if (state_interfaces_.empty())
   {
     return false;

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -229,6 +229,7 @@ bool has_any_key(
 
 bool JointStateBroadcaster::init_joint_data()
 {
+  joint_names_.clear()
   if (state_interfaces_.empty())
   {
     return false;


### PR DESCRIPTION
**Environment:**
 - OS: Ubuntu 20.04 (wsl2)
 - Version: Foxy
 
**Bug**
Hello ROS developers,

I'm reporting this bug and the solution that I found for it. 

I'm using joint_state_broadcaster with a simulation tool. To avoid overprocessing while the simulator is not running, I have used the switch_controllers to stop the controllers and broadcaster while the simulation is not running and to start them while the simulation is running. But, when starting the simulation, the current /joint_states topic was showing this:

```bash
header:
  stamp:
    sec: 1662134819
    nanosec: 730290179
  frame_id: ''
name:
- Dobot_motor1
- Dobot_motor2
- Dobot_motor3
- Dobot_motor4
position:
- -2.384185791015625e-07
- 0.00028073787689208984
- -0.00013053417205810547
- -8.344650268554688e-06
velocity:
- 0.0
- 0.0
- 0.0
- 0.0
effort:
- -0.009952184744179249
- 2.135138511657715
- 0.002720828400924802
- 8.040420652832836e-05
---
```

Until here, everything has worked fine, but when I stop the simulation and starts over again using ros2_control switch_controllers methods, this showed up:

```bash
header:
  stamp:
    sec: 1662134143
    nanosec: 464578297
  frame_id: ''
name:
- Dobot_motor1
- Dobot_motor2
- Dobot_motor3
- Dobot_motor4
- Dobot_motor1
- Dobot_motor2
- Dobot_motor3
- Dobot_motor4
position:
- -2.384185791015625e-07
- 0.00028002262115478516
- -0.0001302957534790039
- -9.5367431640625e-06
- -2.384185791015625e-07
- 0.00028002262115478516
- -0.0001302957534790039
- -9.5367431640625e-06
velocity:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
effort:
- -0.009976904839277267
- 2.1356098651885986
- 0.002771728904917836
- 8.056579099502414e-05
- -0.009976904839277267
- 2.1356098651885986
- 0.002771728904917836
- 8.056579099502414e-05
---
```

And doing the same again:

```bash
header:
  stamp:
    sec: 1662134205
    nanosec: 471354288
  frame_id: ''
name:
- Dobot_motor1
- Dobot_motor2
- Dobot_motor3
- Dobot_motor4
- Dobot_motor1
- Dobot_motor2
- Dobot_motor3
- Dobot_motor4
- Dobot_motor1
- Dobot_motor2
- Dobot_motor3
- Dobot_motor4
position:
- -2.384185791015625e-07
- 0.0002802610397338867
- -0.00013053417205810547
- -8.106231689453125e-06
- -2.384185791015625e-07
- 0.0002802610397338867
- -0.00013053417205810547
- -8.106231689453125e-06
- -2.384185791015625e-07
- 0.0002802610397338867
- -0.00013053417205810547
- -8.106231689453125e-06
velocity:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
effort:
- -0.009941835887730122
- 2.1357245445251465
- 0.002745711011812091
- 8.029067248571664e-05
- -0.009941835887730122
- 2.1357245445251465
- 0.002745711011812091
- 8.029067248571664e-05
- -0.009941835887730122
- 2.1357245445251465
- 0.002745711011812091
- 8.029067248571664e-05
---
```
And so on. I have found that inside joint_state_broadcaster.cpp on init_joint_data(), the vector with joint_names_ wasn't cleaned. So, I've added the following line:

```cpp
bool JointStateBroadcaster::init_joint_data()
{
  joint_names_.clear();
  // loop in reverse order, this maintains the order of values at retrieval time
  for (auto si = state_interfaces_.crbegin(); si != state_interfaces_.crend(); si++)
  ...
...
```

That has solved my problem, and I'm supporting this for other users. Maybe other broadcasters and controllers are facing the same bug.