### PR TITLE
Include <string> to fix compilation error on macOS

### DIFF
--- a/tricycle_controller/src/steering_limiter.cpp
+++ b/tricycle_controller/src/steering_limiter.cpp
@@ -16,9 +16,9 @@
  * Author: Tony Najjar
  */
 
-#include <string>
 #include <algorithm>
 #include <stdexcept>
+#include <string>
 
 #include "rcppmath/clamp.hpp"
 #include "tricycle_controller/steering_limiter.hpp"

--- a/tricycle_controller/src/steering_limiter.cpp
+++ b/tricycle_controller/src/steering_limiter.cpp
@@ -16,6 +16,7 @@
  * Author: Tony Najjar
  */
 
+#include <string>
 #include <algorithm>
 #include <stdexcept>
 


### PR DESCRIPTION
On macOS (maybe generalized to systems using `libc++` for the STL), the inclusions of standard headers `algorithm` and `stdexcept` do not include `string` indirectly which leads to compilation error in `tricycle_controller/src/steering_limiter.cpp` when trying to instantiate an instance `const std::string error`.

Simply include `<string>` improves the compatibility with `libc++`.