### PR TITLE
[JTC] Disable use of closed-loop PID adapter if controller is used in open-loop mode.

### DIFF
--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -142,11 +142,18 @@ interpolation_method (string)
   Default: splines
 
 open_loop_control (boolean)
-  Use controller in open-loop control mode using ignoring the states provided by hardware interface and using last commands as states in the next control step. This is useful if hardware states are not following commands, i.e., an offset between those (typical for hydraulic manipulators).
+  Use controller in open-loop control mode:
+    + The controller ignores the states provided by hardware interface but using last commands as states for starting the trajectory interpolation.
+    + It deactivates the feedback control, see the ``gains`` structure.
+
+  This is useful if hardware states are not following commands, i.e., an offset between those (typical for hydraulic manipulators).
+
+  .. Note::
+     If this flag is set, the controller tries to read the values from the command interfaces on activation.
+     If they have real numeric values, those will be used instead of state interfaces.
+     Therefore it is important set command interfaces to NaN (i.e., ``std::numeric_limits<double>::quiet_NaN()``) or state values when the hardware is started.
 
   Default: false
-
-  If this flag is set, the controller tries to read the values from the command interfaces on starting. If they have real numeric values, those will be used instead of state interfaces. Therefore it is important set command interfaces to NaN (std::numeric_limits<double>::quiet_NaN()) or state values when the hardware is started.
 
 constraints (structure)
   Default values for tolerances if no explicit values are states in JointTrajectory message.
@@ -172,7 +179,10 @@ constraints.<joint_name>.goal (double)
   Default: 0.0 (tolerance is not enforced)
 
 gains (structure)
-  If ``velocity`` is the only command interface for all joints or an ``effort`` command interface is configured, PID controllers are used for every joint. This structure contains the controller gains for every joint with the control law
+  Only relevant, if ``open_loop_control`` is not set.
+
+  If ``velocity`` is the only command interface for all joints or an ``effort`` command interface is configured, PID controllers are used for every joint.
+  This structure contains the controller gains for every joint with the control law
 
   .. math::
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -599,7 +599,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
   // if there is only velocity or if there is effort command interface
   // then use also PID adapter
   use_closed_loop_pid_adapter_ =
-    (has_velocity_command_interface_ && params_.command_interfaces.size() == 1) ||
+    (has_velocity_command_interface_ && params_.command_interfaces.size() == 1 &&
+     !params_.open_loop_control) ||
     has_effort_command_interface_;
 
   if (use_closed_loop_pid_adapter_)


### PR DESCRIPTION
As the name says. It is not sensible to close loop using PID adapter if controller should run in the open-loop.
