### PR TITLE
[JTC] Add note on goal_time=0 in docs

### DIFF
--- a/joint_trajectory_controller/doc/parameters.rst
+++ b/joint_trajectory_controller/doc/parameters.rst
@@ -78,6 +78,7 @@ constraints.stopped_velocity_tolerance (double)
 
 constraints.goal_time (double)
   Maximally allowed tolerance for not reaching the end of the trajectory in a predefined time.
+  If set to zero, the controller will wait an indefinite amount of time.
 
   Default: 0.0 (not checked)
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -117,7 +117,8 @@ joint_trajectory_controller:
     goal_time: {
       type: double,
       default_value: 0.0,
-      description: "Time tolerance for achieving trajectory goal before or after commanded time.",
+      description: "Time tolerance for achieving trajectory goal before or after commanded time.
+        If set to zero, the controller will wait an indefinite amount of time.",
       validation: {
         gt_eq: [0.0],
       }


### PR DESCRIPTION
I added a note on the special case of  `goal_time=0` as suggested with #548.