### PR TITLE
[JTC] Tolerance tests + Hold on time violation

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -376,7 +376,7 @@ controller_interface::return_type JointTrajectoryController::update(
         !before_last_point && !within_goal_time && *(rt_has_pending_goal_.readFromRT()) == false)
       {
         RCLCPP_ERROR(
-          get_node()->get_logger(), "Holding position due goal_time_tolerance exceeding");
+          get_node()->get_logger(), "Exceeded goal_time_tolerance: holding position...");
 
         traj_msg_external_point_ptr_.reset();
         traj_msg_external_point_ptr_.initRT(set_hold_position());

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -362,24 +362,24 @@ controller_interface::return_type JointTrajectoryController::update(
             traj_msg_external_point_ptr_.reset();
             traj_msg_external_point_ptr_.initRT(set_hold_position());
           }
-          // else, run another cycle while waiting for outside_goal_tolerance
-          // to be satisfied or violated within the goal_time_tolerance
         }
       }
       else if (tolerance_violated_while_moving && *(rt_has_pending_goal_.readFromRT()) == false)
       {
         // we need to ensure that there is no pending goal -> we get a race condition otherwise
-
         RCLCPP_ERROR(get_node()->get_logger(), "Holding position due to state tolerance violation");
 
         traj_msg_external_point_ptr_.reset();
         traj_msg_external_point_ptr_.initRT(set_hold_position());
       }
-      else if (!before_last_point && !within_goal_time)
+      else if (
+        !before_last_point && !within_goal_time && *(rt_has_pending_goal_.readFromRT()) == false)
       {
-        set_hold_position();
         RCLCPP_ERROR(
           get_node()->get_logger(), "Holding position due goal_time_tolerance exceeding");
+
+        traj_msg_external_point_ptr_.reset();
+        traj_msg_external_point_ptr_.initRT(set_hold_position());
       }
       // else, run another cycle while waiting for outside_goal_tolerance
       // to be satisfied (will stay in this state until new message arrives)

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -375,8 +375,7 @@ controller_interface::return_type JointTrajectoryController::update(
       else if (
         !before_last_point && !within_goal_time && *(rt_has_pending_goal_.readFromRT()) == false)
       {
-        RCLCPP_ERROR(
-          get_node()->get_logger(), "Exceeded goal_time_tolerance: holding position...");
+        RCLCPP_ERROR(get_node()->get_logger(), "Exceeded goal_time_tolerance: holding position...");
 
         traj_msg_external_point_ptr_.reset();
         traj_msg_external_point_ptr_.initRT(set_hold_position());

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -375,6 +375,15 @@ controller_interface::return_type JointTrajectoryController::update(
         traj_msg_external_point_ptr_.reset();
         traj_msg_external_point_ptr_.initRT(set_hold_position());
       }
+      else if (!before_last_point && !within_goal_time)
+      {
+        set_hold_position();
+        RCLCPP_ERROR(
+          get_node()->get_logger(), "Holding position due goal_time_tolerance exceeding");
+      }
+      // else, run another cycle while waiting for outside_goal_tolerance
+      // to be satisfied (will stay in this state until new message arrives)
+      // or outside_goal_tolerance violated within the goal_time_tolerance
     }
   }
 

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1610,13 +1610,12 @@ TEST_P(TrajectoryControllerTestParameterized, test_state_tolerances_fail)
     EXPECT_NEAR(0.0, joint_vel_[2], COMMON_THRESHOLD);
   }
 
-  // TODO(christophfroehlich) activate once it got merged
-  // if (traj_controller_->has_acceleration_command_interface())
-  // {
-  //   EXPECT_NEAR(0.0, joint_acc_[0], COMMON_THRESHOLD);
-  //   EXPECT_NEAR(0.0, joint_acc_[1], COMMON_THRESHOLD);
-  //   EXPECT_NEAR(0.0, joint_acc_[2], COMMON_THRESHOLD);
-  // }
+  if (traj_controller_->has_acceleration_command_interface())
+  {
+    EXPECT_NEAR(0.0, joint_acc_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_acc_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_acc_[2], COMMON_THRESHOLD);
+  }
 
   if (traj_controller_->has_effort_command_interface())
   {
@@ -1672,13 +1671,12 @@ TEST_P(TrajectoryControllerTestParameterized, test_goal_tolerances_fail)
     EXPECT_NEAR(0.0, joint_vel_[2], COMMON_THRESHOLD);
   }
 
-  // TODO(christophfroehlich) activate once it got merged
-  // if (traj_controller_->has_acceleration_command_interface())
-  // {
-  //   EXPECT_NEAR(0.0, joint_acc_[0], COMMON_THRESHOLD);
-  //   EXPECT_NEAR(0.0, joint_acc_[1], COMMON_THRESHOLD);
-  //   EXPECT_NEAR(0.0, joint_acc_[2], COMMON_THRESHOLD);
-  // }
+  if (traj_controller_->has_acceleration_command_interface())
+  {
+    EXPECT_NEAR(0.0, joint_acc_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_acc_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_acc_[2], COMMON_THRESHOLD);
+  }
 
   if (traj_controller_->has_effort_command_interface())
   {

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1593,36 +1593,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_state_tolerances_fail)
   updateController(rclcpp::Duration(FIRST_POINT_TIME));
 
   // it should have aborted and be holding now
-  // TODO(christophfroehlich): Add has_trajectory check once #609 got merged
-
-  if (traj_controller_->has_position_command_interface())
-  {
-    // should hold at current position
-    EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
-    EXPECT_NEAR(joint_state_pos_[1], joint_pos_[1], COMMON_THRESHOLD);
-    EXPECT_NEAR(joint_state_pos_[2], joint_pos_[2], COMMON_THRESHOLD);
-  }
-
-  if (traj_controller_->has_velocity_command_interface())
-  {
-    EXPECT_NEAR(0.0, joint_vel_[0], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_vel_[1], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_vel_[2], COMMON_THRESHOLD);
-  }
-
-  if (traj_controller_->has_acceleration_command_interface())
-  {
-    EXPECT_NEAR(0.0, joint_acc_[0], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_acc_[1], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_acc_[2], COMMON_THRESHOLD);
-  }
-
-  if (traj_controller_->has_effort_command_interface())
-  {
-    EXPECT_NEAR(0.0, joint_eff_[0], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_eff_[1], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_eff_[2], COMMON_THRESHOLD);
-  }
+  expectHoldingPoint(joint_state_pos_);
 }
 
 TEST_P(TrajectoryControllerTestParameterized, test_goal_tolerances_fail)
@@ -1654,36 +1625,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_goal_tolerances_fail)
   updateController(rclcpp::Duration(4 * FIRST_POINT_TIME));
 
   // it should have aborted and be holding now
-  // TODO(christophfroehlich): Add has_trajectory check once #609 got merged
-
-  if (traj_controller_->has_position_command_interface())
-  {
-    // should hold at current position
-    EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
-    EXPECT_NEAR(joint_state_pos_[1], joint_pos_[1], COMMON_THRESHOLD);
-    EXPECT_NEAR(joint_state_pos_[2], joint_pos_[2], COMMON_THRESHOLD);
-  }
-
-  if (traj_controller_->has_velocity_command_interface())
-  {
-    EXPECT_NEAR(0.0, joint_vel_[0], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_vel_[1], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_vel_[2], COMMON_THRESHOLD);
-  }
-
-  if (traj_controller_->has_acceleration_command_interface())
-  {
-    EXPECT_NEAR(0.0, joint_acc_[0], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_acc_[1], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_acc_[2], COMMON_THRESHOLD);
-  }
-
-  if (traj_controller_->has_effort_command_interface())
-  {
-    EXPECT_NEAR(0.0, joint_eff_[0], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_eff_[1], COMMON_THRESHOLD);
-    EXPECT_NEAR(0.0, joint_eff_[2], COMMON_THRESHOLD);
-  }
+  expectHoldingPoint(joint_state_pos_);
 }
 
 // position controllers

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1567,6 +1567,127 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_co
   executor.cancel();
 }
 
+TEST_P(TrajectoryControllerTestParameterized, test_state_tolerances_fail)
+{
+  // set joint tolerance parameters
+  const double state_tol = 0.0001;
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("constraints.joint1.trajectory", state_tol),
+    rclcpp::Parameter("constraints.joint2.trajectory", state_tol),
+    rclcpp::Parameter("constraints.joint3.trajectory", state_tol)};
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  SetUpAndActivateTrajectoryController(executor, false, {params}, true);
+
+  // send msg
+  constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(100);
+  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(FIRST_POINT_TIME)};
+  // *INDENT-OFF*
+  std::vector<std::vector<double>> points{
+    {{3.3, 4.4, 5.5}}, {{7.7, 8.8, 9.9}}, {{10.10, 11.11, 12.12}}};
+  std::vector<std::vector<double>> points_velocities{
+    {{0.01, 0.01, 0.01}}, {{0.05, 0.05, 0.05}}, {{0.06, 0.06, 0.06}}};
+  // *INDENT-ON*
+  publish(time_from_start, points, rclcpp::Time(0, 0, RCL_STEADY_TIME), {}, points_velocities);
+  traj_controller_->wait_for_trajectory(executor);
+  updateController(rclcpp::Duration(FIRST_POINT_TIME));
+
+  // it should have aborted and be holding now
+  // TODO(christophfroehlich): Add has_trajectory check once #609 got merged
+
+  if (traj_controller_->has_position_command_interface())
+  {
+    // should hold at current position
+    EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(joint_state_pos_[1], joint_pos_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(joint_state_pos_[2], joint_pos_[2], COMMON_THRESHOLD);
+  }
+
+  if (traj_controller_->has_velocity_command_interface())
+  {
+    EXPECT_NEAR(0.0, joint_vel_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_vel_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_vel_[2], COMMON_THRESHOLD);
+  }
+
+  // TODO(christophfroehlich) activate once it got merged
+  // if (traj_controller_->has_acceleration_command_interface())
+  // {
+  //   EXPECT_NEAR(0.0, joint_acc_[0], COMMON_THRESHOLD);
+  //   EXPECT_NEAR(0.0, joint_acc_[1], COMMON_THRESHOLD);
+  //   EXPECT_NEAR(0.0, joint_acc_[2], COMMON_THRESHOLD);
+  // }
+
+  if (traj_controller_->has_effort_command_interface())
+  {
+    EXPECT_NEAR(0.0, joint_eff_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_eff_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_eff_[2], COMMON_THRESHOLD);
+  }
+}
+
+TEST_P(TrajectoryControllerTestParameterized, test_goal_tolerances_fail)
+{
+  // set joint tolerance parameters
+  const double goal_tol = 0.1;
+  // set very small goal_time so that goal_time is violated
+  const double goal_time = 0.000001;
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("constraints.joint1.goal", goal_tol),
+    rclcpp::Parameter("constraints.joint2.goal", goal_tol),
+    rclcpp::Parameter("constraints.joint3.goal", goal_tol),
+    rclcpp::Parameter("constraints.goal_time", goal_time)};
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  SetUpAndActivateTrajectoryController(executor, false, {params}, true);
+
+  // send msg
+  constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(100);
+  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(FIRST_POINT_TIME)};
+  // *INDENT-OFF*
+  std::vector<std::vector<double>> points{
+    {{3.3, 4.4, 5.5}}, {{7.7, 8.8, 9.9}}, {{10.10, 11.11, 12.12}}};
+  std::vector<std::vector<double>> points_velocities{
+    {{0.01, 0.01, 0.01}}, {{0.05, 0.05, 0.05}}, {{0.06, 0.06, 0.06}}};
+  // *INDENT-ON*
+  publish(time_from_start, points, rclcpp::Time(0, 0, RCL_STEADY_TIME), {}, points_velocities);
+  traj_controller_->wait_for_trajectory(executor);
+  updateController(rclcpp::Duration(4 * FIRST_POINT_TIME));
+
+  // it should have aborted and be holding now
+  // TODO(christophfroehlich): Add has_trajectory check once #609 got merged
+
+  if (traj_controller_->has_position_command_interface())
+  {
+    // should hold at current position
+    EXPECT_NEAR(joint_state_pos_[0], joint_pos_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(joint_state_pos_[1], joint_pos_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(joint_state_pos_[2], joint_pos_[2], COMMON_THRESHOLD);
+  }
+
+  if (traj_controller_->has_velocity_command_interface())
+  {
+    EXPECT_NEAR(0.0, joint_vel_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_vel_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_vel_[2], COMMON_THRESHOLD);
+  }
+
+  // TODO(christophfroehlich) activate once it got merged
+  // if (traj_controller_->has_acceleration_command_interface())
+  // {
+  //   EXPECT_NEAR(0.0, joint_acc_[0], COMMON_THRESHOLD);
+  //   EXPECT_NEAR(0.0, joint_acc_[1], COMMON_THRESHOLD);
+  //   EXPECT_NEAR(0.0, joint_acc_[2], COMMON_THRESHOLD);
+  // }
+
+  if (traj_controller_->has_effort_command_interface())
+  {
+    EXPECT_NEAR(0.0, joint_eff_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_eff_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(0.0, joint_eff_[2], COMMON_THRESHOLD);
+  }
+}
+
 // position controllers
 INSTANTIATE_TEST_SUITE_P(
   PositionTrajectoryControllers, TrajectoryControllerTestParameterized,


### PR DESCRIPTION
I realized that if using the topic interface: The current trajectory will never be stopped if the goal isn't reached within time. 

New tests fix #407 but need
- [x] #558 to succeed, because `set_hold_position` does not set hold position now


