### PR TITLE
Clear registered handles of DiffDriveController on deactivate

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -481,6 +481,7 @@ controller_interface::CallbackReturn DiffDriveController::on_deactivate(
   const rclcpp_lifecycle::State &)
 {
   subscriber_is_active_ = false;
+  halt();
   registered_left_wheel_handles_.clear();
   registered_right_wheel_handles_.clear();
   return controller_interface::CallbackReturn::SUCCESS;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -482,6 +482,11 @@ controller_interface::CallbackReturn DiffDriveController::on_deactivate(
 {
   subscriber_is_active_ = false;
   halt();
+    if (!is_halted)
+    {
+      halt();
+      is_halted = true;
+    }
   registered_left_wheel_handles_.clear();
   registered_right_wheel_handles_.clear();
   return controller_interface::CallbackReturn::SUCCESS;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -481,12 +481,11 @@ controller_interface::CallbackReturn DiffDriveController::on_deactivate(
   const rclcpp_lifecycle::State &)
 {
   subscriber_is_active_ = false;
-  halt();
-    if (!is_halted)
-    {
-      halt();
-      is_halted = true;
-    }
+  if (!is_halted)
+  {
+    halt();
+    is_halted = true;
+  }
   registered_left_wheel_handles_.clear();
   registered_right_wheel_handles_.clear();
   return controller_interface::CallbackReturn::SUCCESS;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -481,6 +481,8 @@ controller_interface::CallbackReturn DiffDriveController::on_deactivate(
   const rclcpp_lifecycle::State &)
 {
   subscriber_is_active_ = false;
+  registered_left_wheel_handles_.clear();
+  registered_right_wheel_handles_.clear();
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
@@ -558,7 +560,6 @@ controller_interface::CallbackReturn DiffDriveController::configure_side(
   }
 
   // register handles
-  registered_handles.clear();
   registered_handles.reserve(wheel_names.size());
   for (const auto & wheel_name : wheel_names)
   {

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -558,6 +558,7 @@ controller_interface::CallbackReturn DiffDriveController::configure_side(
   }
 
   // register handles
+  registered_handles.clear();
   registered_handles.reserve(wheel_names.size());
   for (const auto & wheel_name : wheel_names)
   {


### PR DESCRIPTION
Hi,

With the current implementation, the wheel handles are not being reset when running `on_deactivate` method. Then, if the controller is deactivated and then activated again the handles are accumulated and that can lead to issues (See https://github.com/ros-controls/ros2_control_demos/issues/239)

`on_activate` and `on_deactivate` are the opposite, so everything that is enabled in `on_activate` have to be disabled in `on_deactivate` (or reset at the beginning of the `on_activate`). Following that, I propose two possible solutions, let me know which one fits better:

**Current Solution**:  Reset the handles with `registered_handles.clear();` in the `configure_side()` method.

**Alternative Solution**:  Clear each of the handles in `on_deactivate` method:
```
controller_interface::CallbackReturn DiffDriveController::on_deactivate(
  const rclcpp_lifecycle::State &)
{
  subscriber_is_active_ = false;
  registered_left_wheel_handles_.clear();
  registered_right_wheel_handles_.clear();
  return controller_interface::CallbackReturn::SUCCESS;
}
```