### PR TITLE
Fix github links on control.ros.org

### DIFF
--- a/admittance_controller/doc/userdoc.rst
+++ b/admittance_controller/doc/userdoc.rst
@@ -1,4 +1,6 @@
-.. _addmittance_controller_userdoc:
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/admittance_controller/doc/userdoc.rst
+
+.. _admittance_controller_userdoc:
 
 Admittance Controller
 ======================

--- a/diff_drive_controller/doc/userdoc.rst
+++ b/diff_drive_controller/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/diff_drive_controller/doc/userdoc.rst
+
 .. _diff_drive_controller_userdoc:
 
 diff_drive_controller

--- a/doc/controllers_index.rst
+++ b/doc/controllers_index.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/doc/controllers_index.rst
+
 .. _controllers:
 
 #################

--- a/doc/writing_new_controller.rst
+++ b/doc/writing_new_controller.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/doc/writing_new_controller.rst
+
 .. _writing_new_controllers:
 
 Writing a new controller

--- a/effort_controllers/doc/userdoc.rst
+++ b/effort_controllers/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/effort_controllers/doc/userdoc.rst
+
 .. _effort_controllers_userdoc:
 
 effort_controllers

--- a/force_torque_sensor_broadcaster/doc/userdoc.rst
+++ b/force_torque_sensor_broadcaster/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/force_torque_sensor_broadcaster/doc/userdoc.rst
+
 .. _force_torque_sensor_broadcaster_userdoc:
 
 Force Torque Sensor Broadcaster

--- a/forward_command_controller/doc/userdoc.rst
+++ b/forward_command_controller/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/forward_command_controller/doc/userdoc.rst
+
 .. _forward_command_controller_userdoc:
 
 forward_command_controller

--- a/imu_sensor_broadcaster/doc/userdoc.rst
+++ b/imu_sensor_broadcaster/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/imu_sensor_broadcaster/doc/userdoc.rst
+
 .. _imu_sensor_broadcaster_userdoc:
 
 IMU Sensor Broadcaster

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/joint_state_broadcaster/doc/userdoc.rst
+
 .. _joint_state_broadcaster_userdoc:
 
 joint_state_broadcaster

--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/joint_trajectory_controller/doc/userdoc.rst
+
 .. _joint_trajectory_controller_userdoc:
 
 joint_trajectory_controller

--- a/position_controllers/doc/userdoc.rst
+++ b/position_controllers/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/position_controllers/doc/userdoc.rst
+
 .. _position_controllers_userdoc:
 
 position_controllers

--- a/tricycle_controller/doc/userdoc.rst
+++ b/tricycle_controller/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/tricycle_controller/doc/userdoc.rst
+
 .. _tricycle_controller_userdoc:
 
 tricycle_controller

--- a/velocity_controllers/doc/userdoc.rst
+++ b/velocity_controllers/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/|github_branch|/velocity_controllers/doc/userdoc.rst
+
 .. _velocity_controllers_userdoc:
 
 velocity_controllers


### PR DESCRIPTION
This is a companion PR to https://github.com/ros-controls/control.ros.org/pull/85. More details can be found there.