### PR TITLE
[JTC] Allow ff_velocity_scale=0 without deprecated warning

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -565,14 +565,18 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
 
       // TODO(destogl): remove this in ROS2 Iron
       // Check deprecated style for "ff_velocity_scale" parameter definition.
-      if (gains.ff_velocity_scale == 0.0)
+      double ff_velocity_scale_tmp =
+        auto_declare<double>("ff_velocity_scale/" + params_.joints[i], -1.0);
+      if (ff_velocity_scale_tmp != -1.0)
       {
         RCLCPP_WARN(
           get_node()->get_logger(),
-          "'ff_velocity_scale' parameters is not defined under 'gains.<joint_name>.' structure. "
-          "Maybe you are using deprecated format 'ff_velocity_scale/<joint_name>'!");
+          "You are using deprecated format 'ff_velocity_scale/%s: %f'! "
+          "'ff_velocity_scale' parameters have to be defined under 'gains.<joint_name>.' "
+          "structure. ",
+          command_joint_names_[i].c_str(), ff_velocity_scale_tmp);
 
-        ff_velocity_scale_[i] = auto_declare<double>("ff_velocity_scale/" + params_.joints[i], 0.0);
+        ff_velocity_scale_[i] = ff_velocity_scale_tmp;
       }
       else
       {

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -563,25 +563,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
       pids_[i] = std::make_shared<control_toolbox::Pid>(
         gains.p, gains.i, gains.d, gains.i_clamp, -gains.i_clamp);
 
-      // TODO(destogl): remove this in ROS2 Iron
-      // Check deprecated style for "ff_velocity_scale" parameter definition.
-      double ff_velocity_scale_tmp =
-        auto_declare<double>("ff_velocity_scale/" + params_.joints[i], -1.0);
-      if (ff_velocity_scale_tmp != -1.0)
-      {
-        RCLCPP_WARN(
-          get_node()->get_logger(),
-          "You are using deprecated format 'ff_velocity_scale/%s: %f'! "
-          "'ff_velocity_scale' parameters have to be defined under 'gains.<joint_name>.' "
-          "structure. ",
-          command_joint_names_[i].c_str(), ff_velocity_scale_tmp);
-
-        ff_velocity_scale_[i] = ff_velocity_scale_tmp;
-      }
-      else
-      {
-        ff_velocity_scale_[i] = gains.ff_velocity_scale;
-      }
+      ff_velocity_scale_[i] = gains.ff_velocity_scale;
     }
   }
 


### PR DESCRIPTION
Otherwise I always got this warning when I used a PID controller without feedforward gain.