### PR TITLE
Remove compile warnings.

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -150,7 +150,7 @@ controller_interface::return_type DiffDriveController::update(
   {
     double left_feedback_mean = 0.0;
     double right_feedback_mean = 0.0;
-    for (size_t index = 0; index < params_.wheels_per_side; ++index)
+    for (size_t index = 0; index < static_cast<size_t>(params_.wheels_per_side); ++index)
     {
       const double left_feedback = registered_left_wheel_handles_[index].feedback.get().get_value();
       const double right_feedback =
@@ -244,7 +244,7 @@ controller_interface::return_type DiffDriveController::update(
     (linear_command + angular_command * wheel_separation / 2.0) / right_wheel_radius;
 
   // Set wheels velocities:
-  for (size_t index = 0; index < params_.wheels_per_side; ++index)
+  for (size_t index = 0; index < static_cast<size_t>(params_.wheels_per_side); ++index)
   {
     registered_left_wheel_handles_[index].velocity.get().set_value(velocity_left);
     registered_right_wheel_handles_[index].velocity.get().set_value(velocity_right);

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -19,8 +19,8 @@
 #include "hardware_interface/macros.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/time.hpp"
-#include "rcppmath/clamp.hpp"
 #include "std_msgs/msg/header.hpp"
+
 namespace joint_trajectory_controller
 {
 Trajectory::Trajectory() : trajectory_start_time_(0), time_before_traj_msg_(0) {}


### PR DESCRIPTION
- remove unused include from `trajectory.cpp` (clamp.hpp)
- explicitly cast members in for loop to avoid comparison warnings (diff drive controller)

