### PR TITLE
Fix link in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.md
@@ -28,7 +28,7 @@ Nothing. This issue is meant to welcome you to Open Source :) We are happy to wa
 
 - [ ] 🙋 **Claim this issue**: Comment below. If someone else has claimed it, ask if they've opened a pull request already and if they're stuck -- maybe you can help them solve a problem or move it along!
 
-- [ ] 🗄️ **Create a local workspace** for making your changes and testing [following these instructions](https://docs.ros.org/en/rolling/Tutorials/Workspace/Creating-A-Workspace.html), for Step3 use "Download Source Code" section with [these instructions](https://ros-controls.github.io/control.ros.org/getting_started.html#compiling).
+- [ ] 🗄️ **Create a local workspace** for making your changes and testing [following these instructions](https://docs.ros.org/en/rolling/Tutorials/Workspace/Creating-A-Workspace.html), for Step3 use "Download Source Code" section with [these instructions](https://control.ros.org/master/doc/getting_started/getting_started.html#building-from-source).
 
 - [ ] 🍴 **Fork the repository** using the handy button at the top of the repository page and **clone** it into `~/ws_ros2_control/src/ros-controls/ros2_controllers`, [here is a guide that you can follow](https://guides.github.com/activities/forking/) (You will have to remove or empty the existing `ros2_controllers` folder before cloning your own fork)
 
@@ -53,7 +53,7 @@ Nothing. This issue is meant to welcome you to Open Source :) We are happy to wa
 
 Don’t hesitate to ask questions or to get help if you feel like you are getting stuck. For example leave a comment below!
 Furthermore, you find helpful resources here:
-* [ROS2 Control Contribution Guide](https://ros-controls.github.io/control.ros.org/contributing.html)
+* [ROS2 Control Contribution Guide](https://control.ros.org/master/doc/contributing/contributing.html)
 * [ROS2 Tutorials](https://docs.ros.org/en/rolling/Tutorials.html)
 * [ROS Answers](https://answers.ros.org/questions/)
 

--- a/doc/writing_new_controller.rst
+++ b/doc/writing_new_controller.rst
@@ -5,7 +5,7 @@
 Writing a new controller
 ========================
 
-In this framework controllers are libraries, dynamically loaded by the controller manager using the `pluginlib <https://docs.ros.org/en/{REPOS_FILE_BRANCH}/Tutorials/Beginner-Client-Libraries/Pluginlib.html>`_ interface.
+In this framework controllers are libraries, dynamically loaded by the controller manager using the `pluginlib <https://docs.ros.org/en/{DISTRO}/Tutorials/Beginner-Client-Libraries/Pluginlib.html>`_ interface.
 The following is a step-by-step guide to create source files, basic tests, and compile rules for a new controller.
 
 1. **Preparing package**

--- a/joint_trajectory_controller/README.md
+++ b/joint_trajectory_controller/README.md
@@ -2,4 +2,4 @@
 
 The package implements controllers to interpolate joint's trajectory.
 
-For detailed documentation check the `docs` folder or [ros2_control documentation](https://ros-controls.github.io/control.ros.org/).
+For detailed documentation check the `docs` folder or [ros2_control documentation](https://control.ros.org/).


### PR DESCRIPTION
Use `{DISTRO}` (e.g., rolling) instead of `{REPOS_FILE_BRANCH}` (e.g., master) for the links on docs.ros.org.

See https://github.com/ros-controls/control.ros.org/issues/131