### PR TITLE
Removed auto param decl

### DIFF
--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -167,7 +167,7 @@ protected:
     auto options = rclcpp::NodeOptions()
                      .allow_undeclared_parameters(false)
                      .parameter_overrides(parameter_overrides)
-                     .automatically_declare_parameters_from_overrides(true);
+                     .automatically_declare_parameters_from_overrides(false);
     return SetUpControllerCommon(controller_name, options);
   }
 
@@ -176,7 +176,7 @@ protected:
   {
     auto options = rclcpp::NodeOptions()
                      .allow_undeclared_parameters(false)
-                     .automatically_declare_parameters_from_overrides(true);
+                     .automatically_declare_parameters_from_overrides(false);
     return SetUpControllerCommon(controller_name, options);
   }
 


### PR DESCRIPTION
`automatically_declare_parameters_from_overrides=True` in tests hinders from dynamically loading external libraries declaring their own parameters (see https://github.com/ros-controls/ros2_control/issues/531 for original discussion and reasons)

Test still pass without it

