### PR TITLE
Fix compilation warnings

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -194,7 +194,7 @@ controller_interface::return_type DiffDriveController::update(
       should_publish = true;
     }
   }
-  catch (const std::runtime_error)
+  catch (const std::runtime_error &)
   {
     // Handle exceptions when the time source changes and initialize publish timestamp
     previous_publish_timestamp_ = time;

--- a/gripper_controllers/test/test_gripper_controllers.hpp
+++ b/gripper_controllers/test/test_gripper_controllers.hpp
@@ -30,6 +30,9 @@ using hardware_interface::HW_IF_POSITION;
 using hardware_interface::HW_IF_VELOCITY;
 using hardware_interface::StateInterface;
 
+namespace
+{
+
 // subclassing and friending so we can access member variables
 class FriendGripperController
 : public gripper_action_controller::GripperActionController<HW_IF_POSITION>
@@ -61,5 +64,7 @@ protected:
   StateInterface joint_1_vel_state_{joint_name_, HW_IF_VELOCITY, &joint_states_[1]};
   CommandInterface joint_1_pos_cmd_{joint_name_, HW_IF_POSITION, &joint_commands_[0]};
 };
+
+}  // anonymous namespace
 
 #endif  // TEST_GRIPPER_CONTROLLERS_HPP_


### PR DESCRIPTION
This pull request fixes the compilation warnings for this repository.

There are more warnings about the usage of deprecated methods but there is already another pull request ( for humble https://github.com/ros-controls/ros2_controllers/pull/616) for that.