### PR TITLE
joint_state_broadcaster: Add proper subscription to TestCustomInterfaceMappingUpdate

### DIFF
--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -71,6 +71,9 @@ public:
 
   void test_published_dynamic_joint_state_message(const std::string & topic);
 
+  void activate_and_get_joint_state_message(
+    const std::string & topic, sensor_msgs::msg::JointState & msg);
+
 protected:
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};


### PR DESCRIPTION
As mentioned with #821, one tests of joint_state_broadcaster is flaky in the coverage build job. This is because the creation of the `joint_state_msg` is not ensured due to a failing `trylock()` when calling `update()` only once
https://github.com/ros-controls/ros2_controllers/blob/0d3fc520831d10d4c1d16784e7378c2a0bf7b10f/joint_state_broadcaster/src/joint_state_broadcaster.cpp#L353

I reused the wait set from other tests, which retries the update several times.

Unfortunately, I was not able to reproduce a failing test like in the CI, but this should fix #821 (other tests using the wait_set are not flaky).