### PR TITLE
[JTC] Fix typos, implicit cast, const member functions

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -249,7 +249,7 @@ protected:
   bool reset();
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  bool has_active_trajectory();
+  bool has_active_trajectory() const;
 
   using JointTrajectoryPoint = trajectory_msgs::msg::JointTrajectoryPoint;
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1517,7 +1517,7 @@ void JointTrajectoryController::resize_joint_trajectory_point_command(
   }
 }
 
-bool JointTrajectoryController::has_active_trajectory()
+bool JointTrajectoryController::has_active_trajectory() const
 {
   return traj_external_point_ptr_ != nullptr && traj_external_point_ptr_->has_trajectory_msg();
 }

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -86,7 +86,7 @@ joint_trajectory_controller:
       i: {
         type: double,
         default_value: 0.0,
-        description: "Intigral gain for PID"
+        description: "Integral gain for PID"
       }
       d: {
         type: double,
@@ -96,7 +96,7 @@ joint_trajectory_controller:
       i_clamp: {
         type: double,
         default_value: 0.0,
-        description: "Integrale clamp. Symmetrical in both positive and negative direction."
+        description: "Integral clamp. Symmetrical in both positive and negative direction."
       }
       ff_velocity_scale: {
         type: double,

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1531,9 +1531,9 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_co
   // set command values to NaN
   for (size_t i = 0; i < 3; ++i)
   {
-    joint_pos_[i] = 3.1 + i;
-    joint_vel_[i] = 0.25 + i;
-    joint_acc_[i] = 0.02 + i / 10.0;
+    joint_pos_[i] = 3.1 + static_cast<double>(i);
+    joint_vel_[i] = 0.25 + static_cast<double>(i);
+    joint_acc_[i] = 0.02 + static_cast<double>(i) / 10.0;
   }
   SetUpAndActivateTrajectoryController(executor, true, {is_open_loop_parameters}, true);
 

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -102,27 +102,27 @@ public:
 
   void trigger_declare_parameters() { param_listener_->declare_params(); }
 
-  trajectory_msgs::msg::JointTrajectoryPoint get_current_state_when_offset()
+  trajectory_msgs::msg::JointTrajectoryPoint get_current_state_when_offset() const
   {
     return last_commanded_state_;
   }
-  bool has_position_state_interface() { return has_position_state_interface_; }
+  bool has_position_state_interface() const { return has_position_state_interface_; }
 
-  bool has_velocity_state_interface() { return has_velocity_state_interface_; }
+  bool has_velocity_state_interface() const { return has_velocity_state_interface_; }
 
-  bool has_acceleration_state_interface() { return has_acceleration_state_interface_; }
+  bool has_acceleration_state_interface() const { return has_acceleration_state_interface_; }
 
-  bool has_position_command_interface() { return has_position_command_interface_; }
+  bool has_position_command_interface() const { return has_position_command_interface_; }
 
-  bool has_velocity_command_interface() { return has_velocity_command_interface_; }
+  bool has_velocity_command_interface() const { return has_velocity_command_interface_; }
 
-  bool has_acceleration_command_interface() { return has_acceleration_command_interface_; }
+  bool has_acceleration_command_interface() const { return has_acceleration_command_interface_; }
 
-  bool has_effort_command_interface() { return has_effort_command_interface_; }
+  bool has_effort_command_interface() const { return has_effort_command_interface_; }
 
-  bool use_closed_loop_pid_adapter() { return use_closed_loop_pid_adapter_; }
+  bool use_closed_loop_pid_adapter() const { return use_closed_loop_pid_adapter_; }
 
-  bool is_open_loop() { return params_.open_loop_control; }
+  bool is_open_loop() const { return params_.open_loop_control; }
 
   bool has_active_traj() const { return has_active_trajectory(); }
 

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -124,9 +124,9 @@ public:
 
   bool is_open_loop() { return params_.open_loop_control; }
 
-  bool has_active_traj() { return has_active_trajectory(); }
+  bool has_active_traj() const { return has_active_trajectory(); }
 
-  bool has_trivial_traj()
+  bool has_trivial_traj() const
   {
     return has_active_trajectory() && traj_external_point_ptr_->has_nontrivial_msg() == false;
   }


### PR DESCRIPTION
 Fix typos, implicit cast warnings, and declare const member functions as const