### PR TITLE
[CI] Switch to recommended versions of ros-tooling

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -41,8 +41,8 @@ jobs:
           linter: [cpplint]
     steps:
     - uses: actions/checkout@v3
-    - uses: ros-tooling/setup-ros@0.6.1
-    - uses: ros-tooling/action-ros-lint@v0.1
+    - uses: ros-tooling/setup-ros@master
+    - uses: ros-tooling/action-ros-lint@master
       with:
         distribution: rolling
         linter: cpplint


### PR DESCRIPTION
See here: https://github.com/ros-tooling/action-ros-lint#run-generic-and-python-linters