### PR TITLE
Use link pointing to docs.ros.org

### DIFF
--- a/doc/writing_new_controller.rst
+++ b/doc/writing_new_controller.rst
@@ -5,7 +5,7 @@
 Writing a new controller
 ========================
 
-In this framework controllers are libraries, dynamically loaded by the controller manager using the `pluginlib <https://wiki.ros.org/pluginlib>`_ interface.
+In this framework controllers are libraries, dynamically loaded by the controller manager using the `pluginlib <https://docs.ros.org/en/{REPOS_FILE_BRANCH}/Tutorials/Beginner-Client-Libraries/Pluginlib.html>`_ interface.
 The following is a step-by-step guide to create source files, basic tests, and compile rules for a new controller.
 
 1. **Preparing package**


### PR DESCRIPTION
Follow-up to discussion in #662:
Wiki is for ROS 1, and at least pluginlib has a good page on docs.ros.org

Or should we point to https://index.ros.org/p/pluginlib/github-ros-pluginlib/ also?