### PR TITLE
[Doc] Add specific documentation on the available fw cmd controllers

### DIFF
--- a/effort_controllers/doc/userdoc.rst
+++ b/effort_controllers/doc/userdoc.rst
@@ -7,7 +7,7 @@ effort_controllers
 
 This is a collection of controllers that work using the "effort" joint command interface but may accept different joint-level commands at the controller level, e.g. controlling the effort on a certain joint to achieve a set position.
 
-Currently, there is only one controller in this package:
+The package contains the following controllers:
 
 effort_controllers/JointGroupEffortController
 -------------------------------------------------

--- a/effort_controllers/doc/userdoc.rst
+++ b/effort_controllers/doc/userdoc.rst
@@ -38,10 +38,10 @@ An example parameter file is given here
     ros__parameters:
       update_rate: 100  # Hz
 
-      effort_controllers:
+      effort_controller:
         type: effort_controllers/JointGroupEffortController
 
-  effort_controllers:
+  effort_controller:
     ros__parameters:
       joints:
         - slider_to_cart

--- a/effort_controllers/doc/userdoc.rst
+++ b/effort_controllers/doc/userdoc.rst
@@ -7,7 +7,41 @@ effort_controllers
 
 This is a collection of controllers that work using the "effort" joint command interface but may accept different joint-level commands at the controller level, e.g. controlling the effort on a certain joint to achieve a set position.
 
-Hardware interface type
------------------------
+Currently, there is only one controller in this package:
 
-These controllers work with joints using the "effort" command interface.
+effort_controllers/JointGroupEffortController
+-------------------------------------------------
+
+This is specialization of the :ref:`forward_command_controller <forward_command_controller_userdoc>` that works using the "effort" joint interface.
+
+
+ROS 2 interface of the controller
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Topics
+,,,,,,,,,,,,,,,,,,
+
+~/commands (input topic) [std_msgs::msg::Float64MultiArray]
+  Joints' effort commands
+
+
+Parameters
+,,,,,,,,,,,,,,,,,,
+This controller overrides the interface parameter from :ref:`forward_command_controller <forward_command_controller_userdoc>`, and the
+``joints`` parameter is the only one that is required.
+
+An example parameter file is given here
+
+.. code-block:: yaml
+
+  controller_manager:
+    ros__parameters:
+      update_rate: 100  # Hz
+
+      effort_controllers:
+        type: effort_controllers/JointGroupEffortController
+
+  effort_controllers:
+    ros__parameters:
+      joints:
+        - slider_to_cart

--- a/forward_command_controller/doc/userdoc.rst
+++ b/forward_command_controller/doc/userdoc.rst
@@ -16,8 +16,18 @@ Hardware interface type
 
 This controller can be used for every type of command interface.
 
+
+ROS 2 interface of the controller
+---------------------------------
+
+Topics
+^^^^^^^
+
+~/commands (input topic) [std_msgs::msg::Float64MultiArray]
+  Target joint commands
+
 Parameters
-------------
+^^^^^^^^^^^^^^
 
 This controller uses the `generate_parameter_library <https://github.com/PickNikRobotics/generate_parameter_library>`_ to handle its parameters.
 

--- a/position_controllers/doc/userdoc.rst
+++ b/position_controllers/doc/userdoc.rst
@@ -7,7 +7,41 @@ position_controllers
 
 This is a collection of controllers that work using the "position" joint command interface but may accept different joint-level commands at the controller level, e.g. controlling the position on a certain joint to achieve a set velocity.
 
-Hardware interface type
------------------------
+Currently, there is only one controller in this package:
 
-These controllers work with joints using the "position" command interface.
+position_controllers/JointGroupPositionController
+-------------------------------------------------
+
+This is specialization of the :ref:`forward_command_controller <forward_command_controller_userdoc>` that works using the "position" joint interface.
+
+
+ROS 2 interface of the controller
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Topics
+,,,,,,,,,,,,,,,,,,
+
+~/commands (input topic) [std_msgs::msg::Float64MultiArray]
+  Joints' position commands
+
+
+Parameters
+,,,,,,,,,,,,,,,,,,
+This controller overrides the interface parameter from :ref:`forward_command_controller <forward_command_controller_userdoc>`, and the
+``joints`` parameter is the only one that is required.
+
+An example parameter file is given here
+
+.. code-block:: yaml
+
+  controller_manager:
+    ros__parameters:
+      update_rate: 100  # Hz
+
+      position_controller:
+        type: position_controllers/JointGroupPositionController
+
+  position_controller:
+    ros__parameters:
+      joints:
+        - slider_to_cart

--- a/position_controllers/doc/userdoc.rst
+++ b/position_controllers/doc/userdoc.rst
@@ -7,7 +7,7 @@ position_controllers
 
 This is a collection of controllers that work using the "position" joint command interface but may accept different joint-level commands at the controller level, e.g. controlling the position on a certain joint to achieve a set velocity.
 
-Currently, there is only one controller in this package:
+The package contains the following controllers:
 
 position_controllers/JointGroupPositionController
 -------------------------------------------------

--- a/velocity_controllers/doc/userdoc.rst
+++ b/velocity_controllers/doc/userdoc.rst
@@ -7,7 +7,7 @@ velocity_controllers
 
 This is a collection of controllers that work using the "velocity" joint command interface but may accept different joint-level commands at the controller level, e.g. controlling the velocity on a certain joint to achieve a set position.
 
-Currently, there is only one controller in this package:
+The package contains the following controllers:
 
 velocity_controllers/JointGroupVelocityController
 -------------------------------------------------

--- a/velocity_controllers/doc/userdoc.rst
+++ b/velocity_controllers/doc/userdoc.rst
@@ -7,7 +7,41 @@ velocity_controllers
 
 This is a collection of controllers that work using the "velocity" joint command interface but may accept different joint-level commands at the controller level, e.g. controlling the velocity on a certain joint to achieve a set position.
 
-Hardware interface type
------------------------
+Currently, there is only one controller in this package:
 
-These controllers work with joints using the "velocity" command interface.
+velocity_controllers/JointGroupVelocityController
+-------------------------------------------------
+
+This is specialization of the :ref:`forward_command_controller <forward_command_controller_userdoc>` that works using the "velocity" joint interface.
+
+
+ROS 2 interface of the controller
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Topics
+,,,,,,,,,,,,,,,,,,
+
+~/commands (input topic) [std_msgs::msg::Float64MultiArray]
+  Joints' velocity commands
+
+
+Parameters
+,,,,,,,,,,,,,,,,,,
+This controller overrides the interface parameter from :ref:`forward_command_controller <forward_command_controller_userdoc>`, and the
+``joints`` parameter is the only one that is required.
+
+An example parameter file is given here
+
+.. code-block:: yaml
+
+  controller_manager:
+    ros__parameters:
+      update_rate: 100  # Hz
+
+      velocity_controller:
+        type: velocity_controllers/JointGroupVelocityController
+
+  velocity_controller:
+    ros__parameters:
+      joints:
+        - slider_to_cart


### PR DESCRIPTION
The existing documentation was honestly speaking rather misleading than helpful :) I hope this improved now