### PR TITLE
[CI] Fix coverage build and codecov stats

### DIFF
--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -29,7 +29,7 @@ jobs:
           import-token: ${{ secrets.GITHUB_TOKEN }}
           # build all packages listed in the meta package
           package-name:
-            diff_drive_controller
+            ros2_controllers
 
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_controllers-not-released.${{ env.ROS_DISTRO }}.repos?token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -28,7 +28,7 @@ jobs:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           import-token: ${{ secrets.GITHUB_TOKEN }}
           # build all packages listed in the meta package
-          package-name:            
+          package-name:
             ackermann_steering_controller
             admittance_controller
             bicycle_steering_controller

--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           import-token: ${{ secrets.GITHUB_TOKEN }}
-          # build all packages listed in the meta package
+          # build all packages listed here
           package-name:
             ackermann_steering_controller
             admittance_controller

--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -28,8 +28,24 @@ jobs:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           import-token: ${{ secrets.GITHUB_TOKEN }}
           # build all packages listed in the meta package
-          package-name:
-            ros2_controllers
+          package-name:            
+            ackermann_steering_controller
+            admittance_controller
+            bicycle_steering_controller
+            diff_drive_controller
+            effort_controllers
+            force_torque_sensor_broadcaster
+            forward_command_controller
+            gripper_controllers
+            imu_sensor_broadcaster
+            joint_state_broadcaster
+            joint_trajectory_controller
+            position_controllers
+            range_sensor_broadcaster
+            steering_controllers_library
+            tricycle_controller
+            tricycle_steering_controller
+            velocity_controllers
 
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_controllers-not-released.${{ env.ROS_DISTRO }}.repos?token=${{ secrets.GITHUB_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,8 @@ coverage:
     patch: off
 fixes:
   - "ros_ws/src/ros2_controllers/::"
+ignore:
+  - "**/test"
 comment:
   layout: "diff, flags, files"
   behavior: default


### PR DESCRIPTION
- The Codecov stats were only evaluated for diff_drive_controller, see [old](https://app.codecov.io/gh/ros-controls/ros2_controllers) vs [new](https://app.codecov.io/gh/ros-controls/ros2_controllers/tree/patch-2).
- The test folders have very low coverage (why?). I excluded them from the statistics as I don't think it makes sense to include them.