### PR TITLE
Docs: Use tabs for unique headings

### DIFF
--- a/forward_command_controller/doc/userdoc.rst
+++ b/forward_command_controller/doc/userdoc.rst
@@ -21,12 +21,12 @@ Parameters
 
 This controller uses the `generate_parameter_library <https://github.com/PickNikRobotics/generate_parameter_library>`_ to handle its parameters.
 
-forward_command_controller
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+   .. tabs::
 
-.. generate_parameter_library_details:: ../src/forward_command_controller_parameters.yaml
+      .. group-tab:: forward_command_controller
 
-multi_interface_forward_command_controller
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        .. generate_parameter_library_details:: ../src/forward_command_controller_parameters.yaml
 
-.. generate_parameter_library_details:: ../src/multi_interface_forward_command_controller_parameters.yaml
+      .. group-tab:: multi_interface_forward_command_controller
+
+        .. generate_parameter_library_details:: ../src/multi_interface_forward_command_controller_parameters.yaml


### PR DESCRIPTION
To use [autosection labels](https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#automatically-label-sections), we need unique headings within the same document.

Needs https://github.com/ros-controls/control.ros.org/pull/161 to enable tabs.