### PR TITLE
[Galactic] Fix controllers index

### DIFF
--- a/doc/controllers_index.rst
+++ b/doc/controllers_index.rst
@@ -62,5 +62,6 @@ Available Broadcasters
 .. toctree::
    :titlesonly:
 
+   Force Torque Sensor Broadcaster <../force_torque_sensor_broadcaster/doc/userdoc.rst>
    Joint State Broadcaster <../joint_state_broadcaster/doc/userdoc.rst>
    Imu Sensor Broadcaster <../imu_sensor_broadcaster/doc/userdoc.rst>


### PR DESCRIPTION
sphinx always throws warnings without this change.
