### PR TITLE
Do not validate admittance controller parameters until configure

### DIFF
--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -33,31 +33,6 @@ namespace admittance_controller
 {
 controller_interface::CallbackReturn AdmittanceController::on_init()
 {
-  // initialize controller config
-  try
-  {
-    parameter_handler_ = std::make_shared<admittance_controller::ParamListener>(get_node());
-    admittance_ = std::make_unique<admittance_controller::AdmittanceRule>(parameter_handler_);
-  }
-  catch (const std::exception & e)
-  {
-    RCLCPP_ERROR(
-      get_node()->get_logger(), "Exception thrown during init stage with message: %s \n", e.what());
-    return controller_interface::CallbackReturn::ERROR;
-  }
-
-  // number of joints in controllers is fixed after initialization
-  num_joints_ = admittance_->parameters_.joints.size();
-
-  // allocate dynamic memory
-  last_reference_.positions.assign(num_joints_, 0.0);
-  last_reference_.velocities.assign(num_joints_, 0.0);
-  last_reference_.accelerations.assign(num_joints_, 0.0);
-  last_commanded_ = last_reference_;
-  reference_ = last_reference_;
-  reference_admittance_ = last_reference_;
-  joint_state_ = last_reference_;
-
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
@@ -147,6 +122,31 @@ AdmittanceController::on_export_reference_interfaces()
 controller_interface::CallbackReturn AdmittanceController::on_configure(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  try
+  {
+    parameter_handler_ = std::make_shared<admittance_controller::ParamListener>(get_node());
+    admittance_ = std::make_unique<admittance_controller::AdmittanceRule>(parameter_handler_);
+  }
+  catch (const std::exception & e)
+  {
+    RCLCPP_ERROR(
+      get_node()->get_logger(), "Exception thrown during configuration stage with message: %s \n",
+      e.what());
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  // number of joints in controllers is fixed after initialization
+  num_joints_ = admittance_->parameters_.joints.size();
+
+  // allocate dynamic memory
+  last_reference_.positions.assign(num_joints_, 0.0);
+  last_reference_.velocities.assign(num_joints_, 0.0);
+  last_reference_.accelerations.assign(num_joints_, 0.0);
+  last_commanded_ = last_reference_;
+  reference_ = last_reference_;
+  reference_admittance_ = last_reference_;
+  joint_state_ = last_reference_;
+
   command_joint_names_ = admittance_->parameters_.command_joints;
   if (command_joint_names_.empty())
   {

--- a/admittance_controller/test/test_admittance_controller.cpp
+++ b/admittance_controller/test/test_admittance_controller.cpp
@@ -76,8 +76,6 @@ TEST_F(AdmittanceControllerTest, all_parameters_set_configure_success)
 
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-
   ASSERT_TRUE(!controller_->admittance_->parameters_.joints.empty());
   ASSERT_TRUE(controller_->admittance_->parameters_.joints.size() == joint_names_.size());
   ASSERT_TRUE(std::equal(
@@ -145,8 +143,6 @@ TEST_F(AdmittanceControllerTest, check_interfaces)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-
   auto command_interfaces = controller_->command_interface_configuration();
   ASSERT_EQ(command_interfaces.names.size(), joint_command_values_.size());
 
@@ -165,7 +161,6 @@ TEST_F(AdmittanceControllerTest, activate_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(
     controller_->command_interfaces_.size(), command_interface_types_.size() * joint_names_.size());
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
@@ -175,7 +170,6 @@ TEST_F(AdmittanceControllerTest, update_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   broadcast_tfs();
   ASSERT_EQ(
@@ -187,7 +181,6 @@ TEST_F(AdmittanceControllerTest, deactivate_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
 }
@@ -196,7 +189,6 @@ TEST_F(AdmittanceControllerTest, reactivate_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   assign_interfaces();
@@ -211,7 +203,6 @@ TEST_F(AdmittanceControllerTest, publish_status_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
   broadcast_tfs();
@@ -247,7 +238,6 @@ TEST_F(AdmittanceControllerTest, receive_message_and_publish_updated_status)
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   broadcast_tfs();
   ASSERT_EQ(

--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -187,6 +187,11 @@ protected:
   {
     auto result = controller_->init(controller_name, "", options);
 
+    if (controller_->on_configure(rclcpp_lifecycle::State()) == NODE_ERROR)
+    {
+      return controller_interface::return_type::ERROR;
+    }
+
     controller_->export_reference_interfaces();
     assign_interfaces();
 


### PR DESCRIPTION
The root cause is that the `admittance_controller/AdmittanceController` parameters do not have default values for all required parameters.

Without this change, if you try to load an admittance controller without parameters (e.g., by using `ControllerManager::load_controller()` or the corresponding ROS service), the `generate_parameter_library` validation will fail because the value of the `joints` parameter is not set rather than an empty string vector. And same for other follow-on params.

This PR now changes the logic so that we're not validating parameters and dynamically allocating data based on number of joints until `on_configure()` -- it previously happened on `on_init()`.