### PR TITLE
[CI] Update list of reviewers

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -13,28 +13,21 @@ groups:
   - name: reviewers
     reviewers: 5
     usernames:
-      - rosterloh
-      - progtologist
+      - aprotyas
       - arne48
+      - bijoua29
       - christophfroehlich
       - DasRoteSkelett
-      - sgmurray
-      - harderthan
-      - jaron-l
-      - malapatiravi
-      - erickisos
-      - sachinkum0009
-      - qiayuanliao
-      - homalozoa
-      - anfemosa
-      - jackcenter
-      - VX792
-      - mhubii
-      - livanov93
-      - aprotyas
-      - peterdavidfagan
       - duringhof
-      - VanshGehlot
-      - bijoua29
-      - LukasMacha97
+      - erickisos
+      - fmauch
+      - jaron-l
+      - livanov93
       - mcbed
+      - moriarty
+      - olivier-stasse
+      - peterdavidfagan
+      - progtologist
+      - saikishor
+      - VanshGehlot
+      - VX792


### PR DESCRIPTION
I created a [python script](https://gist.github.com/christophfroehlich/007964f5e6cf2a99a919212d48b3dc5c) parsing closed reviews of a repository and making some statistics: [reviewers_ros-controls_ros2_controllers_2023-12-04.csv](https://github.com/ros-controls/ros2_controllers/files/13572932/reviewers_ros-controls_ros2_controllers_2023-12-04.csv)

Thanks for the work of lots of active reviewers! 

But to make that process more efficient, I removed all reviewers from the list which 
a) never finished any review
b) haven't reviewed anything in 2023

Additionally, I promote the following reviewers having already more than approx. 10 reviews and being still active :)
@fmauch
@moriarty 
@olivier-stasse 
@saikishor 
(I think they have to be added to the organisation as well)
 
What do you think? I'd update that for all other repositories of ros-controls.