### PR TITLE
switch from dash to underscore in setup.cfg

### DIFF
--- a/rqt_joint_trajectory_controller/setup.cfg
+++ b/rqt_joint_trajectory_controller/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rqt_joint_trajectory_controller
+script_dir=$base/lib/rqt_joint_trajectory_controller
 [install]
-install-scripts=$base/lib/rqt_joint_trajectory_controller
+install_scripts=$base/lib/rqt_joint_trajectory_controller


### PR DESCRIPTION
This fixes the warning which was introduced here:
https://github.com/pypa/setuptools/commit/a2e9ae4cb
