### PR TITLE
[JTC] Hold the position after the goal was reached successfully

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -328,6 +328,7 @@ controller_interface::return_type JointTrajectoryController::update(
         {
           if (!outside_goal_tolerance)
           {
+            set_hold_position();
             auto res = std::make_shared<FollowJTrajAction::Result>();
             res->set__error_code(FollowJTrajAction::Result::SUCCESSFUL);
             active_goal->setSucceeded(res);


### PR DESCRIPTION
JTC with command interface `velocity`: As described in #469, JTC does not stop if last velocity point is not zero.

I propose calling `set_hold_position` if the goal was successfully reached. 

Optional rejection of nonzero velocity is proposed with #567 

- [ ]  Changes from #558 are necessary to have an effect.
- [ ]  Add tests to check this behavior