### PR TITLE
[Docs+CI] Add range sensor to controller index and lint job

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -32,6 +32,7 @@ jobs:
           joint_state_broadcaster
           joint_trajectory_controller
           position_controllers
+          range_sensor_broadcaster
           ros2_controllers
           ros2_controllers_test_nodes
           rqt_joint_trajectory_controller
@@ -69,6 +70,7 @@ jobs:
           joint_state_broadcaster
           joint_trajectory_controller
           position_controllers
+          range_sensor_broadcaster
           ros2_controllers
           ros2_controllers_test_nodes
           rqt_joint_trajectory_controller

--- a/doc/controllers_index.rst
+++ b/doc/controllers_index.rst
@@ -63,6 +63,7 @@ Available Broadcasters
 .. toctree::
    :titlesonly:
 
-   Joint State Broadcaster <../joint_state_broadcaster/doc/userdoc.rst>
-   Imu Sensor Broadcaster <../imu_sensor_broadcaster/doc/userdoc.rst>
    Force Torque Sensor Broadcaster <../force_torque_sensor_broadcaster/doc/userdoc.rst>
+   Imu Sensor Broadcaster <../imu_sensor_broadcaster/doc/userdoc.rst>
+   Joint State Broadcaster <../joint_state_broadcaster/doc/userdoc.rst>
+   Range Sensor Broadcaster <../range_sensor_broadcaster/doc/userdoc.rst>


### PR DESCRIPTION
A small appendix to #725 

- update lint job
- add controller to index, see [this warning](https://github.com/ros-controls/control.ros.org/actions/runs/6105788073)