### PR TITLE
Use `gt_eq` instead of `lower_bounds`

### DIFF
--- a/admittance_controller/src/admittance_controller_parameters.yaml
+++ b/admittance_controller/src/admittance_controller_parameters.yaml
@@ -142,7 +142,7 @@ admittance_controller:
       description: "Specifies the joint damping applied used in the admittance calculation.",
       default_value: 5,
       validation: {
-        lower_bounds: [ 0.0 ]
+        gt_eq: [ 0.0 ]
       }
     }
 

--- a/gripper_controllers/src/gripper_action_controller_parameters.yaml
+++ b/gripper_controllers/src/gripper_action_controller_parameters.yaml
@@ -4,7 +4,7 @@ gripper_action_controller:
     default_value: 20.0,
     description: "Hz",
     validation: {
-      lower_bounds: [0.1]
+      gt_eq: [0.1]
     },
   }
   joint: {
@@ -15,7 +15,7 @@ gripper_action_controller:
     type: double,
     default_value: 0.01,
     validation: {
-      lower_bounds: [0.0]
+      gt_eq: [0.0]
     },
   }
   max_effort: {
@@ -23,7 +23,7 @@ gripper_action_controller:
     default_value: 0.0,
     description: "Max allowable effort",
     validation: {
-      lower_bounds: [0.0]
+      gt_eq: [0.0]
     },
   }
   allow_stalling: {

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -55,7 +55,7 @@ joint_trajectory_controller:
     default_value: 20.0,
     description: "Rate status changes will be monitored",
     validation: {
-      lower_bounds: [0.1]
+      gt_eq: [0.1]
     }
   }
   interpolation_method: {
@@ -109,7 +109,7 @@ joint_trajectory_controller:
       default_value: 0.0,
       description: "Time tolerance for achieving trajectory goal before or after commanded time.",
       validation: {
-        lower_bounds: [0.0],
+        gt_eq: [0.0],
       }
     }
     __map_joints:


### PR DESCRIPTION
Deprecation can be seen on CI, e.g.:

https://github.com/ros-controls/ros2_controllers/actions/runs/4618180647/jobs/8165304008?pr=434#step:6:877
