### PR TITLE
[JTC] Remove wrong description about specialized versions

### DIFF
--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -179,17 +179,6 @@ Services
   Query controller state at any future time
 
 
-Specialized versions of JointTrajectoryController
---------------------------------------------------------------
-(TBD in ...)
-
-The controller types are placed into namespaces according to their command types for the hardware (see :ref:`controllers`).
-
-The following version of the Joint Trajectory Controller are available mapping the following interfaces:
-
-* position_controllers::JointTrajectoryController
-
-
 Further information
 --------------------------------------------------------------
 


### PR DESCRIPTION
This removes the wrong description from the docs.

We decided in the last WG meeting that we won't implement the specialized versions of JTC -> If the usage of JTC is not clear we should improve the docs instead of adding additional code.

