### PR TITLE
Fix JTC segfault on unload

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -888,8 +888,11 @@ controller_interface::CallbackReturn JointTrajectoryController::on_cleanup(
   const rclcpp_lifecycle::State &)
 {
   // go home
-  traj_home_point_ptr_->update(traj_msg_home_ptr_);
-  traj_point_active_ptr_ = &traj_home_point_ptr_;
+  if (traj_home_point_ptr_ != nullptr)
+  {
+    traj_home_point_ptr_->update(traj_msg_home_ptr_);
+    traj_point_active_ptr_ = &traj_home_point_ptr_;
+  }
 
   return CallbackReturn::SUCCESS;
 }

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -349,6 +349,22 @@ TEST_P(TrajectoryControllerTestParameterized, cleanup)
   executor.cancel();
 }
 
+TEST_P(TrajectoryControllerTestParameterized, cleanup_after_configure)
+{
+  rclcpp::executors::MultiThreadedExecutor executor;
+  SetUpTrajectoryController(executor);
+
+  // configure controller
+  auto state = traj_controller_->get_node()->configure();
+  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+
+  // cleanup controller
+  state = traj_controller_->get_node()->cleanup();
+  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+
+  executor.cancel();
+}
+
 TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_parameters)
 {
   rclcpp::executors::MultiThreadedExecutor executor;


### PR DESCRIPTION
Based on the discussion in #423 - the traj_home_point_ptr_ is a nullptr until the node is activated, so unloading from configured state (if no activation happened before) results in a segfault.
