### PR TITLE
Misplaced param init in admittance_controller

### DIFF
--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -147,18 +147,6 @@ AdmittanceController::on_export_reference_interfaces()
 controller_interface::CallbackReturn AdmittanceController::on_configure(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  try
-  {
-    parameter_handler_ = std::make_shared<admittance_controller::ParamListener>(get_node());
-    admittance_ = std::make_unique<admittance_controller::AdmittanceRule>(parameter_handler_);
-  }
-  catch (const std::exception & e)
-  {
-    RCLCPP_ERROR(
-      get_node()->get_logger(), "Exception thrown during init stage with message: %s \n", e.what());
-    return controller_interface::CallbackReturn::ERROR;
-  }
-
   command_joint_names_ = admittance_->parameters_.command_joints;
   if (command_joint_names_.empty())
   {

--- a/admittance_controller/test/test_admittance_controller.cpp
+++ b/admittance_controller/test/test_admittance_controller.cpp
@@ -21,24 +21,14 @@
 #include <utility>
 #include <vector>
 
-// Test on_configure returns ERROR when a required parameter is missing
-TEST_P(AdmittanceControllerTestParameterizedMissingParameters, one_parameter_is_missing)
+// Test on_init returns ERROR when a required parameter is missing
+TEST_P(AdmittanceControllerTestParameterizedMissingParameters, one_init_parameter_is_missing)
 {
-  auto ret = SetUpController(GetParam());
-  // additionally, test params required during configure only if init worked
-  if (ret == controller_interface::return_type::OK)
-  {
-    ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_FAILURE);
-  }
-  else
-  {
-    ASSERT_EQ(ret, controller_interface::return_type::ERROR);
-  }
+  ASSERT_EQ(SetUpController(GetParam()), controller_interface::return_type::ERROR);
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  MissingMandatoryParameterDuringConfiguration,
-  AdmittanceControllerTestParameterizedMissingParameters,
+  MissingMandatoryParameterDuringInit, AdmittanceControllerTestParameterizedMissingParameters,
   ::testing::Values(
     "admittance.mass", "admittance.selected_axes", "admittance.stiffness",
     "chainable_command_interfaces", "command_interfaces", "control.frame.id",

--- a/admittance_controller/test/test_admittance_controller.cpp
+++ b/admittance_controller/test/test_admittance_controller.cpp
@@ -24,8 +24,16 @@
 // Test on_configure returns ERROR when a required parameter is missing
 TEST_P(AdmittanceControllerTestParameterizedMissingParameters, one_parameter_is_missing)
 {
-  ASSERT_EQ(SetUpController(GetParam()), controller_interface::return_type::ERROR);
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
+  auto ret = SetUpController(GetParam());
+  // additionally, test params required during configure only if init worked
+  if (ret == controller_interface::return_type::OK)
+  {
+    ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_FAILURE);
+  }
+  else
+  {
+    ASSERT_EQ(ret, controller_interface::return_type::ERROR);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -53,6 +53,8 @@ const double COMMON_THRESHOLD = 0.001;
 
 constexpr auto NODE_SUCCESS =
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+constexpr auto NODE_FAILURE =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
 constexpr auto NODE_ERROR =
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
 

--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -142,11 +142,18 @@ interpolation_method (string)
   Default: splines
 
 open_loop_control (boolean)
-  Use controller in open-loop control mode using ignoring the states provided by hardware interface and using last commands as states in the next control step. This is useful if hardware states are not following commands, i.e., an offset between those (typical for hydraulic manipulators).
+  Use controller in open-loop control mode:
+    + The controller ignores the states provided by hardware interface but using last commands as states for starting the trajectory interpolation.
+    + It deactivates the feedback control, see the ``gains`` structure.
+
+  This is useful if hardware states are not following commands, i.e., an offset between those (typical for hydraulic manipulators).
+
+  .. Note::
+     If this flag is set, the controller tries to read the values from the command interfaces on activation.
+     If they have real numeric values, those will be used instead of state interfaces.
+     Therefore it is important set command interfaces to NaN (i.e., ``std::numeric_limits<double>::quiet_NaN()``) or state values when the hardware is started.
 
   Default: false
-
-  If this flag is set, the controller tries to read the values from the command interfaces on starting. If they have real numeric values, those will be used instead of state interfaces. Therefore it is important set command interfaces to NaN (std::numeric_limits<double>::quiet_NaN()) or state values when the hardware is started.
 
 constraints (structure)
   Default values for tolerances if no explicit values are states in JointTrajectory message.
@@ -172,7 +179,10 @@ constraints.<joint_name>.goal (double)
   Default: 0.0 (tolerance is not enforced)
 
 gains (structure)
-  If ``velocity`` is the only command interface for all joints or an ``effort`` command interface is configured, PID controllers are used for every joint. This structure contains the controller gains for every joint with the control law
+  Only relevant, if ``open_loop_control`` is not set.
+
+  If ``velocity`` is the only command interface for all joints or an ``effort`` command interface is configured, PID controllers are used for every joint.
+  This structure contains the controller gains for every joint with the control law
 
   .. math::
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -599,7 +599,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
   // if there is only velocity or if there is effort command interface
   // then use also PID adapter
   use_closed_loop_pid_adapter_ =
-    (has_velocity_command_interface_ && params_.command_interfaces.size() == 1) ||
+    (has_velocity_command_interface_ && params_.command_interfaces.size() == 1 &&
+     !params_.open_loop_control) ||
     has_effort_command_interface_;
 
   if (use_closed_loop_pid_adapter_)


### PR DESCRIPTION
`admittance_controller` was initializing the `ParamListener` twice in `on_init` and `on_configure`. This should not be required.
However, without this, the test failed. The test was calling `on_configure` when `on_init` failed (due to a missing param). Now the test ensures `on_init` fails, and if it does not (because all its params are available), then calls `on_configure` (which might require other params, as will be the case for future pluginlib-based filter loading).