### PR TITLE
[bugfix] diff_drive_controller publish rate is half of what it is supposed to be

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -203,8 +203,6 @@ controller_interface::return_type DiffDriveController::update(
 
   if (should_publish)
   {
-    previous_publish_timestamp_ += publish_period_;
-
     if (realtime_odometry_publisher_->trylock())
     {
       auto & odometry_message = realtime_odometry_publisher_->msg_;


### PR DESCRIPTION
Hello dear reviewer,

The variable `previous_publish_timestamp_` is incremented twice by the `publish_period_` in the `update` function in `diff_drive_controller.cpp`. This effectively halved the `publish_rate` defined in the node parameters.