### PR TITLE
Remove deprecation warning when parameter without value is set.

### DIFF
--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
@@ -18,6 +18,7 @@
 import rclpy
 from rclpy.node import Node
 from builtin_interfaces.msg import Duration
+from rcl_interfaces.msg import ParameterDescriptor
 
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 from sensor_msgs.msg import JointState
@@ -66,7 +67,7 @@ class PublisherJointTrajectory(Node):
         # Read all positions from parameters
         self.goals = []  # List of JointTrajectoryPoint
         for name in goal_names:
-            self.declare_parameter(name)
+            self.declare_parameter(name, descriptor=ParameterDescriptor(dynamic_typing=True))
             goal = self.get_parameter(name).value
 
             # TODO(anyone): remove this "if" part in ROS Iron


### PR DESCRIPTION
Without this change newest Rolling gives the following warning:

```
[publisher_joint_trajectory_controller-1] /opt/ros/rolling/local/lib/python3.10/dist-packages/rclpy/node.py:462: UserWarning: when declaring parameter named 'pos4', declaring a parameter only providing its name is deprecated. You have to either:
[publisher_joint_trajectory_controller-1]       - Pass a name and a default value different to "PARAMETER NOT SET" (and optionally a descriptor).
[publisher_joint_trajectory_controller-1]       - Pass a name and a parameter type.
[publisher_joint_trajectory_controller-1]       - Pass a name and a descriptor with `dynamic_typing=True
```
