### PR TITLE
Have set_hold_position() actually stop the robot

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -364,7 +364,6 @@ controller_interface::return_type JointTrajectoryController::update(
     {
       /// Likely an Empty trajectory from set_hold_position()
       /// Command hold position
-      // TODO(anyone): How to halt when using effort commands?
       for (size_t index = 0; index < dof_; ++index)
       {
         if (has_position_command_interface_)
@@ -377,7 +376,8 @@ controller_interface::return_type JointTrajectoryController::update(
         {
           joint_command_interface_[1][index].get().set_value(0.0);
         }
-
+        
+        // TODO(anyone): How to halt when using effort commands?
         if (has_effort_command_interface_)
         {
           joint_command_interface_[3][index].get().set_value(0.0);

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -360,6 +360,30 @@ controller_interface::return_type JointTrajectoryController::update(
         RCLCPP_ERROR(get_node()->get_logger(), "Holding position due to state tolerance violation");
       }
     }
+    else
+    {
+      /// Likely an Empty trajectory from set_hold_position()
+      /// Command hold position
+      // TODO(anyone): How to halt when using effort commands?
+      for (size_t index = 0; index < dof_; ++index)
+      {
+        if (has_position_command_interface_)
+        {
+          joint_command_interface_[0][index].get().set_value(
+            joint_command_interface_[0][index].get().get_value());
+        }
+
+        if (has_velocity_command_interface_)
+        {
+          joint_command_interface_[1][index].get().set_value(0.0);
+        }
+
+        if (has_effort_command_interface_)
+        {
+          joint_command_interface_[3][index].get().set_value(0.0);
+        }
+      }
+    }
   }
 
   publish_state(time, state_desired_, state_current_, state_error_);

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -362,8 +362,7 @@ controller_interface::return_type JointTrajectoryController::update(
     }
     else
     {
-      /// Likely an Empty trajectory from set_hold_position()
-      /// Command hold position
+      RCLCPP_DEBUG(get_node()->get_logger(), "Likely an Empty trajectory from set_hold_position(). Holding position...");
       for (size_t index = 0; index < dof_; ++index)
       {
         if (has_position_command_interface_)

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -376,7 +376,7 @@ controller_interface::return_type JointTrajectoryController::update(
         {
           joint_command_interface_[1][index].get().set_value(0.0);
         }
-        
+
         // TODO(anyone): How to halt when using effort commands?
         if (has_effort_command_interface_)
         {


### PR DESCRIPTION
Addresses https://github.com/ros-controls/ros2_controllers/issues/683

In almost all cases, that a trajectory doesn't return a valid point implies that `set_hold_position()` (which defines an empty trajectory with no valid points) has been called somewhere. We should stop the robot in this case.

Note the existing TODO that it is unclear how to stop an effort-controlled robot.

Note also that we should not reach this code under any other circumstance, since all incoming trajectories are validated before copied to the realtime pointer. Therefore, reaching this code without `set_hold_position()` implies a bug in our validation code, and I would argue stopping the robot is reasonable behavior.

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
