### PR TITLE
Fix JTC segfault

### DIFF
--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -64,7 +64,6 @@ bool Trajectory::sample(
   TrajectoryPointConstIter & start_segment_itr, TrajectoryPointConstIter & end_segment_itr)
 {
   THROW_ON_NULLPTR(trajectory_msg_)
-  output_state = trajectory_msgs::msg::JointTrajectoryPoint();
 
   if (trajectory_msg_->points.empty())
   {
@@ -90,6 +89,7 @@ bool Trajectory::sample(
     return false;
   }
 
+  output_state = trajectory_msgs::msg::JointTrajectoryPoint();
   auto & first_point_in_msg = trajectory_msg_->points[0];
   const rclcpp::Time first_point_timestamp =
     trajectory_start_time_ + first_point_in_msg.time_from_start;


### PR DESCRIPTION
@swiz23 noticed a segfault in the JTC specifically when aborting a motion, followed by deactivating, followed by activating where the segfault would occur. After looking at this PR, I think it very much has to do with the line
[output_state = trajectory_msgs::msg::JointTrajectoryPoint()](https://github.com/ros-controls/ros2_controllers/blob/master/joint_trajectory_controller/src/trajectory.cpp#L67).
I think the flow of events occur as follows:

When aborting, set_hold_position() is called. That essentially adds and writes an empty trajectory message in order to disregard the current one.
When sample() is called in the update() loop, state_desired_ gets overwritten with that empty trajectory point meaning it has an empty position, velocity, and acceleration array.
The controllers get deactivated
The controllers get reactivated. When this happens, read_state_frome_hardware is called on state_desired_. Within that function, we try to index the position array within state_deisred_ as if it has the same size as dof_ when it in fact no longer does. This causes the segault.
The solution is to simply move the line defining the output_state within the sample() function in trajectory.cpp to after the last possible place that the function can return false -> [here](https://github.com/ros-controls/ros2_controllers/blob/master/joint_trajectory_controller/src/trajectory.cpp#L92). I tested this out at least for the case that @swiz23 had issues with and verified that there was no longer a segfault.

This probably fixes #423 
@JafarAbdi 