### PR TITLE
[gripper] Add test for effort gripper controller

### DIFF
--- a/gripper_controllers/test/test_gripper_controllers.hpp
+++ b/gripper_controllers/test/test_gripper_controllers.hpp
@@ -26,20 +26,22 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 
 using hardware_interface::CommandInterface;
+using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::HW_IF_VELOCITY;
 using hardware_interface::StateInterface;
 
 namespace
 {
-
 // subclassing and friending so we can access member variables
+template <const char * HardwareInterface>
 class FriendGripperController
-: public gripper_action_controller::GripperActionController<HW_IF_POSITION>
+: public gripper_action_controller::GripperActionController<HardwareInterface>
 {
   FRIEND_TEST(GripperControllerTest, CommandSuccessTest);
 };
 
+template <typename T>
 class GripperControllerTest : public ::testing::Test
 {
 public:
@@ -53,7 +55,7 @@ public:
   void SetUpHandles();
 
 protected:
-  std::unique_ptr<FriendGripperController> controller_;
+  std::unique_ptr<FriendGripperController<T::value>> controller_;
 
   // dummy joint state values used for tests
   const std::string joint_name_ = "joint1";
@@ -62,7 +64,7 @@ protected:
 
   StateInterface joint_1_pos_state_{joint_name_, HW_IF_POSITION, &joint_states_[0]};
   StateInterface joint_1_vel_state_{joint_name_, HW_IF_VELOCITY, &joint_states_[1]};
-  CommandInterface joint_1_pos_cmd_{joint_name_, HW_IF_POSITION, &joint_commands_[0]};
+  CommandInterface joint_1_cmd_{joint_name_, T::value, &joint_commands_[0]};
 };
 
 }  // anonymous namespace


### PR DESCRIPTION
Add test for effort gripper controller.

Fix #764 

GripperController uses template parameters, so I used type-parameterized tests.
https://github.com/google/googletest/blob/main/docs/advanced.md#type-parameterized-tests
https://en.cppreference.com/w/cpp/types/integral_constant