### PR TITLE
Add CI workflow to check docs

### DIFF
--- a/.github/workflows/ci-check-docs.yml
+++ b/.github/workflows/ci-check-docs.yml
@@ -1,0 +1,12 @@
+name: Check Docs
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  check-docs:
+    name: Check Docs
+    uses: ros-controls/control.ros.org/.github/workflows/reusable-sphinx-check-single-version.yml@master
+    with:
+      ROS2_CONTROLLERS_PR: ${{ github.ref }}


### PR DESCRIPTION
This should add a CI job with the reusable workflow from https://github.com/ros-controls/control.ros.org/pull/125. It checks if there are no warnings from sphinx while building the docs.