### PR TITLE
Updated hyperlink of pluginlib documentation

### DIFF
--- a/doc/writing_new_controller.rst
+++ b/doc/writing_new_controller.rst
@@ -5,7 +5,7 @@
 Writing a new controller
 ========================
 
-In this framework controllers are libraries, dynamically loaded by the controller manager using the `pluginlib <ros.org/wiki/pluginlib>`_ interface.
+In this framework controllers are libraries, dynamically loaded by the controller manager using the `pluginlib <https://wiki.ros.org/pluginlib>`_ interface.
 The following is a step-by-step guide to create source files, basic tests, and compile rules for a new controller.
 
 1. **Preparing package**


### PR DESCRIPTION
Added https:// to hyperlink of pluginlib, so that it is redirecting to the correct website. The old version is just appending ros.org/wiki/pluginlib to the link of the documentation: https://control.ros.org/humble/doc/ros2_controllers/doc/ros.org/wiki/pluginlib.