### PR TITLE
Fix out of bound access in admittance controller

### DIFF
--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -28,6 +28,9 @@
 
 namespace admittance_controller
 {
+
+constexpr auto NUM_CARTESIAN_DOF = 6;  // (3 translation + 3 rotation)
+
 /// Configure admittance rule memory for num joints and load kinematics interface
 controller_interface::return_type AdmittanceRule::configure(
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node, const size_t num_joints)
@@ -83,10 +86,10 @@ controller_interface::return_type AdmittanceRule::reset(const size_t num_joints)
   {
     state_message_.joint_state.name = parameters_.joints;
   }
-  state_message_.mass.data.resize(6, 0.0);
-  state_message_.selected_axes.data.resize(6, 0);
-  state_message_.damping.data.resize(6, 0);
-  state_message_.stiffness.data.resize(6, 0);
+  state_message_.mass.data.resize(NUM_CARTESIAN_DOF, 0.0);
+  state_message_.selected_axes.data.resize(NUM_CARTESIAN_DOF, 0);
+  state_message_.damping.data.resize(NUM_CARTESIAN_DOF, 0);
+  state_message_.stiffness.data.resize(NUM_CARTESIAN_DOF, 0);
   state_message_.wrench_base.header.frame_id = parameters_.kinematics.base;
   state_message_.admittance_velocity.header.frame_id = parameters_.kinematics.base;
   state_message_.admittance_acceleration.header.frame_id = parameters_.kinematics.base;
@@ -122,7 +125,7 @@ void AdmittanceRule::apply_parameters_update()
   vec_to_eigen(parameters_.admittance.stiffness, admittance_state_.stiffness);
   vec_to_eigen(parameters_.admittance.selected_axes, admittance_state_.selected_axes);
 
-  for (size_t i = 0; i < 6; ++i)
+  for (size_t i = 0; i < NUM_CARTESIAN_DOF; ++i)
   {
     admittance_state_.mass_inv[i] = 1.0 / parameters_.admittance.mass[i];
     admittance_state_.damping[i] = parameters_.admittance.damping_ratio[i] * 2 *
@@ -331,7 +334,7 @@ void AdmittanceRule::process_wrench_measurements(
 
 const control_msgs::msg::AdmittanceControllerState & AdmittanceRule::get_controller_state()
 {
-  for (size_t i = 0; i < 6; ++i)
+  for (size_t i = 0; i < NUM_CARTESIAN_DOF; ++i)
   {
     state_message_.stiffness.data[i] = admittance_state_.stiffness[i];
     state_message_.damping.data[i] = admittance_state_.damping[i];

--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -331,16 +331,20 @@ void AdmittanceRule::process_wrench_measurements(
 
 const control_msgs::msg::AdmittanceControllerState & AdmittanceRule::get_controller_state()
 {
+  for (size_t i = 0; i < 6; ++i)
+  {
+    state_message_.stiffness.data[i] = admittance_state_.stiffness[i];
+    state_message_.damping.data[i] = admittance_state_.damping[i];
+    state_message_.selected_axes.data[i] = static_cast<bool>(admittance_state_.selected_axes[i]);
+    state_message_.mass.data[i] = admittance_state_.mass[i];
+  }
+
   for (size_t i = 0; i < parameters_.joints.size(); ++i)
   {
     state_message_.joint_state.name[i] = parameters_.joints[i];
     state_message_.joint_state.position[i] = admittance_state_.joint_pos[i];
     state_message_.joint_state.velocity[i] = admittance_state_.joint_vel[i];
     state_message_.joint_state.effort[i] = admittance_state_.joint_acc[i];
-    state_message_.stiffness.data[i] = admittance_state_.stiffness[i];
-    state_message_.damping.data[i] = admittance_state_.damping[i];
-    state_message_.selected_axes.data[i] = static_cast<bool>(admittance_state_.selected_axes[i]);
-    state_message_.mass.data[i] = admittance_state_.mass[i];
   }
 
   state_message_.wrench_base.wrench.force.x = admittance_state_.wrench_base[0];


### PR DESCRIPTION
If the number of robot joints is more than 6, admittance controller currently segfaults with an out-of-bound access error.
This PR moves a few state updates out of the loop which iterates over the number of joint states.