### PR TITLE
Humble backport diff_drive tf_prefix | change tf separation from / to _

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -392,19 +392,31 @@ controller_interface::CallbackReturn DiffDriveController::on_configure(
     std::make_shared<realtime_tools::RealtimePublisher<nav_msgs::msg::Odometry>>(
       odometry_publisher_);
 
-  std::string controller_namespace = std::string(get_node()->get_namespace());
-
-  if (controller_namespace == "/")
+  // Append the tf prefix if there is one
+  std::string tf_prefix = "";
+  if (params_.tf_frame_prefix_enable)
   {
-    controller_namespace = "";
-  }
-  else
-  {
-    controller_namespace = controller_namespace.erase(0, 1) + "/";
+    if (params_.tf_frame_prefix != "")
+    {
+      tf_prefix = params_.tf_frame_prefix;
+    }
+    else
+    {
+      tf_prefix = std::string(get_node()->get_namespace());
+    }
+
+    if (tf_prefix == "/")
+    {
+      tf_prefix = "";
+    }
+    else
+    {
+      tf_prefix = tf_prefix + "/";
+    }
   }
 
-  const auto odom_frame_id = controller_namespace + params_.odom_frame_id;
-  const auto base_frame_id = controller_namespace + params_.base_frame_id;
+  const auto odom_frame_id = tf_prefix + params_.odom_frame_id;
+  const auto base_frame_id = tf_prefix + params_.base_frame_id;
 
   auto & odometry_message = realtime_odometry_publisher_->msg_;
   odometry_message.header.frame_id = odom_frame_id;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -411,7 +411,7 @@ controller_interface::CallbackReturn DiffDriveController::on_configure(
     }
     else
     {
-      tf_prefix = tf_prefix + "/";
+      tf_prefix = tf_prefix + "_";
     }
   }
 

--- a/diff_drive_controller/src/diff_drive_controller_parameter.yaml
+++ b/diff_drive_controller/src/diff_drive_controller_parameter.yaml
@@ -39,6 +39,16 @@ diff_drive_controller:
     default_value: 1.0,
     description: "Correction factor when radius of right wheels differs from the nominal value in ``wheel_radius`` parameter.",
   }
+  tf_frame_prefix_enable: {
+    type: bool,
+    default_value: true,
+    description:  "Enables or disables appending tf_prefix to tf frame id's.",
+  }
+  tf_frame_prefix: {
+    type: string,
+    default_value: "",
+    description:  "(optional) Prefix to be appended to the tf frames, will be added to odom_id and base_frame_id before publishing. If the parameter is empty, controller's namespace will be used.",
+  }
   odom_frame_id: {
     type: string,
     default_value: "odom",

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -68,6 +68,17 @@ public:
     }
     return false;
   }
+
+  /**
+   * @brief Used to get the real_time_odometry_publisher to verify its contents
+   *
+   * @return Copy of realtime_odometry_publisher_ object
+   */
+  std::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::msg::Odometry>>
+  get_rt_odom_publisher()
+  {
+    return realtime_odometry_publisher_;
+  }
 };
 
 class TestDiffDriveController : public ::testing::Test
@@ -242,6 +253,216 @@ TEST_F(TestDiffDriveController, configure_succeeds_when_wheels_are_specified)
   ASSERT_THAT(
     controller_->command_interface_configuration().names,
     SizeIs(left_wheel_names.size() + right_wheel_names.size()));
+}
+
+TEST_F(TestDiffDriveController, configure_succeeds_tf_test_prefix_false_no_namespace)
+{
+  const auto ret = controller_->init(controller_name);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
+
+  std::string odom_id = "odom";
+  std::string base_link_id = "base_link";
+  std::string frame_prefix = "test_prefix";
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("left_wheel_names", rclcpp::ParameterValue(left_wheel_names)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("right_wheel_names", rclcpp::ParameterValue(right_wheel_names)));
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix_enable", rclcpp::ParameterValue(false)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix", rclcpp::ParameterValue(frame_prefix)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("odom_frame_id", rclcpp::ParameterValue(odom_id)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("base_frame_id", rclcpp::ParameterValue(base_link_id)));
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  auto odometry_message = controller_->get_rt_odom_publisher()->msg_;
+  std::string test_odom_frame_id = odometry_message.header.frame_id;
+  std::string test_base_frame_id = odometry_message.child_frame_id;
+  /* tf_frame_prefix_enable is false so no modifications to the frame id's */
+  ASSERT_EQ(test_odom_frame_id, odom_id);
+  ASSERT_EQ(test_base_frame_id, base_link_id);
+}
+
+TEST_F(TestDiffDriveController, configure_succeeds_tf_test_prefix_true_no_namespace)
+{
+  const auto ret = controller_->init(controller_name);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
+
+  std::string odom_id = "odom";
+  std::string base_link_id = "base_link";
+  std::string frame_prefix = "test_prefix";
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("left_wheel_names", rclcpp::ParameterValue(left_wheel_names)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("right_wheel_names", rclcpp::ParameterValue(right_wheel_names)));
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix_enable", rclcpp::ParameterValue(true)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix", rclcpp::ParameterValue(frame_prefix)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("odom_frame_id", rclcpp::ParameterValue(odom_id)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("base_frame_id", rclcpp::ParameterValue(base_link_id)));
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  auto odometry_message = controller_->get_rt_odom_publisher()->msg_;
+  std::string test_odom_frame_id = odometry_message.header.frame_id;
+  std::string test_base_frame_id = odometry_message.child_frame_id;
+
+  /* tf_frame_prefix_enable is true and frame_prefix is not blank so should be appended to the frame
+   * id's */
+  ASSERT_EQ(test_odom_frame_id, frame_prefix + "/" + odom_id);
+  ASSERT_EQ(test_base_frame_id, frame_prefix + "/" + base_link_id);
+}
+
+TEST_F(TestDiffDriveController, configure_succeeds_tf_blank_prefix_true_no_namespace)
+{
+  const auto ret = controller_->init(controller_name);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
+
+  std::string odom_id = "odom";
+  std::string base_link_id = "base_link";
+  std::string frame_prefix = "";
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("left_wheel_names", rclcpp::ParameterValue(left_wheel_names)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("right_wheel_names", rclcpp::ParameterValue(right_wheel_names)));
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix_enable", rclcpp::ParameterValue(true)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix", rclcpp::ParameterValue(frame_prefix)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("odom_frame_id", rclcpp::ParameterValue(odom_id)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("base_frame_id", rclcpp::ParameterValue(base_link_id)));
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  auto odometry_message = controller_->get_rt_odom_publisher()->msg_;
+  std::string test_odom_frame_id = odometry_message.header.frame_id;
+  std::string test_base_frame_id = odometry_message.child_frame_id;
+  /* tf_frame_prefix_enable is true but frame_prefix is blank so should not be appended to the frame
+   * id's */
+  ASSERT_EQ(test_odom_frame_id, odom_id);
+  ASSERT_EQ(test_base_frame_id, base_link_id);
+}
+
+TEST_F(TestDiffDriveController, configure_succeeds_tf_test_prefix_false_set_namespace)
+{
+  std::string test_namespace = "/test_namespace";
+
+  const auto ret = controller_->init(controller_name, test_namespace);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
+
+  std::string odom_id = "odom";
+  std::string base_link_id = "base_link";
+  std::string frame_prefix = "test_prefix";
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("left_wheel_names", rclcpp::ParameterValue(left_wheel_names)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("right_wheel_names", rclcpp::ParameterValue(right_wheel_names)));
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix_enable", rclcpp::ParameterValue(false)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix", rclcpp::ParameterValue(frame_prefix)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("odom_frame_id", rclcpp::ParameterValue(odom_id)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("base_frame_id", rclcpp::ParameterValue(base_link_id)));
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  auto odometry_message = controller_->get_rt_odom_publisher()->msg_;
+  std::string test_odom_frame_id = odometry_message.header.frame_id;
+  std::string test_base_frame_id = odometry_message.child_frame_id;
+  /* tf_frame_prefix_enable is false so no modifications to the frame id's */
+  ASSERT_EQ(test_odom_frame_id, odom_id);
+  ASSERT_EQ(test_base_frame_id, base_link_id);
+}
+
+TEST_F(TestDiffDriveController, configure_succeeds_tf_test_prefix_true_set_namespace)
+{
+  std::string test_namespace = "/test_namespace";
+
+  const auto ret = controller_->init(controller_name, test_namespace);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
+
+  std::string odom_id = "odom";
+  std::string base_link_id = "base_link";
+  std::string frame_prefix = "test_prefix";
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("left_wheel_names", rclcpp::ParameterValue(left_wheel_names)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("right_wheel_names", rclcpp::ParameterValue(right_wheel_names)));
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix_enable", rclcpp::ParameterValue(true)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix", rclcpp::ParameterValue(frame_prefix)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("odom_frame_id", rclcpp::ParameterValue(odom_id)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("base_frame_id", rclcpp::ParameterValue(base_link_id)));
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  auto odometry_message = controller_->get_rt_odom_publisher()->msg_;
+  std::string test_odom_frame_id = odometry_message.header.frame_id;
+  std::string test_base_frame_id = odometry_message.child_frame_id;
+
+  /* tf_frame_prefix_enable is true and frame_prefix is not blank so should be appended to the frame
+   * id's instead of the namespace*/
+  ASSERT_EQ(test_odom_frame_id, frame_prefix + "/" + odom_id);
+  ASSERT_EQ(test_base_frame_id, frame_prefix + "/" + base_link_id);
+}
+
+TEST_F(TestDiffDriveController, configure_succeeds_tf_blank_prefix_true_set_namespace)
+{
+  std::string test_namespace = "/test_namespace";
+
+  const auto ret = controller_->init(controller_name, test_namespace);
+  ASSERT_EQ(ret, controller_interface::return_type::OK);
+
+  std::string odom_id = "odom";
+  std::string base_link_id = "base_link";
+  std::string frame_prefix = "";
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("left_wheel_names", rclcpp::ParameterValue(left_wheel_names)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("right_wheel_names", rclcpp::ParameterValue(right_wheel_names)));
+
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix_enable", rclcpp::ParameterValue(true)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("tf_frame_prefix", rclcpp::ParameterValue(frame_prefix)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("odom_frame_id", rclcpp::ParameterValue(odom_id)));
+  controller_->get_node()->set_parameter(
+    rclcpp::Parameter("base_frame_id", rclcpp::ParameterValue(base_link_id)));
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+
+  auto odometry_message = controller_->get_rt_odom_publisher()->msg_;
+  std::string test_odom_frame_id = odometry_message.header.frame_id;
+  std::string test_base_frame_id = odometry_message.child_frame_id;
+  /* tf_frame_prefix_enable is true but frame_prefix is blank so namespace should be appended to the
+   * frame id's */
+  ASSERT_EQ(test_odom_frame_id, test_namespace + "/" + odom_id);
+  ASSERT_EQ(test_base_frame_id, test_namespace + "/" + base_link_id);
 }
 
 TEST_F(TestDiffDriveController, activate_fails_without_resources_assigned)

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -319,8 +319,8 @@ TEST_F(TestDiffDriveController, configure_succeeds_tf_test_prefix_true_no_namesp
 
   /* tf_frame_prefix_enable is true and frame_prefix is not blank so should be appended to the frame
    * id's */
-  ASSERT_EQ(test_odom_frame_id, frame_prefix + "/" + odom_id);
-  ASSERT_EQ(test_base_frame_id, frame_prefix + "/" + base_link_id);
+  ASSERT_EQ(test_odom_frame_id, frame_prefix + "_" + odom_id);
+  ASSERT_EQ(test_base_frame_id, frame_prefix + "_" + base_link_id);
 }
 
 TEST_F(TestDiffDriveController, configure_succeeds_tf_blank_prefix_true_no_namespace)
@@ -425,8 +425,8 @@ TEST_F(TestDiffDriveController, configure_succeeds_tf_test_prefix_true_set_names
 
   /* tf_frame_prefix_enable is true and frame_prefix is not blank so should be appended to the frame
    * id's instead of the namespace*/
-  ASSERT_EQ(test_odom_frame_id, frame_prefix + "/" + odom_id);
-  ASSERT_EQ(test_base_frame_id, frame_prefix + "/" + base_link_id);
+  ASSERT_EQ(test_odom_frame_id, frame_prefix + "_" + odom_id);
+  ASSERT_EQ(test_base_frame_id, frame_prefix + "_" + base_link_id);
 }
 
 TEST_F(TestDiffDriveController, configure_succeeds_tf_blank_prefix_true_set_namespace)
@@ -461,8 +461,8 @@ TEST_F(TestDiffDriveController, configure_succeeds_tf_blank_prefix_true_set_name
   std::string test_base_frame_id = odometry_message.child_frame_id;
   /* tf_frame_prefix_enable is true but frame_prefix is blank so namespace should be appended to the
    * frame id's */
-  ASSERT_EQ(test_odom_frame_id, test_namespace + "/" + odom_id);
-  ASSERT_EQ(test_base_frame_id, test_namespace + "/" + base_link_id);
+  ASSERT_EQ(test_odom_frame_id, test_namespace + "_" + odom_id);
+  ASSERT_EQ(test_base_frame_id, test_namespace + "_" + base_link_id);
 }
 
 TEST_F(TestDiffDriveController, activate_fails_without_resources_assigned)

--- a/imu_sensor_broadcaster/src/imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/src/imu_sensor_broadcaster.cpp
@@ -62,8 +62,29 @@ controller_interface::CallbackReturn IMUSensorBroadcaster::on_configure(
     return CallbackReturn::ERROR;
   }
 
+  std::string tf_prefix;
+  if (params_.tf_frame_prefix_enable)
+  {
+    if (params_.tf_frame_prefix != "")
+    {
+      tf_prefix = params_.tf_frame_prefix;
+    }
+    else
+    {
+      tf_prefix = std::string(get_node()->get_namespace());
+    }
+    if (tf_prefix == "/")
+    {
+      tf_prefix = "";
+    }
+    else
+    {
+      tf_prefix = tf_prefix + "_";
+    }
+  }
+
   realtime_publisher_->lock();
-  realtime_publisher_->msg_.header.frame_id = params_.frame_id;
+  realtime_publisher_->msg_.header.frame_id = tf_prefix + params_.frame_id;
   // convert double vector to fixed-size array in the message
   for (size_t i = 0; i < 9; ++i)
   {

--- a/imu_sensor_broadcaster/src/imu_sensor_broadcaster_parameters.yaml
+++ b/imu_sensor_broadcaster/src/imu_sensor_broadcaster_parameters.yaml
@@ -17,6 +17,16 @@ imu_sensor_broadcaster:
       not_empty<>: null
     }
   }
+  tf_frame_prefix_enable: {
+    type: bool,
+    default_value: true,
+    description:  "Enables or disables appending tf_prefix to tf frame id's.",
+  }
+  tf_frame_prefix: {
+    type: string,
+    default_value: "",
+    description:  "(optional) Prefix to be appended to the tf frames, will be added to frame_id before publishing."
+  }
   static_covariance_orientation: {
     type: double_array,
     default_value: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],


### PR DESCRIPTION
Backporting a feature with tf parameters for diff_drive and changing the separator from / to _.
 
