### PR TITLE
Update ci-ros-lint.yml and copyright format

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -18,17 +18,23 @@ jobs:
         distribution: rolling
         linter: ${{ matrix.linter }}
         package-name:
+          ackermann_steering_controller
+          admittance_controller
+          bicycle_steering_controller
           diff_drive_controller
           effort_controllers
           force_torque_sensor_broadcaster
           forward_command_controller
+          gripper_controllers
+          imu_sensor_broadcaster
           joint_state_broadcaster
           joint_trajectory_controller
-          gripper_controllers
           position_controllers
-          ros2_controllers
           ros2_controllers_test_nodes
+          rqt_joint_trajectory_controller
+          steering_controllers_library
           tricycle_controller
+          tricycle_steering_controller
           velocity_controllers
 
 
@@ -48,15 +54,21 @@ jobs:
         linter: cpplint
         arguments: "--linelength=100 --filter=-whitespace/newline"
         package-name:
+          ackermann_steering_controller
+          admittance_controller
+          bicycle_steering_controller
           diff_drive_controller
           effort_controllers
           force_torque_sensor_broadcaster
           forward_command_controller
+          gripper_controllers
+          imu_sensor_broadcaster
           joint_state_broadcaster
           joint_trajectory_controller
-          gripper_controllers
           position_controllers
-          ros2_controllers
           ros2_controllers_test_nodes
+          rqt_joint_trajectory_controller
+          steering_controllers_library
           tricycle_controller
+          tricycle_steering_controller
           velocity_controllers

--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   ament_lint:
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +34,7 @@ jobs:
 
   ament_lint_100:
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   ament_lint:
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -30,6 +30,7 @@ jobs:
           joint_state_broadcaster
           joint_trajectory_controller
           position_controllers
+          ros2_controllers
           ros2_controllers_test_nodes
           rqt_joint_trajectory_controller
           steering_controllers_library
@@ -66,6 +67,7 @@ jobs:
           joint_state_broadcaster
           joint_trajectory_controller
           position_controllers
+          ros2_controllers
           ros2_controllers_test_nodes
           rqt_joint_trajectory_controller
           steering_controllers_library

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -1,18 +1,16 @@
-/*********************************************************************
- * Copyright (c) 2023, Stogl Robotics Consulting UG (haftungsbeschränkt)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *********************************************************************/
+// Copyright (c) 2023, Stogl Robotics Consulting UG (haftungsbeschränkt)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /*
  * Author: dr. sc. Tomislav Petkovic


### PR DESCRIPTION
- Update ubuntu version for ament_cpplint job, this maybe fixes the [workflow](https://github.com/ros-controls/ros2_controllers/actions/workflows/ci-ros-lint.yml)
- Update package list for jobs
- Format failing copyright statement

Should we use ubuntu-latest or an explicit version instead? This is not consistent with the other workflows.