### PR TITLE
[Docs] Fix broken links

### DIFF
--- a/forward_command_controller/doc/userdoc.rst
+++ b/forward_command_controller/doc/userdoc.rst
@@ -5,9 +5,9 @@ forward_command_controller
 
 This is a base class implementing a feedforward controller. Specific implementations can be found in:
 
-- `Position Controllers <../position_controllers/doc/userdoc.rst>`_
-- `Velocity Controllers <../velocity_controllers/doc/userdoc.rst>`_
-- `Effort Controllers <../effort_controllers/doc/userdoc.rst>`_
+- :ref:`position_controllers_userdoc`
+- :ref:`velocity_controllers_userdoc`
+- :ref:`effort_controllers_userdoc`
 
 Hardware interface type
 -----------------------


### PR DESCRIPTION
I realized that I used wrong relative pahts in the links with #552. Furthermore, links to `.rst` files does not make sense because sphinx does not replace them with html links?! I tried it with the `:ref:` in my local sphinx installation, at least here it works. Or are there other ways to make proper links?