### PR TITLE
Fix Segfault in GripperActionController

### DIFF
--- a/gripper_controllers/include/gripper_controllers/gripper_action_controller.hpp
+++ b/gripper_controllers/include/gripper_controllers/gripper_action_controller.hpp
@@ -135,7 +135,8 @@ protected:
 
   HwIfaceAdapter hw_iface_adapter_;  ///< Adapts desired goal state to HW interface.
 
-  RealtimeGoalHandleBuffer rt_active_goal_;  ///< Container for the currently active action goal, if any.
+  RealtimeGoalHandleBuffer
+    rt_active_goal_;  ///< Container for the currently active action goal, if any.
   control_msgs::action::GripperCommand::Result::SharedPtr pre_alloc_result_;
 
   rclcpp::Duration action_monitor_period_;

--- a/gripper_controllers/include/gripper_controllers/gripper_action_controller.hpp
+++ b/gripper_controllers/include/gripper_controllers/gripper_action_controller.hpp
@@ -115,6 +115,7 @@ protected:
   using RealtimeGoalHandle =
     realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>;
   using RealtimeGoalHandlePtr = std::shared_ptr<RealtimeGoalHandle>;
+  using RealtimeGoalHandleBuffer = realtime_tools::RealtimeBuffer<RealtimeGoalHandlePtr>;
 
   using HwIfaceAdapter = HardwareInterfaceAdapter<HardwareInterface>;
 
@@ -134,7 +135,7 @@ protected:
 
   HwIfaceAdapter hw_iface_adapter_;  ///< Adapts desired goal state to HW interface.
 
-  RealtimeGoalHandlePtr rt_active_goal_;  ///< Currently active action goal, if any.
+  RealtimeGoalHandleBuffer rt_active_goal_;  ///< Container for the currently active action goal, if any.
   control_msgs::action::GripperCommand::Result::SharedPtr pre_alloc_result_;
 
   rclcpp::Duration action_monitor_period_;


### PR DESCRIPTION
We have occasionally observed segfaults in the GripperActionController, particularly when pre-empting an executing goal. As far as I can tell the source is the shared goal handle pointer being reset while the action monitor loop is running.

This change wraps the raw `shared_ptr` for the `RealtimeGoalHandlePtr` in a `RealtimeBuffer`, and provides thread-safe access to the executing goal (if present) through the buffer. This is inline with other controller implementations, like the [JointTrajectoryController](https://github.com/ros-controls/ros2_controllers/blob/master/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp#L204).

Sample backtrace:

```
Thread 31 "ruby" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0xffffb5fbf100 (LWP 1728392)]
0x0000ffff5c35c230 in realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::runNonRealtime (this=0x0) at /opt/ros/humble/include/realtime_tools/realtime_server_goal_handle.h:142
142        if (!valid()) {return;}
(gdb) bt
#0  0x0000ffff5c35c230 in realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::runNonRealtime (this=0x0) at /opt/ros/humble/include/realtime_tools/realtime_server_goal_handle.h:142
#1  0x0000ffff5c358ab4 in std::__invoke_impl<void, void (realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::*&)(), std::shared_ptr<realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand> >&> (
    __t=std::shared_ptr<realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>> (empty) = {...}, __f=@0xffffa0162c50: (void (realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::*)(realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand> * const)) 0xffff5c35c210 <realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::runNonRealtime()>) at /usr/include/c++/11/bits/invoke.h:74
#2  std::__invoke<void (realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::*&)(), std::shared_ptr<realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand> >&> (
    __fn=@0xffffa0162c50: (void (realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::*)(realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand> * const)) 0xffff5c35c210 <realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::runNonRealtime()>) at /usr/include/c++/11/bits/invoke.h:96
#3  std::_Bind<void (realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::*(std::shared_ptr<realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand> >))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (__args=..., this=0xffffa0162c50) at /usr/include/c++/11/functional:420
#4  std::_Bind<void (realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::*(std::shared_ptr<realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand> >))()>::operator()<, void>() (
    this=0xffffa0162c50) at /usr/include/c++/11/functional:503
#5  rclcpp::GenericTimer<std::_Bind<void (realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::*(std::shared_ptr<realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand> >))()>, (void*)0>::execute_callback_delegate<std::_Bind<void (realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::*(std::shared_ptr<realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand> >))()>, (void*)0>() (
    this=0xffffa0162c20) at /opt/ros/humble/include/rclcpp/rclcpp/timer.hpp:244
#6  rclcpp::GenericTimer<std::_Bind<void (realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>::*(std::shared_ptr<realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand> >))()>, (void*)0>::execute_callback() (this=0xffffa0162c20) at /opt/ros/humble/include/rclcpp/rclcpp/timer.hpp:230
#7  0x0000ffffceea804c in rclcpp::Executor::execute_any_executable(rclcpp::AnyExecutable&) ()
   from /opt/ros/humble/lib/librclcpp.so
#8  0x0000ffffceea980c in rclcpp::Executor::spin_once_impl(std::chrono::duration<long, std::ratio<1l, 1000000000l> >)
    () from /opt/ros/humble/lib/librclcpp.so
#9  0x0000ffffcee9f334 in rclcpp::Executor::spin_once(std::chrono::duration<long, std::ratio<1l, 1000000000l> >) ()
   from /opt/ros/humble/lib/librclcpp.so
#10 0x0000ffffcf14b104 in operator() (__closure=0xaaaab30ab9d8) at /usr/include/c++/11/chrono:521
#11 std::__invoke_impl<void, ign_ros2_control::IgnitionROS2ControlPlugin::Configure(const Entity&, const std::shared_ptr<const sdf::v12::Element>&, ignition::gazebo::v6::EntityComponentManager&, ignition::gazebo::v6::EventManager&)::<lambda()> > (__f=...) at /usr/include/c++/11/bits/invoke.h:61
#12 std::__invoke<ign_ros2_control::IgnitionROS2ControlPlugin::Configure(const Entity&, const std::shared_ptr<const sdf::v12::Element>&, ignition::gazebo::v6::EntityComponentManager&, ignition::gazebo::v6::EventManager&)::<lambda()> > (
    __fn=...) at /usr/include/c++/11/bits/invoke.h:96
#13 std::thread::_Invoker<std::tuple<ign_ros2_control::IgnitionROS2ControlPlugin::Configure(const Entity&, const std::shared_ptr<const sdf::v12::Element>&, ignition::gazebo::v6::EntityComponentManager&, ignition::gazebo::v6::EventManager&)::<lambda()> > >::_M_invoke<0> (this=0xaaaab30ab9d8) at /usr/include/c++/11/bits/std_thread.h:253
#14 std::thread::_Invoker<std::tuple<ign_ros2_control::IgnitionROS2ControlPlugin::Configure(const Entity&, const std::shared_ptr<const sdf::v12::Element>&, ignition::gazebo::v6::EntityComponentManager&, ignition::gazebo::v6::EventManager&)::<lambda()> > >::operator() (this=0xaaaab30ab9d8) at /usr/include/c++/11/bits/std_thread.h:260
#15 std::thread::_State_impl<std::thread::_Invoker<std::tuple<ign_ros2_control::IgnitionROS2ControlPlugin::Configure(const Entity&, const std::shared_ptr<const sdf::v12::Element>&, ignition::gazebo::v6::EntityComponentManager&, ignition::gazebo::v6::EventManager&)::<lambda()> > > >::_M_run(void) (this=0xaaaab30ab9d0)
    at /usr/include/c++/11/bits/std_thread.h:211
#16 0x0000fffff3a831fc in ?? () from /lib/aarch64-linux-gnu/libstdc++.so.6
#17 0x0000fffff7aed5c8 in start_thread (arg=0x0) at ./nptl/pthread_create.c:442
#18 0x0000fffff7b55d1c in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:79
```