### PR TITLE
[CI] Codecov humble (backport #819)

### DIFF
--- a/.github/workflows/ci-coverage-build-humble.yml
+++ b/.github/workflows/ci-coverage-build-humble.yml
@@ -1,0 +1,65 @@
+name: Coverage Build - Humble
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - humble
+  pull_request:
+    branches:
+      - humble
+
+jobs:
+  coverage:
+    name: coverage build
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    env:
+      ROS_DISTRO: humble
+    steps:
+      - uses: ros-tooling/setup-ros@0.7.0
+        with:
+          required-ros-distributions: ${{ env.ROS_DISTRO }}
+      - uses: actions/checkout@v4
+      - uses: ros-tooling/action-ros-ci@0.3.4
+        with:
+          target-ros2-distro: ${{ env.ROS_DISTRO }}
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          # build all packages listed here
+          package-name:
+            ackermann_steering_controller
+            admittance_controller
+            bicycle_steering_controller
+            diff_drive_controller
+            effort_controllers
+            force_torque_sensor_broadcaster
+            forward_command_controller
+            gripper_controllers
+            imu_sensor_broadcaster
+            joint_state_broadcaster
+            joint_trajectory_controller
+            position_controllers
+            range_sensor_broadcaster
+            steering_controllers_library
+            tricycle_controller
+            tricycle_steering_controller
+            velocity_controllers
+
+          vcs-repo-file-url: |
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_controllers.${{ env.ROS_DISTRO }}.repos?token=${{ secrets.GITHUB_TOKEN }}
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: codecov/codecov-action@v3.1.4
+        with:
+          file: ros_ws/lcov/total_coverage.info
+          flags: unittests
+          name: codecov-umbrella
+      - uses: actions/upload-artifact@v3.1.3
+        with:
+          name: colcon-logs-coverage-humble
+          path: ros_ws/log

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -37,7 +37,26 @@ jobs:
           target-ros2-distro: ${{ inputs.ros_distro }}
           # build all packages listed in the meta package
           package-name:
+            ackermann_steering_controller
+            admittance_controller
+            bicycle_steering_controller
             diff_drive_controller
+            effort_controllers
+            force_torque_sensor_broadcaster
+            forward_command_controller
+            gripper_controllers
+            imu_sensor_broadcaster
+            joint_state_broadcaster
+            joint_trajectory_controller
+            position_controllers
+            range_sensor_broadcaster
+            ros2_controllers
+            ros2_controllers_test_nodes
+            rqt_joint_trajectory_controller
+            steering_controllers_library
+            tricycle_controller
+            tricycle_steering_controller
+            velocity_controllers
 
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/${{ inputs.ros2_repo_branch }}/ros2.repos

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ros2_controllers
 
+[![Licence](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![codecov](https://codecov.io/gh/ros-controls/ros2_controllers/branch/humble/graph/badge.svg?token=KSdY0tsHm6)](https://codecov.io/gh/ros-controls/ros2_controllers)
+
 Commonly used and generalized controllers for ros2-control framework that are ready to use with many robots, MoveIt2 and Navigation2.
 
 ## Build status


### PR DESCRIPTION
This is a manual backport of #819 without conflicts. At least I think this is needed for running the coverage build on pull requests for humble: After merging #819, they are not triggered yet in the PRs.

Additionally, I added the correct badge to the readme.