### PR TITLE
Changing to_chrono to use nanoseconds

### DIFF
--- a/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
+++ b/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
@@ -105,6 +105,10 @@ void GripperActionController<HardwareInterface>::accepted_callback(
     rt_active_goal_ = rt_goal;
     rt_active_goal_->execute();
   }
+
+  // Set smartpointer to expire for create_wall_timer to delete previous entry from timer list
+  goal_handle_timer_.reset();
+
   // Setup goal status checking timer
   goal_handle_timer_ = get_node()->create_wall_timer(
     action_monitor_period_.to_chrono<std::chrono::nanoseconds>(),

--- a/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
+++ b/gripper_controllers/include/gripper_controllers/gripper_action_controller_impl.hpp
@@ -107,7 +107,7 @@ void GripperActionController<HardwareInterface>::accepted_callback(
   }
   // Setup goal status checking timer
   goal_handle_timer_ = get_node()->create_wall_timer(
-    action_monitor_period_.to_chrono<std::chrono::seconds>(),
+    action_monitor_period_.to_chrono<std::chrono::nanoseconds>(),
     std::bind(&RealtimeGoalHandle::runNonRealtime, rt_active_goal_));
 }
 


### PR DESCRIPTION
Previously std::chrono::seconds, which rounds to 0 if action_monitor_period_ < 1