### PR TITLE
Add build_export_dependency on parameter_traits for controllers that …

### DIFF
--- a/force_torque_sensor_broadcaster/package.xml
+++ b/force_torque_sensor_broadcaster/package.xml
@@ -13,6 +13,8 @@
 
   <build_depend>generate_parameter_library</build_depend>
 
+  <build_export_depend>parameter_traits/</build_export_depend>
+
   <depend>controller_interface</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -16,6 +16,8 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>realtime_tools</build_depend>
 
+  <build_export_depend>parameter_traits/</build_export_depend>
+
   <exec_depend>angles</exec_depend>
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>realtime_tools</exec_depend>


### PR DESCRIPTION
…use generate_parameter_library

The generated paramters.hpp file will include <parameter_traits/parameter_traits.hpp> and will itself be included by the controller.hpp files, this is indeed a dependency that should get exported to packages including this controller.hpp.

This currently breaks building [`ur_controllers`](https://build.ros2.org/job/Hbin_uJ64__ur_controllers__ubuntu_jammy_amd64__binary/26/console) on the buildfarm.