### PR TITLE
Fix file name for include guard

### DIFF
--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -27,7 +27,6 @@
 
 #include "gmock/gmock.h"
 
-#include "6d_robot_description.hpp"
 #include "admittance_controller/admittance_controller.hpp"
 #include "control_msgs/msg/admittance_controller_state.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
@@ -38,6 +37,7 @@
 #include "rclcpp/utilities.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "semantic_components/force_torque_sensor.hpp"
+#include "test_asset_6d_robot_description.hpp"
 #include "tf2_ros/transform_broadcaster.h"
 #include "trajectory_msgs/msg/joint_trajectory.hpp"
 

--- a/admittance_controller/test/test_asset_6d_robot_description.hpp
+++ b/admittance_controller/test/test_asset_6d_robot_description.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROS2_CONTROL_TEST_ASSETS__6D_ROBOT_DESCRIPTION_HPP_
-#define ROS2_CONTROL_TEST_ASSETS__6D_ROBOT_DESCRIPTION_HPP_
+#ifndef TEST_ASSET_6D_ROBOT_DESCRIPTION_HPP_
+#define TEST_ASSET_6D_ROBOT_DESCRIPTION_HPP_
 
 #include <string>
 
@@ -310,4 +310,4 @@ const auto valid_6d_robot_srdf =
 
 }  // namespace ros2_control_test_assets
 
-#endif  // ROS2_CONTROL_TEST_ASSETS__6D_ROBOT_DESCRIPTION_HPP_
+#endif  // TEST_ASSET_6D_ROBOT_DESCRIPTION_HPP_


### PR DESCRIPTION
Otherwise cpplint complains

> Using '--root=/workspaces/ros2_rolling_ws/src/ros2_controllers/admittance_controller/test' argument
> 
> /workspaces/ros2_rolling_ws/src/ros2_controllers/admittance_controller/test/6d_robot_description.hpp:15:  #ifndef header guard has wrong style, please use: 6D_ROBOT_DESCRIPTION_HPP_  [build/header_guard] [5]
> /workspaces/ros2_rolling_ws/src/ros2_controllers/admittance_controller/test/6d_robot_description.hpp:313:  #endif line should be "#endif  // 6D_ROBOT_DESCRIPTION_HPP_"  [build/header_guard] [5]

and the preprocessor macro cannot start with a number.