### PR TITLE
[JTC] Fix state offset tests

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -263,6 +263,12 @@ protected:
 
   void read_state_from_hardware(JointTrajectoryPoint & state);
 
+  /** Assign values from the command interfaces as state.
+   * This is only possible if command AND state interfaces exist for the same type,
+   *  therefore needs check for both.
+   * @param[out] state to be filled with values from command interfaces.
+   * @return true if all interfaces exists and contain non-NaN values, false otherwise.
+   */
   bool read_state_from_command_interfaces(JointTrajectoryPoint & state);
   bool read_commands_from_command_interfaces(JointTrajectoryPoint & commands);
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -261,7 +261,7 @@ protected:
     const rclcpp::Time & time, const JointTrajectoryPoint & desired_state,
     const JointTrajectoryPoint & current_state, const JointTrajectoryPoint & state_error);
 
-  void read_state_from_hardware(JointTrajectoryPoint & state);
+  void read_state_from_state_interfaces(JointTrajectoryPoint & state);
 
   /** Assign values from the command interfaces as state.
    * This is only possible if command AND state interfaces exist for the same type,

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -951,12 +951,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
 
   subscriber_is_active_ = true;
 
-  // Initialize current state storage if hardware state has tracking offset
-  read_state_from_hardware(state_current_);
-  read_state_from_hardware(state_desired_);
-  read_state_from_hardware(last_commanded_state_);
-  // Handle restart of controller by reading from commands if
-  // those are not nan
+  // Handle restart of controller by reading from commands if those are not nan (a controller was
+  // running already)
   trajectory_msgs::msg::JointTrajectoryPoint state;
   resize_joint_trajectory_point(state, dof_);
   if (read_state_from_command_interfaces(state))
@@ -964,6 +960,13 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
     state_current_ = state;
     state_desired_ = state;
     last_commanded_state_ = state;
+  }
+  else
+  {
+    // Initialize current state storage if hardware state has tracking offset
+    read_state_from_hardware(state_current_);
+    read_state_from_hardware(state_desired_);
+    read_state_from_hardware(last_commanded_state_);
   }
 
   // Should the controller start by holding position at the beginning of active state?

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -463,9 +463,18 @@ bool JointTrajectoryController::read_state_from_command_interfaces(JointTrajecto
   }
   else
   {
+    if (has_position_command_interface_ == false)
+    {
+      RCLCPP_DEBUG(get_node()->get_logger(), "No position command interface found.");
+    }
+    if (interface_has_values(joint_command_interface_[0]) == false)
+    {
+      RCLCPP_DEBUG(get_node()->get_logger(), "Interface position doesn't have values.");
+    }
     state.positions.clear();
     has_values = false;
   }
+
   // velocity and acceleration states are optional
   if (has_velocity_state_interface_)
   {
@@ -475,6 +484,14 @@ bool JointTrajectoryController::read_state_from_command_interfaces(JointTrajecto
     }
     else
     {
+      if (has_velocity_command_interface_ == false)
+      {
+        RCLCPP_DEBUG(get_node()->get_logger(), "No velocity command interface found.");
+      }
+      if (interface_has_values(joint_command_interface_[1]) == false)
+      {
+        RCLCPP_DEBUG(get_node()->get_logger(), "Interface velocity doesn't have values.");
+      }
       state.velocities.clear();
       has_values = false;
     }
@@ -492,6 +509,14 @@ bool JointTrajectoryController::read_state_from_command_interfaces(JointTrajecto
     }
     else
     {
+      if (has_acceleration_command_interface_ == false)
+      {
+        RCLCPP_DEBUG(get_node()->get_logger(), "No acceleration command interface found.");
+      }
+      if (interface_has_values(joint_command_interface_[2]) == false)
+      {
+        RCLCPP_DEBUG(get_node()->get_logger(), "Interface acceleration doesn't have values.");
+      }
       state.accelerations.clear();
       has_values = false;
     }
@@ -951,7 +976,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
 
   subscriber_is_active_ = true;
 
-  // Handle restart of controller by reading from commands if those are not nan (a controller was
+  // Handle restart of controller by reading from commands if those are not NaN (a controller was
   // running already)
   trajectory_msgs::msg::JointTrajectoryPoint state;
   resize_joint_trajectory_point(state, dof_);
@@ -963,7 +988,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
   }
   else
   {
-    // Initialize current state storage if hardware state has tracking offset
+    // Initialize current state storage from hardware
     read_state_from_hardware(state_current_);
     read_state_from_hardware(state_desired_);
     read_state_from_hardware(last_commanded_state_);

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -463,14 +463,6 @@ bool JointTrajectoryController::read_state_from_command_interfaces(JointTrajecto
   }
   else
   {
-    if (has_position_command_interface_ == false)
-    {
-      RCLCPP_DEBUG(get_node()->get_logger(), "No position command interface found.");
-    }
-    if (interface_has_values(joint_command_interface_[0]) == false)
-    {
-      RCLCPP_DEBUG(get_node()->get_logger(), "Interface position doesn't have values.");
-    }
     state.positions.clear();
     has_values = false;
   }
@@ -484,14 +476,6 @@ bool JointTrajectoryController::read_state_from_command_interfaces(JointTrajecto
     }
     else
     {
-      if (has_velocity_command_interface_ == false)
-      {
-        RCLCPP_DEBUG(get_node()->get_logger(), "No velocity command interface found.");
-      }
-      if (interface_has_values(joint_command_interface_[1]) == false)
-      {
-        RCLCPP_DEBUG(get_node()->get_logger(), "Interface velocity doesn't have values.");
-      }
       state.velocities.clear();
       has_values = false;
     }
@@ -509,14 +493,6 @@ bool JointTrajectoryController::read_state_from_command_interfaces(JointTrajecto
     }
     else
     {
-      if (has_acceleration_command_interface_ == false)
-      {
-        RCLCPP_DEBUG(get_node()->get_logger(), "No acceleration command interface found.");
-      }
-      if (interface_has_values(joint_command_interface_[2]) == false)
-      {
-        RCLCPP_DEBUG(get_node()->get_logger(), "Interface acceleration doesn't have values.");
-      }
       state.accelerations.clear();
       has_values = false;
     }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -466,7 +466,6 @@ bool JointTrajectoryController::read_state_from_command_interfaces(JointTrajecto
     state.positions.clear();
     has_values = false;
   }
-
   // velocity and acceleration states are optional
   if (has_velocity_state_interface_)
   {

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -959,14 +959,12 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
   if (read_state_from_command_interfaces(state))
   {
     state_current_ = state;
-    state_desired_ = state;
     last_commanded_state_ = state;
   }
   else
   {
     // Initialize current state storage from hardware
     read_state_from_state_interfaces(state_current_);
-    read_state_from_state_interfaces(state_desired_);
     read_state_from_state_interfaces(last_commanded_state_);
   }
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -175,7 +175,7 @@ controller_interface::return_type JointTrajectoryController::update(
 
   // current state update
   state_current_.time_from_start.set__sec(0);
-  read_state_from_hardware(state_current_);
+  read_state_from_state_interfaces(state_current_);
 
   // currently carrying out a trajectory
   if (has_active_trajectory())
@@ -397,7 +397,7 @@ controller_interface::return_type JointTrajectoryController::update(
   return controller_interface::return_type::OK;
 }
 
-void JointTrajectoryController::read_state_from_hardware(JointTrajectoryPoint & state)
+void JointTrajectoryController::read_state_from_state_interfaces(JointTrajectoryPoint & state)
 {
   auto assign_point_from_interface =
     [&](std::vector<double> & trajectory_point_interface, const auto & joint_interface)
@@ -965,9 +965,9 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
   else
   {
     // Initialize current state storage from hardware
-    read_state_from_hardware(state_current_);
-    read_state_from_hardware(state_desired_);
-    read_state_from_hardware(last_commanded_state_);
+    read_state_from_state_interfaces(state_current_);
+    read_state_from_state_interfaces(state_desired_);
+    read_state_from_state_interfaces(last_commanded_state_);
   }
 
   // Should the controller start by holding position at the beginning of active state?

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1668,20 +1668,23 @@ TEST_P(TrajectoryControllerTestParameterized, test_no_jump_when_state_tracking_e
 #endif
 
 // Testing that values are read from state interfaces when hardware is started for the first
-// time and hardware state has offset --> this is indicated by NaN values in state interfaces
+// time and hardware state has offset --> this is indicated by NaN values in command interfaces
 TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_first_controller_start)
 {
   rclcpp::executors::SingleThreadedExecutor executor;
   rclcpp::Parameter is_open_loop_parameters("open_loop_control", true);
 
   // set command values to NaN
-  for (size_t i = 0; i < 3; ++i)
-  {
-    joint_pos_[i] = std::numeric_limits<double>::quiet_NaN();
-    joint_vel_[i] = std::numeric_limits<double>::quiet_NaN();
-    joint_acc_[i] = std::numeric_limits<double>::quiet_NaN();
-  }
-  SetUpAndActivateTrajectoryController(executor, {is_open_loop_parameters}, true);
+  std::vector<double> initial_pos_cmd{3, std::numeric_limits<double>::quiet_NaN()};
+  std::vector<double> initial_vel_cmd{3, std::numeric_limits<double>::quiet_NaN()};
+  std::vector<double> initial_acc_cmd{3, std::numeric_limits<double>::quiet_NaN()};
+
+  SetUpAndActivateTrajectoryController(
+    executor, {is_open_loop_parameters}, true, 0., 1., false, initial_pos_cmd, initial_vel_cmd,
+    initial_acc_cmd);
+
+  // no call of update method, so the values should be read from state interfaces
+  // (command interface are NaN)
 
   auto current_state_when_offset = traj_controller_->get_current_state_when_offset();
 
@@ -1690,21 +1693,13 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_first_co
     EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
 
     // check velocity
-    if (
-      std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end() &&
-      traj_controller_->has_velocity_command_interface())
+    if (traj_controller_->has_velocity_state_interface())
     {
       EXPECT_EQ(current_state_when_offset.velocities[i], joint_state_vel_[i]);
     }
 
     // check acceleration
-    if (
-      std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end() &&
-      traj_controller_->has_acceleration_command_interface())
+    if (traj_controller_->has_acceleration_state_interface())
     {
       EXPECT_EQ(current_state_when_offset.accelerations[i], joint_state_acc_[i]);
     }
@@ -1731,32 +1726,66 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_co
     joint_acc_[i] = 0.02 + static_cast<double>(i) / 10.0;
     initial_acc_cmd.push_back(joint_acc_[i]);
   }
-  SetUpAndActivateTrajectoryController(executor, {is_open_loop_parameters}, true);
+  SetUpAndActivateTrajectoryController(
+    executor, {is_open_loop_parameters}, true, 0., 1., false, initial_pos_cmd, initial_vel_cmd,
+    initial_acc_cmd);
+
+  // no call of update method, so the values should be read from command interfaces
 
   auto current_state_when_offset = traj_controller_->get_current_state_when_offset();
 
   for (size_t i = 0; i < 3; ++i)
   {
-    EXPECT_EQ(current_state_when_offset.positions[i], initial_pos_cmd[i]);
-
-    // check velocity
-    if (
-      std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end() &&
-      traj_controller_->has_velocity_command_interface())
+    // check position
+    if (traj_controller_->has_position_command_interface())
     {
-      EXPECT_EQ(current_state_when_offset.velocities[i], initial_vel_cmd[i]);
+      // check velocity
+      if (traj_controller_->has_velocity_state_interface())
+      {
+        if (traj_controller_->has_velocity_command_interface())
+        {
+          // check acceleration
+          if (traj_controller_->has_acceleration_state_interface())
+          {
+            if (traj_controller_->has_acceleration_command_interface())
+            {
+              // should have set it to last position + velocity + acceleration command
+              EXPECT_EQ(current_state_when_offset.positions[i], initial_pos_cmd[i]);
+              EXPECT_EQ(current_state_when_offset.velocities[i], initial_vel_cmd[i]);
+              EXPECT_EQ(current_state_when_offset.accelerations[i], initial_acc_cmd[i]);
+            }
+            else
+            {
+              // should have set it to the state interface instead
+              EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
+              EXPECT_EQ(current_state_when_offset.velocities[i], joint_state_vel_[i]);
+              EXPECT_EQ(current_state_when_offset.accelerations[i], joint_state_acc_[i]);
+            }
+          }
+          else
+          {
+            // should have set it to last position + velocity command
+            EXPECT_EQ(current_state_when_offset.positions[i], initial_pos_cmd[i]);
+            EXPECT_EQ(current_state_when_offset.velocities[i], initial_vel_cmd[i]);
+          }
+        }
+        else
+        {
+          // should have set it to the state interface instead
+          EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
+          EXPECT_EQ(current_state_when_offset.velocities[i], joint_state_vel_[i]);
+        }
+      }
+      else
+      {
+        // should have set it to last position command
+        EXPECT_EQ(current_state_when_offset.positions[i], initial_pos_cmd[i]);
+      }
     }
-
-    // check acceleration
-    if (
-      std::find(
-        state_interface_types_.begin(), state_interface_types_.end(),
-        hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end() &&
-      traj_controller_->has_acceleration_command_interface())
+    else
     {
-      EXPECT_EQ(current_state_when_offset.accelerations[i], initial_acc_cmd[i]);
+      // should have set it to the state interface instead
+      EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
     }
   }
 

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1713,7 +1713,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_first_co
   executor.cancel();
 }
 
-// Testing that values are read from state interfaces when hardware is started after some values
+// Testing that values are read from command interfaces when hardware is started after some values
 // are set on the hardware commands
 TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_controller_start)
 {

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1719,12 +1719,9 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_co
   std::vector<double> initial_pos_cmd, initial_vel_cmd, initial_acc_cmd;
   for (size_t i = 0; i < 3; ++i)
   {
-    joint_pos_[i] = 3.1 + static_cast<double>(i);
-    initial_pos_cmd.push_back(joint_pos_[i]);
-    joint_vel_[i] = 0.25 + static_cast<double>(i);
-    initial_vel_cmd.push_back(joint_vel_[i]);
-    joint_acc_[i] = 0.02 + static_cast<double>(i) / 10.0;
-    initial_acc_cmd.push_back(joint_acc_[i]);
+    initial_pos_cmd.push_back(3.1 + static_cast<double>(i));
+    initial_vel_cmd.push_back(0.25 + static_cast<double>(i));
+    initial_acc_cmd.push_back(0.02 + static_cast<double>(i) / 10.0);
   }
   SetUpAndActivateTrajectoryController(
     executor, {is_open_loop_parameters}, true, 0., 1., false, initial_pos_cmd, initial_vel_cmd,

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -1672,7 +1672,6 @@ TEST_P(TrajectoryControllerTestParameterized, test_no_jump_when_state_tracking_e
 TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_first_controller_start)
 {
   rclcpp::executors::SingleThreadedExecutor executor;
-  // default if false so it will not be actually set parameter
   rclcpp::Parameter is_open_loop_parameters("open_loop_control", true);
 
   // set command values to NaN
@@ -1697,7 +1696,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_first_co
         hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end() &&
       traj_controller_->has_velocity_command_interface())
     {
-      EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
+      EXPECT_EQ(current_state_when_offset.velocities[i], joint_state_vel_[i]);
     }
 
     // check acceleration
@@ -1707,7 +1706,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_first_co
         hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end() &&
       traj_controller_->has_acceleration_command_interface())
     {
-      EXPECT_EQ(current_state_when_offset.positions[i], joint_state_pos_[i]);
+      EXPECT_EQ(current_state_when_offset.accelerations[i], joint_state_acc_[i]);
     }
   }
 
@@ -1719,15 +1718,18 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_first_co
 TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_controller_start)
 {
   rclcpp::executors::SingleThreadedExecutor executor;
-  // default if false so it will not be actually set parameter
   rclcpp::Parameter is_open_loop_parameters("open_loop_control", true);
 
-  // set command values to NaN
+  // set command values to arbitrary values
+  std::vector<double> initial_pos_cmd, initial_vel_cmd, initial_acc_cmd;
   for (size_t i = 0; i < 3; ++i)
   {
     joint_pos_[i] = 3.1 + static_cast<double>(i);
+    initial_pos_cmd.push_back(joint_pos_[i]);
     joint_vel_[i] = 0.25 + static_cast<double>(i);
+    initial_vel_cmd.push_back(joint_vel_[i]);
     joint_acc_[i] = 0.02 + static_cast<double>(i) / 10.0;
+    initial_acc_cmd.push_back(joint_acc_[i]);
   }
   SetUpAndActivateTrajectoryController(executor, {is_open_loop_parameters}, true);
 
@@ -1735,7 +1737,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_co
 
   for (size_t i = 0; i < 3; ++i)
   {
-    EXPECT_EQ(current_state_when_offset.positions[i], joint_pos_[i]);
+    EXPECT_EQ(current_state_when_offset.positions[i], initial_pos_cmd[i]);
 
     // check velocity
     if (
@@ -1744,7 +1746,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_co
         hardware_interface::HW_IF_VELOCITY) != state_interface_types_.end() &&
       traj_controller_->has_velocity_command_interface())
     {
-      EXPECT_EQ(current_state_when_offset.positions[i], joint_pos_[i]);
+      EXPECT_EQ(current_state_when_offset.velocities[i], initial_vel_cmd[i]);
     }
 
     // check acceleration
@@ -1754,7 +1756,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_hw_states_has_offset_later_co
         hardware_interface::HW_IF_ACCELERATION) != state_interface_types_.end() &&
       traj_controller_->has_acceleration_command_interface())
     {
-      EXPECT_EQ(current_state_when_offset.positions[i], joint_pos_[i]);
+      EXPECT_EQ(current_state_when_offset.accelerations[i], initial_acc_cmd[i]);
     }
   }
 

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -220,7 +220,7 @@ public:
   void SetUpAndActivateTrajectoryController(
     rclcpp::Executor & executor, const std::vector<rclcpp::Parameter> & parameters = {},
     bool separate_cmd_and_state_values = false, double k_p = 0.0, double ff = 1.0,
-    bool angle_wraparound = false, 
+    bool angle_wraparound = false,
     const std::vector<double> initial_pos_joints = INITIAL_POS_JOINTS,
     const std::vector<double> initial_vel_joints = INITIAL_VEL_JOINTS,
     const std::vector<double> initial_acc_joints = INITIAL_ACC_JOINTS,

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -220,7 +220,11 @@ public:
   void SetUpAndActivateTrajectoryController(
     rclcpp::Executor & executor, const std::vector<rclcpp::Parameter> & parameters = {},
     bool separate_cmd_and_state_values = false, double k_p = 0.0, double ff = 1.0,
-    bool angle_wraparound = false)
+    bool angle_wraparound = false, 
+    const std::vector<double> initial_pos_joints = INITIAL_POS_JOINTS,
+    const std::vector<double> initial_vel_joints = INITIAL_VEL_JOINTS,
+    const std::vector<double> initial_acc_joints = INITIAL_ACC_JOINTS,
+    const std::vector<double> initial_eff_joints = INITIAL_EFF_JOINTS)
   {
     SetUpTrajectoryController(executor);
 
@@ -239,12 +243,17 @@ public:
 
     traj_controller_->get_node()->configure();
 
-    ActivateTrajectoryController(separate_cmd_and_state_values);
+    ActivateTrajectoryController(
+      separate_cmd_and_state_values, initial_pos_joints, initial_vel_joints, initial_acc_joints,
+      initial_eff_joints);
   }
 
   void ActivateTrajectoryController(
     bool separate_cmd_and_state_values = false,
-    const std::vector<double> initial_pos_joints = INITIAL_POS_JOINTS)
+    const std::vector<double> initial_pos_joints = INITIAL_POS_JOINTS,
+    const std::vector<double> initial_vel_joints = INITIAL_VEL_JOINTS,
+    const std::vector<double> initial_acc_joints = INITIAL_ACC_JOINTS,
+    const std::vector<double> initial_eff_joints = INITIAL_EFF_JOINTS)
   {
     std::vector<hardware_interface::LoanedCommandInterface> cmd_interfaces;
     std::vector<hardware_interface::LoanedStateInterface> state_interfaces;
@@ -280,14 +289,17 @@ public:
       cmd_interfaces.emplace_back(pos_cmd_interfaces_.back());
       cmd_interfaces.back().set_value(initial_pos_joints[i]);
       cmd_interfaces.emplace_back(vel_cmd_interfaces_.back());
-      cmd_interfaces.back().set_value(INITIAL_VEL_JOINTS[i]);
+      cmd_interfaces.back().set_value(initial_vel_joints[i]);
       cmd_interfaces.emplace_back(acc_cmd_interfaces_.back());
-      cmd_interfaces.back().set_value(INITIAL_ACC_JOINTS[i]);
+      cmd_interfaces.back().set_value(initial_acc_joints[i]);
       cmd_interfaces.emplace_back(eff_cmd_interfaces_.back());
-      cmd_interfaces.back().set_value(INITIAL_EFF_JOINTS[i]);
-      joint_state_pos_[i] = initial_pos_joints[i];
-      joint_state_vel_[i] = INITIAL_VEL_JOINTS[i];
-      joint_state_acc_[i] = INITIAL_ACC_JOINTS[i];
+      cmd_interfaces.back().set_value(initial_eff_joints[i]);
+      if (separate_cmd_and_state_values)
+      {
+        joint_state_pos_[i] = INITIAL_POS_JOINTS[i];
+        joint_state_vel_[i] = INITIAL_VEL_JOINTS[i];
+        joint_state_acc_[i] = INITIAL_ACC_JOINTS[i];
+      }
       state_interfaces.emplace_back(pos_state_interfaces_.back());
       state_interfaces.emplace_back(vel_state_interfaces_.back());
       state_interfaces.emplace_back(acc_state_interfaces_.back());
@@ -489,27 +501,33 @@ public:
       // --> set kp > 0.0 in test
       if (traj_controller_->has_velocity_command_interface())
       {
-        EXPECT_TRUE(is_same_sign_or_zero(point.at(0) - joint_state_pos_[0], joint_vel_[0]))
-          << "current error: " << point.at(0) - joint_state_pos_[0] << ", velocity command is "
-          << joint_vel_[0];
-        EXPECT_TRUE(is_same_sign_or_zero(point.at(1) - joint_state_pos_[1], joint_vel_[1]))
-          << "current error: " << point.at(1) - joint_state_pos_[1] << ", velocity command is "
-          << joint_vel_[1];
-        EXPECT_TRUE(is_same_sign_or_zero(point.at(2) - joint_state_pos_[2], joint_vel_[2]))
-          << "current error: " << point.at(2) - joint_state_pos_[2] << ", velocity command is "
-          << joint_vel_[2];
+        EXPECT_TRUE(
+          is_same_sign_or_zero(point.at(0) - pos_state_interfaces_[0].get_value(), joint_vel_[0]))
+          << "current error: " << point.at(0) - pos_state_interfaces_[0].get_value()
+          << ", velocity command is " << joint_vel_[0];
+        EXPECT_TRUE(
+          is_same_sign_or_zero(point.at(1) - pos_state_interfaces_[1].get_value(), joint_vel_[1]))
+          << "current error: " << point.at(1) - pos_state_interfaces_[1].get_value()
+          << ", velocity command is " << joint_vel_[1];
+        EXPECT_TRUE(
+          is_same_sign_or_zero(point.at(2) - pos_state_interfaces_[2].get_value(), joint_vel_[2]))
+          << "current error: " << point.at(2) - pos_state_interfaces_[2].get_value()
+          << ", velocity command is " << joint_vel_[2];
       }
       if (traj_controller_->has_effort_command_interface())
       {
-        EXPECT_TRUE(is_same_sign_or_zero(point.at(0) - joint_state_pos_[0], joint_eff_[0]))
-          << "current error: " << point.at(0) - joint_state_pos_[0] << ", effort command is "
-          << joint_eff_[0];
-        EXPECT_TRUE(is_same_sign_or_zero(point.at(1) - joint_state_pos_[1], joint_eff_[1]))
-          << "current error: " << point.at(1) - joint_state_pos_[1] << ", effort command is "
-          << joint_eff_[1];
-        EXPECT_TRUE(is_same_sign_or_zero(point.at(2) - joint_state_pos_[2], joint_eff_[2]))
-          << "current error: " << point.at(2) - joint_state_pos_[2] << ", effort command is "
-          << joint_eff_[2];
+        EXPECT_TRUE(
+          is_same_sign_or_zero(point.at(0) - pos_state_interfaces_[0].get_value(), joint_eff_[0]))
+          << "current error: " << point.at(0) - pos_state_interfaces_[0].get_value()
+          << ", effort command is " << joint_eff_[0];
+        EXPECT_TRUE(
+          is_same_sign_or_zero(point.at(1) - pos_state_interfaces_[1].get_value(), joint_eff_[1]))
+          << "current error: " << point.at(1) - pos_state_interfaces_[1].get_value()
+          << ", effort command is " << joint_eff_[1];
+        EXPECT_TRUE(
+          is_same_sign_or_zero(point.at(2) - pos_state_interfaces_[2].get_value(), joint_eff_[2]))
+          << "current error: " << point.at(2) - pos_state_interfaces_[2].get_value()
+          << ", effort command is " << joint_eff_[2];
       }
     }
   }


### PR DESCRIPTION
I tried to write tests for #794 and copied the initialization of `joint_pos_` from `test_hw_states_has_offset_first_controller_start`/`test_hw_states_has_offset_later_controller_start`: This did not work because `ActivateTrajectoryController` always has set it to the constant values from the utils-header -> I fixed that.

Tests failed now, and thinking about the test criteria itself, considering #189, I rewrote the tests -> succeed now.
> add approach to change controller without "jumps" from the command to state values:
> 
>    * when started HW interface has to set command_interfaces to N aN
>    * controller checks if command interfaces are NaN --> then is a controller started for the first time, so read states
>    * if command interface have a value --> so a controller was running already (supports switching between controllers)

@destogl You have added this part, before it got changed a bit by #340 by @AndyZe and @mechwiz 
* Why should we set `state_desired_` to the value of `read_state_from_command_interfaces`? If there is no active trajectory (`start_with_holding` is false), this value will only be published on the state-topic. If there is a new trajectory, it will be overwritten by the sampled trajectory.
* Setting `state_current` to the command read from the hardware interface is fine: It is only used for setting the set_hold_position if `start_with_holding` is set. It will be overwritten by the first call of `update`.
