### PR TITLE
Update docs for diff drive controller

### DIFF
--- a/admittance_controller/doc/userdoc.rst
+++ b/admittance_controller/doc/userdoc.rst
@@ -11,7 +11,7 @@ The controller implements ``ChainedControllerInterface``, so it is possible to a
 The controller requires an external kinematics plugin to function. The `kinematics_interface <https://github.com/ros-controls/kinematics_interface>`_ repository provides an interface and an implementation that the admittance controller can use.
 
 
-ROS2 interface of the controller
+ROS 2 interface of the controller
 ---------------------------------
 
 Parameters

--- a/diff_drive_controller/doc/userdoc.rst
+++ b/diff_drive_controller/doc/userdoc.rst
@@ -6,71 +6,66 @@ diff_drive_controller
 =====================
 
 Controller for mobile robots with differential drive.
-Input for control are robot body velocity commands which are translated to wheel commands for the differential drive base.
+
+As input it takes velocity commands for the robot body, which are translated to wheel commands for the differential drive base.
+
 Odometry is computed from hardware feedback and published.
-
-Velocity commands
------------------
-
-The controller works with a velocity twist from which it extracts the x component of the linear velocity and the z component of the angular velocity. Velocities on other components are ignored.
-
-Hardware interface type
------------------------
-
-The controller works with wheel joints through a velocity interface.
 
 Other features
 --------------
 
-    Realtime-safe implementation.
-    Odometry publishing
-    Task-space velocity, acceleration and jerk limits
-    Automatic stop after command time-out
+   + Realtime-safe implementation.
+   + Odometry publishing
+   + Task-space velocity, acceleration and jerk limits
+   + Automatic stop after command time-out
 
 
-ros2_control Interfaces
-------------------------
+Description of controller's interfaces
+------------------------------------------------
 
 References
-,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,
 
+(the controller is not yet implemented as chainable controller)
 
-States
-,,,,,,,
+Feedback
+,,,,,,,,,,,,,,
 
+As feedback interface type the joints' position (``hardware_interface::HW_IF_POSITION``) or velocity (``hardware_interface::HW_IF_VELOCITY``,if parameter ``position_feedback=false``) are used.
 
-Commands
+Output
 ,,,,,,,,,
 
+Joints' velocity (``hardware_interface::HW_IF_VELOCITY``) are used.
 
-ROS2 Interfaces
-----------------
+
+ROS 2 Interfaces
+------------------------
 
 Subscribers
 ,,,,,,,,,,,,
+
 ~/cmd_vel [geometry_msgs/msg/TwistStamped]
-  Velocity command for the controller.
+  Velocity command for the controller, if ``use_stamped_vel=true``. The controller extracts the x component of the linear velocity and the z component of the angular velocity. Velocities on other components are ignored.
 
 ~/cmd_vel_unstamped [geometry_msgs::msg::Twist]
-
-~/cmd_vel_out []
-
-
+  Velocity command for the controller, if ``use_stamped_vel=false``. The controller extracts the x component of the linear velocity and the z component of the angular velocity. Velocities on other components are ignored.
 
 
 Publishers
 ,,,,,,,,,,,
-~/odom []
+~/odom [nav_msgs::msg::Odometry]
+  This represents an estimate of the robot's position and velocity in free space.
 
-/tf
+/tf [tf2_msgs::msg::TFMessage]
+  tf tree. Published only if ``enable_odom_tf=true``
 
-
-Services
-,,,,,,,,,
+~/cmd_vel_out [geometry_msgs/msg/TwistStamped]
+  Velocity command for the controller, where limits were applied. Published only if ``publish_limited_velocity=true``
 
 
 Parameters
-------------
+,,,,,,,,,,,,
 
 Check `parameter definition file for details <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/diff_drive_controller/src/diff_drive_controller_parameter.yaml>`_.
 

--- a/doc/writing_new_controller.rst
+++ b/doc/writing_new_controller.rst
@@ -27,7 +27,7 @@ The following is a step-by-step guide to create source files, basic tests, and c
 
 3. **Adding declarations into header file (.hpp)**
 
-   1. Take care that you use header guards. ROS2-style is using ``#ifndef`` and ``#define`` preprocessor directives. (For more information on this, a search engine is your friend :) ).
+   1. Take care that you use header guards. ROS 2-style is using ``#ifndef`` and ``#define`` preprocessor directives. (For more information on this, a search engine is your friend :) ).
 
    2. include ``"controller_interface/controller_interface.hpp"`` and ``visibility_control.h`` if you are using one.
 


### PR DESCRIPTION
While having a look on https://github.com/ros-controls/ros2_control_demos/pull/350 I realized, that the diff drive controller documentation was in a rather incomplete state.

I updated it now (and applied another ROS-space-2 flaw)