### PR TITLE
Fix Interpolation Logic

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/interpolation_methods.hpp
@@ -45,7 +45,7 @@ const std::unordered_map<InterpolationMethod, std::string> InterpolationMethodMa
     return InterpolationMethod::NONE;
   }
   else if (
-    !interpolation_method.compare(
+    interpolation_method.compare(
       InterpolationMethodMap.at(InterpolationMethod::VARIABLE_DEGREE_SPLINE)) == 0)
   {
     return InterpolationMethod::VARIABLE_DEGREE_SPLINE;


### PR DESCRIPTION
Within the `from_string` function, there is logic being performed to determine what interpolation method to use for the Joint Trajectory Controller. Currently, the logic to check if 'splines' is being used seems to say... if the specified interpolation method is not equal to splines, then return the splines interpolation method. This doesn't make sense to me. I think the check should really be _if the specified interpolation method is equal to splines, then return the splines interpolation method._

Since there are only two options currently, this does not cause any breaking change (as we first check to see if 'None' is specified). However, if there were three or more interpolation methods, then the check in its current state will return either 'None' or Splines only.

@AndyZe, @mechwiz 