### PR TITLE
Fixed period computation in test

### DIFF
--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -373,9 +373,13 @@ public:
     auto clock = rclcpp::Clock(RCL_STEADY_TIME);
     const auto start_time = clock.now();
     const auto end_time = start_time + wait_time;
+    auto previous_time = start_time;
+
     while (clock.now() < end_time)
     {
-      traj_controller_->update(clock.now(), clock.now() - start_time);
+      auto now = clock.now();
+      traj_controller_->update(now, now - previous_time);
+      previous_time = now;
     }
   }
 


### PR DESCRIPTION
As discussed and confirmed in https://github.com/ros-controls/ros2_controllers/pull/686 there seem to be a wrong computation of the period (dt)  passed to `traj_controller->update` in the `UpdateController` test helper function.

Fixing it does not make tests fail, but is, first necessary to avoid keeping wrong computations, and second for future up-coming improvement that relies on dt to update the state interface as well.