### PR TITLE
Renovate JTC action tests

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -81,12 +81,13 @@ if(BUILD_TESTING)
   )
 
   # TODO(andyz): Disabled due to flakiness
-  # ament_add_gmock(test_trajectory_actions
-  #   test/test_trajectory_actions.cpp
-  # )
-  # target_link_libraries(test_trajectory_actions
-  #   joint_trajectory_controller
-  # )
+  # TODO(christophfroehlich): Temporarily (?) activated again
+  ament_add_gmock(test_trajectory_actions
+    test/test_trajectory_actions.cpp
+  )
+  target_link_libraries(test_trajectory_actions
+    joint_trajectory_controller
+  )
 endif()
 
 

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -80,8 +80,6 @@ if(BUILD_TESTING)
     ros2_control_test_assets
   )
 
-  # TODO(andyz): Disabled due to flakiness
-  # TODO(christophfroehlich): Temporarily (?) activated again
   ament_add_gmock(test_trajectory_actions
     test/test_trajectory_actions.cpp
   )


### PR DESCRIPTION
I applied changes to get the `test_trajectory_actions` running again, cherrypicking from #567.

The flakiness should be fixed (or the test be deactivated again) before the branch `jtc-features` gets merged into master.