### PR TITLE
[JTC] Increase action tests timeout

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -83,6 +83,7 @@ if(BUILD_TESTING)
   ament_add_gmock(test_trajectory_actions
     test/test_trajectory_actions.cpp
   )
+  set_tests_properties(test_trajectory_actions PROPERTIES TIMEOUT 300)
   target_link_libraries(test_trajectory_actions
     joint_trajectory_controller
   )


### PR DESCRIPTION
The test failed locally in my docker and also [here](https://github.com/ros-controls/ros2_controllers/actions/runs/5327191645/jobs/9650232927?pr=607#step:6:5590)

However, there might be something still wrong with the clock -> fix comes with a different PR.

> 4: [ RUN      ] OnlyEffortTrajectoryControllers/TestTrajectoryActionsTestParameterized.test_goal_tolerances_fail/0
> 4: [INFO] [1687297889.159827233] [test_joint_trajectory_controller]: No specific joint names are used for command interfaces. Using 'joints' parameter.
> 4: [INFO] [1687297889.159858902] [test_joint_trajectory_controller]: Command interfaces are [effort] and state interfaces are [position velocity].
> 4: [INFO] [1687297889.159869506] [test_joint_trajectory_controller]: Using 'splines' interpolation method.
> 4: [INFO] [1687297889.160144563] [test_joint_trajectory_controller]: Action status changes will be monitored at 20.00 Hz.
> 4: [INFO] [1687297889.461739408] [test_joint_trajectory_controller]: Received new action goal
> 4: [INFO] [1687297889.461780570] [test_joint_trajectory_controller]: Accepted new action goal
> 4: [WARN] [1687297889.461844027] [test_joint_trajectory_controller]: Aborted due goal_time_tolerance exceeding by 1687208373.175506 seconds
> 4: [       OK ] OnlyEffortTrajectoryControllers/TestTrajectoryActionsTestParameterized.test_goal_tolerances_fail/0 (2022 ms)