### PR TITLE
Fix undeclared and wrong parameters in controllers.

### DIFF
--- a/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
@@ -102,7 +102,7 @@ void IMUSensorBroadcasterTest::subscribe_and_get_message(sensor_msgs::msg::Imu &
   ASSERT_TRUE(subscription->take(imu_msg, msg_info));
 }
 
-TEST_F(IMUSensorBroadcasterTest, SensorName_InterfaceNames_NotSet)
+TEST_F(IMUSensorBroadcasterTest, SensorName_FrameId_NotSet)
 {
   SetUpIMUBroadcaster();
 
@@ -110,21 +110,18 @@ TEST_F(IMUSensorBroadcasterTest, SensorName_InterfaceNames_NotSet)
   ASSERT_EQ(imu_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
 }
 
-TEST_F(IMUSensorBroadcasterTest, SensorName_FrameId_NotSet)
+TEST_F(IMUSensorBroadcasterTest, SensorName_NotSet)
 {
   SetUpIMUBroadcaster();
 
-  // set the 'interface_names'
-  imu_broadcaster_->get_node()->set_parameter(
-    {"interface_names.angular_velocity.x", "imu_sensor/angular_velocity.x"});
-  imu_broadcaster_->get_node()->set_parameter(
-    {"interface_names.linear_acceleration.z", "imu_sensor/linear_acceleration.z"});
+  // set the 'frame_id'
+  imu_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
-  // configure failed, 'frame_id' parameter not set
+  // configure failed, 'sensor_name' parameter not set
   ASSERT_EQ(imu_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
 }
 
-TEST_F(IMUSensorBroadcasterTest, InterfaceNames_FrameId_NotSet)
+TEST_F(IMUSensorBroadcasterTest, FrameId_NotSet)
 {
   SetUpIMUBroadcaster();
 

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -53,6 +53,7 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_init()
     auto_declare<bool>("use_local_topics", false);
     auto_declare<std::vector<std::string>>("joints", std::vector<std::string>({}));
     auto_declare<std::vector<std::string>>("interfaces", std::vector<std::string>({}));
+    auto_declare<std::vector<std::string>>("extra_joints", std::vector<std::string>({}));
     auto_declare<std::string>(
       std::string("map_interface_to_joint_state.") + HW_IF_POSITION, HW_IF_POSITION);
     auto_declare<std::string>(


### PR DESCRIPTION
This PR add separate commits related to other controller than JTC to get #384 building on CI.
This changes are caused by removal of the autodeclaration of parameters, this means that this parameters where not declared properly or were purely wrong (in IMU broadcaster case).

Recommend to merge before #384.
