### PR TITLE
[DiffDriveController] Adjusted open_loop parameter description

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller_parameter.yaml
+++ b/diff_drive_controller/src/diff_drive_controller_parameter.yaml
@@ -62,7 +62,7 @@ diff_drive_controller:
   open_loop: {
     type: bool,
     default_value: false,
-    description: "If set to false the odometry of the robot will be calculated from the commanded values and not from feedback.",
+    description: "If set to true the odometry of the robot will be calculated from the commanded values and not from feedback.",
   }
   position_feedback: {
     type: bool,


### PR DESCRIPTION
The issue is described here: #549
The description does not reflect the code:
Description: "If set to false the odometry of the robot will be calculated from the commanded values and not from feedback."
The code: https://github.com/ros-controls/ros2_controllers/blob/master/diff_drive_controller/src/diff_drive_controller.cpp#L145-L152

![open_loop_param](https://user-images.githubusercontent.com/31107191/232107878-5ce7ca47-7e71-45e1-853b-4914cbc05eef.png)
