### PR TITLE
Use Generic Steering Controller State Message in Steering Controllers Library

### DIFF
--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
@@ -34,7 +34,7 @@
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 
 using ControllerStateMsg =
-  steering_controllers_library::SteeringControllersLibrary::AckermanControllerState;
+  steering_controllers_library::SteeringControllersLibrary::SteeringControllerStateMsg;
 using ControllerReferenceMsg =
   steering_controllers_library::SteeringControllersLibrary::ControllerTwistReferenceMsg;
 

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -34,7 +34,7 @@
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 
 using ControllerStateMsg =
-  steering_controllers_library::SteeringControllersLibrary::AckermanControllerState;
+  steering_controllers_library::SteeringControllersLibrary::SteeringControllerStateMsg;
 using ControllerReferenceMsg =
   steering_controllers_library::SteeringControllersLibrary::ControllerTwistReferenceMsg;
 

--- a/steering_controllers_library/CMakeLists.txt
+++ b/steering_controllers_library/CMakeLists.txt
@@ -21,7 +21,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   tf2
   tf2_msgs
   tf2_geometry_msgs
-  ackermann_msgs
 )
 
 find_package(ament_cmake REQUIRED)

--- a/steering_controllers_library/include/steering_controllers_library/steering_controllers_library.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_controllers_library.hpp
@@ -35,7 +35,6 @@
 #include "steering_controllers_library_parameters.hpp"
 
 // TODO(anyone): Replace with controller specific messages
-#include "ackermann_msgs/msg/ackermann_drive_stamped.hpp"
 #include "control_msgs/msg/steering_controller_status.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
@@ -81,11 +80,10 @@ public:
   STEERING_CONTROLLERS__VISIBILITY_PUBLIC controller_interface::return_type
   update_and_write_commands(const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
-  using ControllerAckermannReferenceMsg = ackermann_msgs::msg::AckermannDriveStamped;
   using ControllerTwistReferenceMsg = geometry_msgs::msg::TwistStamped;
   using ControllerStateMsgOdom = nav_msgs::msg::Odometry;
   using ControllerStateMsgTf = tf2_msgs::msg::TFMessage;
-  using AckermanControllerState = control_msgs::msg::SteeringControllerStatus;
+  using SteeringControllerStateMsg = control_msgs::msg::SteeringControllerStatus;
 
 protected:
   controller_interface::CallbackReturn set_interface_numbers(
@@ -96,7 +94,6 @@ protected:
 
   // Command subscribers and Controller State publisher
   rclcpp::Subscription<ControllerTwistReferenceMsg>::SharedPtr ref_subscriber_twist_ = nullptr;
-  rclcpp::Subscription<ControllerTwistReferenceMsg>::SharedPtr ref_subscriber_ackermann_ = nullptr;
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr ref_subscriber_unstamped_ = nullptr;
   realtime_tools::RealtimeBuffer<std::shared_ptr<ControllerTwistReferenceMsg>> input_ref_;
   rclcpp::Duration ref_timeout_ = rclcpp::Duration::from_seconds(0.0);  // 0ms
@@ -118,10 +115,10 @@ protected:
   /// Odometry:
   steering_odometry::SteeringOdometry odometry_;
 
-  AckermanControllerState published_state_;
+  SteeringControllerStateMsg published_state_;
 
-  using ControllerStatePublisher = realtime_tools::RealtimePublisher<AckermanControllerState>;
-  rclcpp::Publisher<AckermanControllerState>::SharedPtr controller_s_publisher_;
+  using ControllerStatePublisher = realtime_tools::RealtimePublisher<SteeringControllerStateMsg>;
+  rclcpp::Publisher<SteeringControllerStateMsg>::SharedPtr controller_s_publisher_;
   std::unique_ptr<ControllerStatePublisher> controller_state_publisher_;
 
   // name constants for state interfaces

--- a/steering_controllers_library/package.xml
+++ b/steering_controllers_library/package.xml
@@ -31,7 +31,6 @@
   <depend>tf2</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>ackermann_msgs</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>

--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -192,7 +192,7 @@ controller_interface::CallbackReturn SteeringControllersLibrary::on_configure(
   try
   {
     // State publisher
-    controller_s_publisher_ = get_node()->create_publisher<AckermanControllerState>(
+    controller_s_publisher_ = get_node()->create_publisher<SteeringControllerStateMsg>(
       "~/controller_state", rclcpp::SystemDefaultsQoS());
     controller_state_publisher_ =
       std::make_unique<ControllerStatePublisher>(controller_s_publisher_);

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -34,7 +34,7 @@
 #include "steering_controllers_library/steering_controllers_library.hpp"
 
 using ControllerStateMsg =
-  steering_controllers_library::SteeringControllersLibrary::AckermanControllerState;
+  steering_controllers_library::SteeringControllersLibrary::SteeringControllerStateMsg;
 using ControllerReferenceMsg =
   steering_controllers_library::SteeringControllersLibrary::ControllerTwistReferenceMsg;
 

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
@@ -34,7 +34,7 @@
 #include "tricycle_steering_controller/tricycle_steering_controller.hpp"
 
 using ControllerStateMsg =
-  steering_controllers_library::SteeringControllersLibrary::AckermanControllerState;
+  steering_controllers_library::SteeringControllersLibrary::SteeringControllerStateMsg;
 using ControllerReferenceMsg =
   steering_controllers_library::SteeringControllersLibrary::ControllerTwistReferenceMsg;
 


### PR DESCRIPTION
I was reading through the code as a part of learning how to write a new steering controller. I understood that a new steering controller inherits from the SteeringControllersLibrary. But I also found the use of `Ackermannxxx` in the base class code for a status message and the same was being used in other steering controllers such as `BicycleSteeringController` and `TricycleSteeringController`. 

If I understood the inheritance and the code structure correctly, the SteerinControllersLibrary should be agnostic to the specifics of a steering controller that derives from it. Therefore, this PR introduces the following changes:

- Remove the use of `Ackermannxxx` declarations in the `SteeringControllersLibrary` base class and rename it to `SteeringControllerStateMsg`
- Modify the tests and state publishers to use the renamed declaration
- Remove `ackermann_msgs` dependency from `steering_controllers_library` package.

All tests for the modified packages were run successfully (locally).