### PR TITLE
Fix the version of generate_parameter_library for CI

### DIFF
--- a/ros2_controllers.rolling.repos
+++ b/ros2_controllers.rolling.repos
@@ -11,7 +11,3 @@ repositories:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
     version: master
-  generate_parameter_library:
-    type: git
-    url: https://github.com/picknikrobotics/generate_parameter_library.git
-    version: 0d8f54aeae41ee49e1b559ee67021019a547d01c

--- a/ros2_controllers.rolling.repos
+++ b/ros2_controllers.rolling.repos
@@ -14,4 +14,4 @@ repositories:
   generate_parameter_library:
     type: git
     url: https://github.com/picknikrobotics/generate_parameter_library.git
-    version: main
+    version: 0d8f54aeae41ee49e1b559ee67021019a547d01c


### PR DESCRIPTION
I am migrating the package tcb_span into its own repo and I don't want to break ros2_control's CI while I am doing that so this PR fixes the version used by CI to the hash just before this upcoming change:

- https://github.com/PickNikRobotics/generate_parameter_library/pull/69
- https://github.com/picknikrobotics/cpp_polyfills.git