### PR TITLE
[JTC] Fix time sources and wrong checks in tests

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -231,7 +231,7 @@ controller_interface::return_type JointTrajectoryController::update(
             const rclcpp::Time traj_start = (*traj_point_active_ptr_)->get_trajectory_start_time();
             const rclcpp::Time traj_end = traj_start + start_segment_itr->time_from_start;
 
-            time_difference = get_node()->now().seconds() - traj_end.seconds();
+            time_difference = time.seconds() - traj_end.seconds();
 
             if (time_difference > default_tolerances_.goal_time_tolerance)
             {

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -502,6 +502,16 @@ TEST_P(TestTrajectoryActionsTestParameterized, test_goal_tolerances_fail)
   EXPECT_EQ(
     control_msgs::action::FollowJointTrajectory_Result::GOAL_TOLERANCE_VIOLATED,
     common_action_result_code_);
+
+  // run an update, it should be holding the last received goal
+  updateController(rclcpp::Duration::from_seconds(0.01));
+
+  if (traj_controller_->has_position_command_interface())
+  {
+    EXPECT_NEAR(4.0, joint_pos_[0], COMMON_THRESHOLD);
+    EXPECT_NEAR(5.0, joint_pos_[1], COMMON_THRESHOLD);
+    EXPECT_NEAR(6.0, joint_pos_[2], COMMON_THRESHOLD);
+  }
 }
 
 TEST_P(TestTrajectoryActionsTestParameterized, test_no_time_from_start_state_tolerance_fail)

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1109,16 +1109,18 @@ TEST_P(TrajectoryControllerTestParameterized, test_ignore_partial_old_trajectory
 
   std::vector<std::vector<double>> points_old{{{2., 3., 4.}, {4., 5., 6.}}};
   std::vector<std::vector<double>> points_new{{{-1., -2., -3.}, {-2., -4., -6.}}};
-
+  trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
   const auto delay = std::chrono::milliseconds(500);
   builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(delay)};
+
+  // send points_old and wait to reach first point
   publish(time_from_start, points_old, rclcpp::Time());
-  trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired, expected_old;
   expected_actual.positions = {points_old[0].begin(), points_old[0].end()};
   expected_desired = expected_actual;
   //  Check that we reached end of points_old[0]trajectory
   waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
 
+  // send points_new before the old trajectory is finished
   RCLCPP_INFO(
     traj_controller_->get_node()->get_logger(), "Sending new trajectory partially in the past");
   //  New trajectory first point is in the past, second is in the future

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -365,13 +365,7 @@ public:
     const auto end_time = start_time + wait_time;
     while (clock.now() < end_time)
     {
-      // TODO(christophfroehlich): use the node's clock here for internal comparison
-      // if using RCL_STEADY_TIME ->
-      //   C++ exception with description
-      //   "can't compare times with different time sources" thrown in the test body.
-      // traj_controller_->update(clock.now(), clock.now() - start_time);
-      // maybe we can set the node clock to use RCL_STEADY_TIME too?
-      traj_controller_->update(node_->get_clock()->now(), clock.now() - start_time);
+      traj_controller_->update(clock.now(), clock.now() - start_time);
     }
   }
 


### PR DESCRIPTION
I found some weird time differences when running the tests:

> 4: [WARN] [1687297889.461844027] [test_joint_trajectory_controller]: Aborted due goal_time_tolerance exceeding by 1687208373.175506 seconds

So I tried `RCL_STEADY_TIME` for all clocks and new failures popped up. 

- `JointTrajectoryController::update`: Why would we use the node's clock instead of the time argument of the method?
- `test_goal_tolerances_fail` -> It won't hold the initial position but the last one  from the goal.
- `test_ignore_old_trajectory` -> The new message isn't accepted, so the old message keeps being processed and it will reach its last point instead of the points from the discarded message.