### PR TITLE
diff_drive base_frame_id param - default value

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller_parameter.yaml
+++ b/diff_drive_controller/src/diff_drive_controller_parameter.yaml
@@ -46,7 +46,7 @@ diff_drive_controller:
   }
   base_frame_id: {
     type: string,
-    default_value: "odom",
+    default_value: "base_link",
     description: "Name of the robot's base frame that is child of the odometry frame.",
   }
   pose_covariance_diagonal: {


### PR DESCRIPTION
I think the most common `base_frame_id` would be the `base_link` value.
Furthermore the default diff_drive_controller parameters make `odom` -> `odom` transform.

Found issue:
https://github.com/ros-controls/ros2_controllers/issues/482