### PR TITLE
🔧 Fixes and updated on pre-commit hooks and their action

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4.4.0
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install system hooks
-      run: sudo apt install -qq clang-format-12 cppcheck
-    - uses: pre-commit/action@v2.0.3
+      run: sudo apt install -qq clang-format-14 cppcheck
+    - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files --hook-stage manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
       - id: clang-format
         name: clang-format
         description: Format files with ClangFormat.
-        entry: clang-format-12
+        entry: clang-format-14
         language: system
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
         args: ['-fallback-style=none', '-i']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
 
   # PyDocStyle
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.2.3
+    rev: 6.2.2
     hooks:
     - id: pydocstyle
       args: ["--ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -33,26 +33,26 @@ repos:
 
   # Python hooks
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v3.3.1
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.12.0
     hooks:
       - id: black
         args: ["--line-length=99"]
 
-  # PEP 257
-  - repo: https://github.com/FalconSocial/pre-commit-mirrors-pep257
-    rev: v0.3.3
+  # PyDocStyle
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.2.3
     hooks:
-    - id: pep257
+    - id: pydocstyle
       args: ["--ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404"]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
     - id: flake8
       args: ["--ignore=E501"]
@@ -119,7 +119,7 @@ repos:
 
   # Docs - RestructuredText hooks
   - repo: https://github.com/PyCQA/doc8
-    rev: v1.0.0
+    rev: v1.1.1
     hooks:
       - id: doc8
         args: ['--max-line-length=100', '--ignore=D001']
@@ -136,7 +136,7 @@ repos:
   # Spellcheck in comments and docs
   # skipping of *.svg files is not working...
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell
         args: ['--write-changes', '--uri-ignore-words-list=ist']

--- a/rqt_joint_trajectory_controller/resource/joint_trajectory_controller.ui
+++ b/rqt_joint_trajectory_controller/resource/joint_trajectory_controller.ui
@@ -31,7 +31,7 @@
         <item row="0" column="0">
          <widget class="QLabel" name="cm_list_label">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;controller manager&lt;/span&gt; namespace. It is assumed that the &lt;span style=&quot; font-weight:600;&quot;&gt;robot_description&lt;/span&gt; parameter also lives in the same namesapce.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;controller manager&lt;/span&gt; namespace. It is assumed that the &lt;span style=&quot; font-weight:600;&quot;&gt;robot_description&lt;/span&gt; parameter also lives in the same namespace.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>controller manager ns</string>

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/update_combo.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/update_combo.py
@@ -48,7 +48,8 @@ def update_combo(combo, new_vals):
 
 
 def _is_permutation(a, b):
-    """Check is arrays are permutation of each other.
+    """
+    Check is arrays are permutation of each other.
 
     @type a [] first array with values to compare with the second one.
     @type b [] second array with values to compare with the first one.


### PR DESCRIPTION
- Use pydocstyle instead of pep257 because it replaces it.
- Bump versions of hooks.
- Remove fixed python version from formatting action.
- Fix action warnings about Node.js 12 by updating them.
- Bump version of clang-format.
