### PR TITLE
[JTC] Reject trajectories with nonzero terminal velocity

### DIFF
--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -175,6 +175,9 @@ open_loop_control (boolean)
 
   Default: false
 
+allow_nonzero_velocity_stop (boolean)
+  If not set true, the last velocity point has to be zero or the goal will be rejected.
+
 constraints (structure)
   Default values for tolerances if no explicit values are states in JointTrajectory message.
 

--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -175,8 +175,10 @@ open_loop_control (boolean)
 
   Default: false
 
-allow_nonzero_velocity_stop (boolean)
+allow_nonzero_velocity_at_trajectory_end (boolean)
   If not set true, the last velocity point has to be zero or the goal will be rejected.
+
+  Default: true
 
 constraints (structure)
   Default values for tolerances if no explicit values are states in JointTrajectory message.

--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -176,7 +176,7 @@ open_loop_control (boolean)
   Default: false
 
 allow_nonzero_velocity_at_trajectory_end (boolean)
-  If not set true, the last velocity point has to be zero or the goal will be rejected.
+  If false, the last velocity point has to be zero or the goal will be rejected.
 
   Default: true
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -65,11 +65,11 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
   }
 
   // TODO(christophfroehlich): remove deprecation warning
-  if (params_.allow_nonzero_velocity_stop)
+  if (params_.allow_nonzero_velocity_at_trajectory_end)
   {
     RCLCPP_WARN(
       get_node()->get_logger(),
-      "[Deprecated]: \"allow_nonzero_velocity_stop\" is set to "
+      "[Deprecated]: \"allow_nonzero_velocity_at_trajectory_end\" is set to "
       "true. The default behavior will change to false.");
   }
 
@@ -1328,7 +1328,7 @@ bool JointTrajectoryController::validate_trajectory_msg(
     }
   }
 
-  if (!params_.allow_nonzero_velocity_stop)
+  if (!params_.allow_nonzero_velocity_at_trajectory_end)
   {
     for (size_t i = 0; i < trajectory.points.back().velocities.size(); ++i)
     {

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -66,7 +66,7 @@ joint_trajectory_controller:
       one_of<>: [["splines", "none"]],
     }
   }
-  allow_nonzero_velocity_stop: {
+  allow_nonzero_velocity_at_trajectory_end: {
     type: bool,
     default_value: true,
     description: "If not set true, the last velocity point has to be zero or the goal will be rejected",

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -66,6 +66,11 @@ joint_trajectory_controller:
       one_of<>: [["splines", "none"]],
     }
   }
+  allow_nonzero_velocity_stop: {
+    type: bool,
+    default_value: true,
+    description: "If not set true, the last velocity point has to be zero or the goal will be rejected",
+  }
   gains:
     __map_joints:
       p: {

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -69,7 +69,7 @@ joint_trajectory_controller:
   allow_nonzero_velocity_at_trajectory_end: {
     type: bool,
     default_value: true,
-    description: "If not set true, the last velocity point has to be zero or the goal will be rejected",
+    description: "If false, the last velocity point has to be zero or the goal will be rejected",
   }
   gains:
     __map_joints:

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -616,9 +616,10 @@ TEST_P(TestTrajectoryActionsTestParameterized, test_cancel_hold_position)
   }
 }
 
-TEST_P(TestTrajectoryActionsTestParameterized, test_allow_nonzero_velocity_stop_true)
+TEST_P(TestTrajectoryActionsTestParameterized, test_allow_nonzero_velocity_at_trajectory_end_true)
 {
-  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", true)};
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", true)};
   SetUpExecutor(params);
   SetUpControllerHardware();
 
@@ -661,9 +662,10 @@ TEST_P(TestTrajectoryActionsTestParameterized, test_allow_nonzero_velocity_stop_
   EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode_);
 }
 
-TEST_P(TestTrajectoryActionsTestParameterized, test_allow_nonzero_velocity_stop_false)
+TEST_P(TestTrajectoryActionsTestParameterized, test_allow_nonzero_velocity_at_trajectory_end_false)
 {
-  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", false)};
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", false)};
   SetUpExecutor(params);
   SetUpControllerHardware();
 

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -616,19 +616,14 @@ TEST_P(TestTrajectoryActionsTestParameterized, test_cancel_hold_position)
   }
 }
 
-TEST_F(TestTrajectoryActions, test_allow_nonzero_velocity_stop_true)
+TEST_P(TestTrajectoryActionsTestParameterized, test_allow_nonzero_velocity_stop_true)
 {
-  // set parameter
-  command_interface_types_ = {"velocity"};
-  std::vector<rclcpp::Parameter> params = {
-    rclcpp::Parameter("command_interfaces", "velocity"),
-    rclcpp::Parameter("allow_nonzero_velocity_stop", true)};
-
+  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", true)};
   SetUpExecutor(params);
   SetUpControllerHardware();
 
   std::shared_future<typename GoalHandle::SharedPtr> gh_future;
-  // send goal
+  // send goal with nonzero last velocities
   {
     std::vector<JointTrajectoryPoint> points;
     JointTrajectoryPoint point1;
@@ -666,13 +661,9 @@ TEST_F(TestTrajectoryActions, test_allow_nonzero_velocity_stop_true)
   EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode_);
 }
 
-TEST_F(TestTrajectoryActions, test_allow_nonzero_velocity_stop_false)
+TEST_P(TestTrajectoryActionsTestParameterized, test_allow_nonzero_velocity_stop_false)
 {
-  // set parameter
-  std::vector<rclcpp::Parameter> params = {
-    rclcpp::Parameter("command_interfaces", "velocity"),
-    rclcpp::Parameter("allow_nonzero_velocity_stop", false)};
-
+  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", false)};
   SetUpExecutor(params);
   SetUpControllerHardware();
 
@@ -745,7 +736,6 @@ TEST_F(TestTrajectoryActions, test_allow_nonzero_velocity_stop_false)
   }
 
   EXPECT_TRUE(gh_future.get());
-  EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode_);
 }
 
 // position controllers

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -66,7 +66,7 @@ TEST_P(TrajectoryControllerTestParameterized, configure_state_ignores_commands)
   rclcpp::executors::MultiThreadedExecutor executor;
   SetUpTrajectoryController(executor);
   traj_controller_->get_node()->set_parameter(
-    rclcpp::Parameter("allow_nonzero_velocity_stop", true));
+    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", true));
 
   // const auto future_handle_ = std::async(std::launch::async, spin, &executor);
 
@@ -204,7 +204,8 @@ TEST_P(TrajectoryControllerTestParameterized, activate)
 TEST_P(TrajectoryControllerTestParameterized, cleanup)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
-  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", true)};
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", true)};
   SetUpAndActivateTrajectoryController(executor, true, params);
 
   // send msg
@@ -263,7 +264,7 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   rclcpp::executors::MultiThreadedExecutor executor;
   SetUpTrajectoryController(executor, false);
   traj_controller_->get_node()->set_parameter(
-    rclcpp::Parameter("allow_nonzero_velocity_stop", true));
+    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", true));
 
   // This call is replacing the way parameters are set via launch
   SetParameters();
@@ -455,7 +456,8 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_not_normalized)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   constexpr double k_p = 10.0;
-  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", true)};
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", true)};
   SetUpAndActivateTrajectoryController(executor, true, params, true, k_p, 0.0, false);
   subscribeToState();
 
@@ -563,7 +565,8 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_normalized)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   constexpr double k_p = 10.0;
-  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", true)};
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", true)};
   SetUpAndActivateTrajectoryController(executor, true, params, true, k_p, 0.0, true);
   subscribeToState();
 

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -65,6 +65,8 @@ TEST_P(TrajectoryControllerTestParameterized, configure_state_ignores_commands)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   SetUpTrajectoryController(executor);
+  traj_controller_->get_node()->set_parameter(
+    rclcpp::Parameter("allow_nonzero_velocity_stop", true));
 
   // const auto future_handle_ = std::async(std::launch::async, spin, &executor);
 
@@ -202,7 +204,8 @@ TEST_P(TrajectoryControllerTestParameterized, activate)
 TEST_P(TrajectoryControllerTestParameterized, cleanup)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(executor);
+  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", true)};
+  SetUpAndActivateTrajectoryController(executor, true, params);
 
   // send msg
   constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(250);
@@ -259,6 +262,8 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   SetUpTrajectoryController(executor, false);
+  traj_controller_->get_node()->set_parameter(
+    rclcpp::Parameter("allow_nonzero_velocity_stop", true));
 
   // This call is replacing the way parameters are set via launch
   SetParameters();
@@ -450,7 +455,8 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_not_normalized)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   constexpr double k_p = 10.0;
-  SetUpAndActivateTrajectoryController(executor, true, {}, true, k_p, 0.0, false);
+  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", true)};
+  SetUpAndActivateTrajectoryController(executor, true, params, true, k_p, 0.0, false);
   subscribeToState();
 
   size_t n_joints = joint_names_.size();
@@ -557,7 +563,8 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_normalized)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   constexpr double k_p = 10.0;
-  SetUpAndActivateTrajectoryController(executor, true, {}, true, k_p, 0.0, true);
+  std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("allow_nonzero_velocity_stop", true)};
+  SetUpAndActivateTrajectoryController(executor, true, params, true, k_p, 0.0, true);
   subscribeToState();
 
   size_t n_joints = joint_names_.size();


### PR DESCRIPTION
As suggested by @bmagyar, the new trajectory should be even ignored if the last velocity point is nonzero. 
- This is valid for both interfaces (topic + actions).
- I think there might be use-cases, where this is intentionally (maybe receiving topics from a MPC with moving horizon, where the end of the trajectory is not a steady state). Therefore, I added a parameter to be able to deactivate this behavior. To avoid breaking changes, I deactivated this by default now but give a deprecation warning if `allow_nonzero_velocity_stop==true`.

I also added a test for that, please review #603 first.