### PR TITLE
[backport] Fix for high CPU usage by JTC in gzserver (#428)

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -957,9 +957,12 @@ void JointTrajectoryController::feedback_setup_callback(
   rt_goal->execute();
   rt_active_goal_.writeFromNonRT(rt_goal);
 
+  // Set smartpointer to expire for create_wall_timer to delete previous entry from timer list
+  goal_handle_timer_.reset();
+
   // Setup goal status checking timer
-  goal_handle_timer_ = node_->create_wall_timer(
-    action_monitor_period_.to_chrono<std::chrono::seconds>(),
+  goal_handle_timer_ = get_node()->create_wall_timer(
+    action_monitor_period_.to_chrono<std::chrono::nanoseconds>(),
     std::bind(&RealtimeGoalHandle::runNonRealtime, rt_goal));
 }
 


### PR DESCRIPTION
* Change type cast wall timer period from second to nanoseconds. create_wall_timer() expects delay in nanoseconds (duration object) however the type cast to seconds will result in 0 (if duration is less than 1s) and thus causing timer to be fired non stop resulting in very high CPU usage.

* Reset smartpointer so that create_wall_timer() call can destroy previous trajectory timer. node->create_wall_timer() first removes timers associated with expired smartpointers before servicing current request.  The JTC timer pointer gets overwrite only after the create_wall_timer() returns and thus not able to remove previous trajectory timer resulting in upto two timers running for JTC during trajectory execution.  Althougth the previous timer does nothing but still get fired.

Signed-off-by: Arshad Mehmood <arshad.mehmood@intel.com>

Signed-off-by: Arshad Mehmood <arshad.mehmood@intel.com>