### PR TITLE
[JTC] Add test for velocity error with effort cmd interface

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -133,7 +133,7 @@ controller_interface::return_type JointTrajectoryController::update(
     {
       error.positions[index] = desired.positions[index] - current.positions[index];
     }
-    if (has_velocity_state_interface_ && has_velocity_command_interface_)
+    if (has_velocity_state_interface_ && (has_velocity_command_interface_ || has_effort_command_interface_))
     {
       error.velocities[index] = desired.velocities[index] - current.velocities[index];
     }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -133,7 +133,9 @@ controller_interface::return_type JointTrajectoryController::update(
     {
       error.positions[index] = desired.positions[index] - current.positions[index];
     }
-    if (has_velocity_state_interface_ && (has_velocity_command_interface_ || has_effort_command_interface_))
+    if (
+      has_velocity_state_interface_ &&
+      (has_velocity_command_interface_ || has_effort_command_interface_))
     {
       error.velocities[index] = desired.velocities[index] - current.velocities[index];
     }

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -304,7 +304,7 @@ TEST_P(TestTrajectoryActionsTestParameterized, test_success_multi_point_sendgoal
 /**
  * Makes sense with position command interface only,
  * because no integration to position state interface is implemented
-*/
+ */
 TEST_F(TestTrajectoryActions, test_goal_tolerances_single_point_success)
 {
   // set tolerance parameters
@@ -349,7 +349,7 @@ TEST_F(TestTrajectoryActions, test_goal_tolerances_single_point_success)
 /**
  * Makes sense with position command interface only,
  * because no integration to position state interface is implemented
-*/
+ */
 TEST_F(TestTrajectoryActions, test_goal_tolerances_multi_point_success)
 {
   // set tolerance parameters

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -674,6 +674,96 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_normalized)
 }
 
 /**
+ * @brief check if use_closed_loop_pid is active
+ */
+TEST_P(TrajectoryControllerTestParameterized, use_closed_loop_pid)
+{
+  rclcpp::executors::MultiThreadedExecutor executor;
+
+  SetUpAndActivateTrajectoryController(executor);
+
+  if (
+    (traj_controller_->has_velocity_command_interface() &&
+     !traj_controller_->has_position_command_interface() &&
+     !traj_controller_->has_effort_command_interface() &&
+     !traj_controller_->has_acceleration_command_interface() &&
+     !traj_controller_->is_open_loop()) ||
+    traj_controller_->has_effort_command_interface())
+  {
+    EXPECT_TRUE(traj_controller_->use_closed_loop_pid_adapter());
+  }
+}
+
+/**
+ * @brief check if velocity error is calculated correctly
+ */
+TEST_P(TrajectoryControllerTestParameterized, velocity_error)
+{
+  rclcpp::executors::MultiThreadedExecutor executor;
+  SetUpAndActivateTrajectoryController(executor, true, {}, true);
+  subscribeToState();
+
+  size_t n_joints = joint_names_.size();
+
+  // send msg
+  constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(250);
+  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(FIRST_POINT_TIME)};
+  // *INDENT-OFF*
+  std::vector<std::vector<double>> points_positions{
+    {{3.3, 4.4, 6.6}}, {{7.7, 8.8, 9.9}}, {{10.10, 11.11, 12.12}}};
+  std::vector<std::vector<double>> points_velocities{
+    {{0.1, 0.1, 0.1}}, {{0.2, 0.2, 0.2}}, {{0.3, 0.3, 0.3}}};
+  // *INDENT-ON*
+  publish(time_from_start, points_positions, rclcpp::Time(), {}, points_velocities);
+  traj_controller_->wait_for_trajectory(executor);
+
+  // first update
+  updateController(rclcpp::Duration(FIRST_POINT_TIME));
+
+  // Spin to receive latest state
+  executor.spin_some();
+  auto state_msg = getState();
+  ASSERT_TRUE(state_msg);
+
+  // has the msg the correct vector sizes?
+  EXPECT_EQ(n_joints, state_msg->reference.positions.size());
+  EXPECT_EQ(n_joints, state_msg->feedback.positions.size());
+  EXPECT_EQ(n_joints, state_msg->error.positions.size());
+  if (traj_controller_->has_velocity_state_interface())
+  {
+    EXPECT_EQ(n_joints, state_msg->reference.velocities.size());
+    EXPECT_EQ(n_joints, state_msg->feedback.velocities.size());
+    EXPECT_EQ(n_joints, state_msg->error.velocities.size());
+  }
+  if (traj_controller_->has_acceleration_state_interface())
+  {
+    EXPECT_EQ(n_joints, state_msg->reference.accelerations.size());
+    EXPECT_EQ(n_joints, state_msg->feedback.accelerations.size());
+    EXPECT_EQ(n_joints, state_msg->error.accelerations.size());
+  }
+
+  // no change in state interface should happen
+  if (traj_controller_->has_velocity_state_interface())
+  {
+    EXPECT_EQ(state_msg->feedback.velocities, INITIAL_VEL_JOINTS);
+  }
+  // is the velocity error correct?
+  if (
+    traj_controller_->use_closed_loop_pid_adapter()  // always needed for PID controller
+    || (traj_controller_->has_velocity_state_interface() &&
+        traj_controller_->has_velocity_command_interface()))
+  {
+    // don't check against a value, because spline intepolation might overshoot depending on
+    // interface combinations
+    EXPECT_GE(state_msg->error.velocities[0], points_velocities[0][0]);
+    EXPECT_GE(state_msg->error.velocities[1], points_velocities[0][1]);
+    EXPECT_GE(state_msg->error.velocities[2], points_velocities[0][2]);
+  }
+
+  executor.cancel();
+}
+
+/**
  * @brief test_jumbled_joint_order Test sending trajectories with a joint order different from
  * internal controller order
  */

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -105,6 +105,11 @@ public:
   {
     return last_commanded_state_;
   }
+  bool has_position_state_interface() { return has_position_state_interface_; }
+
+  bool has_velocity_state_interface() { return has_velocity_state_interface_; }
+
+  bool has_acceleration_state_interface() { return has_acceleration_state_interface_; }
 
   bool has_position_command_interface() { return has_position_command_interface_; }
 
@@ -115,6 +120,8 @@ public:
   bool has_effort_command_interface() { return has_effort_command_interface_; }
 
   bool use_closed_loop_pid_adapter() { return use_closed_loop_pid_adapter_; }
+
+  bool is_open_loop() { return params_.open_loop_control; }
 
   rclcpp::WaitSet joint_cmd_sub_wait_set_;
 };
@@ -294,13 +301,14 @@ public:
   /// Publish trajectory msgs with multiple points
   /**
    *  delay_btwn_points - delay between each points
-   *  points - vector of trajectories. One point per controlled joint
+   *  points_positions - vector of trajectory-positions. One point per controlled joint
    *  joint_names - names of joints, if empty, will use joint_names_ up to the number of provided
    * points
+   *  points - vector of trajectory-velocities. One point per controlled joint
    */
   void publish(
     const builtin_interfaces::msg::Duration & delay_btwn_points,
-    const std::vector<std::vector<double>> & points, rclcpp::Time start_time,
+    const std::vector<std::vector<double>> & points_positions, rclcpp::Time start_time,
     const std::vector<std::string> & joint_names = {},
     const std::vector<std::vector<double>> & points_velocities = {})
   {
@@ -320,14 +328,15 @@ public:
     trajectory_msgs::msg::JointTrajectory traj_msg;
     if (joint_names.empty())
     {
-      traj_msg.joint_names = {joint_names_.begin(), joint_names_.begin() + points[0].size()};
+      traj_msg.joint_names = {
+        joint_names_.begin(), joint_names_.begin() + points_positions[0].size()};
     }
     else
     {
       traj_msg.joint_names = joint_names;
     }
     traj_msg.header.stamp = start_time;
-    traj_msg.points.resize(points.size());
+    traj_msg.points.resize(points_positions.size());
 
     builtin_interfaces::msg::Duration duration_msg;
     duration_msg.sec = delay_btwn_points.sec;
@@ -335,14 +344,14 @@ public:
     rclcpp::Duration duration(duration_msg);
     rclcpp::Duration duration_total(duration_msg);
 
-    for (size_t index = 0; index < points.size(); ++index)
+    for (size_t index = 0; index < points_positions.size(); ++index)
     {
       traj_msg.points[index].time_from_start = duration_total;
 
-      traj_msg.points[index].positions.resize(points[index].size());
-      for (size_t j = 0; j < points[index].size(); ++j)
+      traj_msg.points[index].positions.resize(points_positions[index].size());
+      for (size_t j = 0; j < points_positions[index].size(); ++j)
       {
-        traj_msg.points[index].positions[j] = points[index][j];
+        traj_msg.points[index].positions[j] = points_positions[index][j];
       }
       duration_total = duration_total + duration;
     }


### PR DESCRIPTION
For details see #679.
This needs to go into jtc-features, because parameterized tests for effort controllers are not activated on master yet.

I reverted #682 here, the segfault introduced there should be fixed directly on master before the merge of this one here IMHO.