### PR TITLE
Fix parameter library export

### DIFF
--- a/admittance_controller/CMakeLists.txt
+++ b/admittance_controller/CMakeLists.txt
@@ -38,15 +38,15 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
 
-add_library(${PROJECT_NAME} SHARED src/admittance_controller.cpp)
-target_include_directories(${PROJECT_NAME} PRIVATE include)
-generate_parameter_library(${PROJECT_NAME}_parameters src/admittance_controller_parameters.yaml)
-target_link_libraries(${PROJECT_NAME} admittance_controller_parameters)
-ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+add_library(admittance_controller SHARED src/admittance_controller.cpp)
+target_include_directories(admittance_controller PRIVATE include)
+generate_parameter_library(admittance_controller_parameters src/admittance_controller_parameters.yaml)
+target_link_libraries(admittance_controller admittance_controller_parameters)
+ament_target_dependencies(admittance_controller ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(${PROJECT_NAME} PRIVATE "ADMITTANCE_CONTROLLER_BUILDING_DLL")
+target_compile_definitions(admittance_controller PRIVATE "ADMITTANCE_CONTROLLER_BUILDING_DLL")
 
 pluginlib_export_plugin_description_file(controller_interface admittance_controller.xml)
 
@@ -54,7 +54,8 @@ install(DIRECTORY include/
   DESTINATION include
 )
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS admittance_controller admittance_controller_parameters
+  EXPORT export_admittance_controller
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -67,23 +68,6 @@ if(BUILD_TESTING)
   find_package(controller_interface REQUIRED)
   find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
-
-  ## create custom test function to pass yaml file into test main
-  #function(add_test_with_yaml_input TARGET SOURCES YAML_FILE)
-    #add_executable(${TARGET} ${SOURCES})
-    #_ament_cmake_gmock_find_gmock()
-    #target_include_directories(${TARGET} PUBLIC "${GMOCK_INCLUDE_DIRS}")
-    #target_link_libraries(${TARGET} ${GMOCK_LIBRARIES})
-    #set(executable "$<TARGET_FILE:${TARGET}>")
-    #set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TARGET}.gtest.xml")
-    #ament_add_test(
-      #${TARGET}
-      #COMMAND ${executable} --ros-args --params-file ${YAML_FILE}
-      #--gtest_output=xml:${result_file}
-      #OUTPUT_FILE ${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TARGET}.txt
-      #RESULT_FILE ${result_file}
-    #)
-  #endfunction()
 
   # test loading admittance controller
   add_rostest_with_parameters_gmock(test_load_admittance_controller test/test_load_admittance_controller.cpp
@@ -110,13 +94,10 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_export_include_directories(
-  include
+ament_export_targets(
+  export_admittance_controller HAS_LIBRARY_TARGET
 )
 ament_export_dependencies(
   ${THIS_PACKAGE_INCLUDE_DEPENDS}
-)
-ament_export_libraries(
-  ${PROJECT_NAME}
 )
 ament_package()

--- a/force_torque_sensor_broadcaster/CMakeLists.txt
+++ b/force_torque_sensor_broadcaster/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
     controller_interface
+    generate_parameter_library
     geometry_msgs
     hardware_interface
     pluginlib
@@ -26,7 +27,6 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
 
-find_package(generate_parameter_library REQUIRED)
 generate_parameter_library(force_torque_sensor_broadcaster_parameters
   src/force_torque_sensor_broadcaster_parameters.yaml
 )
@@ -54,8 +54,8 @@ pluginlib_export_plugin_description_file(
   controller_interface force_torque_sensor_broadcaster.xml)
 
 install(
-  TARGETS
-  ${PROJECT_NAME}
+  TARGETS force_torque_sensor_broadcaster force_torque_sensor_broadcaster_parameters
+  EXPORT export_force_torque_sensor_broadcaster
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -101,11 +101,8 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_export_include_directories(
-  include
-)
-ament_export_libraries(
-  ${PROJECT_NAME}
+ament_export_targets(
+  export_force_torque_sensor_broadcaster HAS_LIBRARY_TARGET
 )
 ament_export_dependencies(
   ${THIS_PACKAGE_INCLUDE_DEPENDS}

--- a/force_torque_sensor_broadcaster/package.xml
+++ b/force_torque_sensor_broadcaster/package.xml
@@ -11,8 +11,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>generate_parameter_library</build_depend>
-
   <depend>controller_interface</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
@@ -20,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>realtime_tools</depend>
+  <depend>generate_parameter_library</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -13,9 +13,10 @@ endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
     angles
-    controller_interface
     control_msgs
     control_toolbox
+    controller_interface
+    generate_parameter_library
     hardware_interface
     pluginlib
     rclcpp
@@ -28,8 +29,6 @@ find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
-
-find_package(generate_parameter_library REQUIRED)
 
 generate_parameter_library(joint_trajectory_controller_parameters
   src/joint_trajectory_controller_parameters.yaml
@@ -52,7 +51,8 @@ install(DIRECTORY include/
   DESTINATION include
 )
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS joint_trajectory_controller joint_trajectory_controller_parameters
+  EXPORT export_joint_trajectory_controller
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -105,13 +105,10 @@ if(BUILD_TESTING)
   # )
 endif()
 
+ament_export_targets(
+  export_joint_trajectory_controller HAS_LIBRARY_TARGET
+)
 ament_export_dependencies(
   ${THIS_PACKAGE_INCLUDE_DEPENDS}
-)
-ament_export_include_directories(
-  include
-)
-ament_export_libraries(
-  ${PROJECT_NAME}
 )
 ament_package()

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>angles</build_depend>
-  <build_depend>generate_parameter_library</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>realtime_tools</build_depend>
 
@@ -27,6 +26,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>trajectory_msgs</depend>
+  <depend>generate_parameter_library</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>


### PR DESCRIPTION
@fmauch

This PR is directed towards fixing the issue experienced by ur_controllers in this PR: #446

In my local testing the changes in #446 did not cuase the ur_controllers code to complete building, it did get it further than the error experienced in the buildfarm.

Instead of using the parameters.xml to export the transitive dependency of `parameter_traits` from the parmaeter library this updates the cmake to export the generated pareamters library and export a dependency on `generate_parameter_library` which exports the dependency on `parameter_traits` in addition to a handful of other dependencies of the parameters interface.

I tested this by building the following workspace on Rolling.
```yaml
repositories:
  Universal_Robots_ROS2_Driver:
    type: git
    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
    version: main
  control_msgs:
    type: git
    url: https://github.com/ros-controls/control_msgs.git
    version: humble
  cpp_polyfills:
    type: git
    url: https://github.com/PickNikRobotics/cpp_polyfills.git
    version: main
  generate_parameter_library:
    type: git
    url: https://github.com/PickNikRobotics/generate_parameter_library.git
    version: main
  realtime_tools:
    type: git
    url: https://github.com/ros-controls/realtime_tools.git
    version: master
  ros2_control:
    type: git
    url: https://github.com/ros-controls/ros2_control.git
    version: master
  ros2_controllers:
    type: git
    url: https://github.com/tylerjw/ros2_controllers.git
    version: fix_gpl_export
```

For reference on the cmake changes for exporting libraries I used this: https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html#building-a-library

Recently I went through fixing a bunch of my other library code and had to learn how all this works again.
