### PR TITLE
Run workflow on feature branches

### DIFF
--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -6,9 +6,13 @@ on:
   workflow_dispatch:
     branches:
       - master
+      - '*feature*'
+      - '*feature/**'
   pull_request:
     branches:
       - master
+      - '*feature*'
+      - '*feature/**'
   push:
     branches:
       - master

--- a/.github/workflows/rolling-binary-build-testing.yml
+++ b/.github/workflows/rolling-binary-build-testing.yml
@@ -6,9 +6,13 @@ on:
   workflow_dispatch:
     branches:
       - master
+      - '*feature*'
+      - '*feature/**'
   pull_request:
     branches:
       - master
+      - '*feature*'
+      - '*feature/**'
   push:
     branches:
       - master

--- a/.github/workflows/rolling-semi-binary-build-main.yml
+++ b/.github/workflows/rolling-semi-binary-build-main.yml
@@ -5,9 +5,13 @@ on:
   workflow_dispatch:
     branches:
       - master
+      - '*feature*'
+      - '*feature/**'
   pull_request:
     branches:
       - master
+      - '*feature*'
+      - '*feature/**'
   push:
     branches:
       - master

--- a/.github/workflows/rolling-semi-binary-build-testing.yml
+++ b/.github/workflows/rolling-semi-binary-build-testing.yml
@@ -5,9 +5,13 @@ on:
   workflow_dispatch:
     branches:
       - master
+      - '*feature*'
+      - '*feature/**'
   pull_request:
     branches:
       - master
+      - '*feature*'
+      - '*feature/**'
   push:
     branches:
       - master


### PR DESCRIPTION
Rolling build workflows now should run on `workflow_dispatch` and `pull_request` events on branches matching `*feature*` or `*feature/**`.

These jobs fail now, because of #688