### PR TITLE
Use std::clamp instead of rcppmath::clamp

### DIFF
--- a/tricycle_controller/src/steering_limiter.cpp
+++ b/tricycle_controller/src/steering_limiter.cpp
@@ -76,7 +76,7 @@ double SteeringLimiter::limit(double & p, double p0, double p1, double dt)
 double SteeringLimiter::limit_position(double & p)
 {
   const double tmp = p;
-  p = rcppmath::clamp(p, min_position_, max_position_);
+  p = std::clamp(p, min_position_, max_position_);
 
   return tmp != 0.0 ? p / tmp : 1.0;
 }
@@ -88,7 +88,7 @@ double SteeringLimiter::limit_velocity(double & p, double p0, double dt)
   const double dv_min = min_velocity_ * dt;
   const double dv_max = max_velocity_ * dt;
 
-  double dv = rcppmath::clamp(std::fabs(p - p0), dv_min, dv_max);
+  double dv = std::clamp(std::fabs(p - p0), dv_min, dv_max);
   dv *= (p - p0 >= 0 ? 1 : -1);
   p = p0 + dv;
 
@@ -107,7 +107,7 @@ double SteeringLimiter::limit_acceleration(double & p, double p0, double p1, dou
   const double da_min = min_acceleration_ * dt2;
   const double da_max = max_acceleration_ * dt2;
 
-  double da = rcppmath::clamp(std::fabs(dv - dp0), da_min, da_max);
+  double da = std::clamp(std::fabs(dv - dp0), da_min, da_max);
   da *= (dv - dp0 >= 0 ? 1 : -1);
   p = p0 + dp0 + da;
 

--- a/tricycle_controller/src/steering_limiter.cpp
+++ b/tricycle_controller/src/steering_limiter.cpp
@@ -20,7 +20,6 @@
 #include <stdexcept>
 #include <string>
 
-#include "rcppmath/clamp.hpp"
 #include "tricycle_controller/steering_limiter.hpp"
 
 namespace tricycle_controller

--- a/tricycle_controller/src/traction_limiter.cpp
+++ b/tricycle_controller/src/traction_limiter.cpp
@@ -20,7 +20,6 @@
 #include <stdexcept>
 #include <string>
 
-#include "rcppmath/clamp.hpp"
 #include "tricycle_controller/traction_limiter.hpp"
 
 namespace tricycle_controller

--- a/tricycle_controller/src/traction_limiter.cpp
+++ b/tricycle_controller/src/traction_limiter.cpp
@@ -91,7 +91,7 @@ double TractionLimiter::limit_velocity(double & v)
 {
   const double tmp = v;
 
-  v = rcppmath::clamp(std::fabs(v), min_velocity_, max_velocity_);
+  v = std::clamp(std::fabs(v), min_velocity_, max_velocity_);
 
   v *= tmp >= 0 ? 1 : -1;
   return tmp != 0.0 ? v / tmp : 1.0;
@@ -113,7 +113,7 @@ double TractionLimiter::limit_acceleration(double & v, double v0, double dt)
     dv_min = min_deceleration_ * dt;
     dv_max = max_deceleration_ * dt;
   }
-  double dv = rcppmath::clamp(std::fabs(v - v0), dv_min, dv_max);
+  double dv = std::clamp(std::fabs(v - v0), dv_min, dv_max);
   dv *= (v - v0 >= 0 ? 1 : -1);
   v = v0 + dv;
 
@@ -132,7 +132,7 @@ double TractionLimiter::limit_jerk(double & v, double v0, double v1, double dt)
   const double da_min = min_jerk_ * dt2;
   const double da_max = max_jerk_ * dt2;
 
-  double da = rcppmath::clamp(std::fabs(dv - dv0), da_min, da_max);
+  double da = std::clamp(std::fabs(dv - dv0), da_min, da_max);
   da *= (dv - dv0 >= 0 ? 1 : -1);
   v = v0 + dv0 + da;
 


### PR DESCRIPTION
`rcppmath::clamp` throws a deprecated warning now.