### PR TITLE
Fix wrong publish timestamp initialization

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
@@ -148,7 +148,7 @@ protected:
   // publish rate limiter
   double publish_rate_ = 50.0;
   rclcpp::Duration publish_period_ = rclcpp::Duration::from_nanoseconds(0);
-  rclcpp::Time previous_publish_timestamp_{0};
+  rclcpp::Time previous_publish_timestamp_{0, 0, RCL_CLOCK_UNINITIALIZED};
 
   bool is_halted = false;
   bool use_stamped_vel_ = true;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -185,7 +185,23 @@ controller_interface::return_type DiffDriveController::update(
   tf2::Quaternion orientation;
   orientation.setRPY(0.0, 0.0, odometry_.getHeading());
 
-  if (previous_publish_timestamp_ + publish_period_ < time)
+  bool should_publish = false;
+  try
+  {
+    if (previous_publish_timestamp_ + publish_period_ < time)
+    {
+      previous_publish_timestamp_ += publish_period_;
+      should_publish = true;
+    }
+  }
+  catch (const std::runtime_error)
+  {
+    // Initialize when the time source changes
+    previous_publish_timestamp_ = time;
+    should_publish = true;
+  }
+
+  if (should_publish)
   {
     previous_publish_timestamp_ += publish_period_;
 
@@ -400,7 +416,6 @@ controller_interface::CallbackReturn DiffDriveController::on_configure(
   // limit the publication on the topics /odom and /tf
   publish_rate_ = get_node()->get_parameter("publish_rate").as_double();
   publish_period_ = rclcpp::Duration::from_seconds(1.0 / publish_rate_);
-  previous_publish_timestamp_ = get_node()->get_clock()->now();
 
   // initialize odom values zeros
   odometry_message.twist =

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -196,7 +196,7 @@ controller_interface::return_type DiffDriveController::update(
   }
   catch (const std::runtime_error)
   {
-    // Initialize when the time source changes
+    // Handle exceptions when the time source changes and initialize publish timestamp
     previous_publish_timestamp_ = time;
     should_publish = true;
   }


### PR DESCRIPTION
With the current implementation the `previous_publish_timestamp_` variable was initialized in the `on_configure` method.

However, when using the simulation, the time source has not been always updated to the ros time and it's initialized to the system time, so the condition for publishing the odometry and the related tf is never satisfied:

`system_time` + `publish_period_` is always  > `simulation_time`


With this fix, `previous_publish_timestamp_` starts without an uninitialized clock and whenever the time source changes, it is initialized/changed.

The odometry will be published in 2 cases:
- Whenever the time source is changed
- If the publish_rate condition is satisfied