### PR TITLE
Remove unnecessary include

### DIFF
--- a/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
@@ -24,7 +24,6 @@
 #include "realtime_tools/realtime_buffer.h"
 #include "realtime_tools/realtime_publisher.h"
 
-#include <boost/function.hpp>
 #include "rcpputils/rolling_mean_accumulator.hpp"
 
 namespace steering_odometry


### PR DESCRIPTION
This fixes current buildfarm failures

For future reference:

https://build.ros2.org/job/Ibin_ujv8_uJv8__steering_controllers_library__ubuntu_jammy_arm64__binary/7/display/redirect
https://build.ros2.org/job/Rbin_ujv8_uJv8__steering_controllers_library__ubuntu_jammy_arm64__binary/5/display/redirect
