### PR TITLE
Add another warning from mergify[bot]

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,7 +8,6 @@ pull_request_rules:
         branches:
           - humble
 
-
   - name: Backport to iron at reviewers discretion
     conditions:
       - base=master
@@ -21,7 +20,29 @@ pull_request_rules:
   - name: Ask to resolve conflict
     conditions:
       - conflict
-      - author!=mergify
+      - author!=mergify[bot]
     actions:
         comment:
           message: This pull request is in conflict. Could you fix it @{{author}}?
+
+  - name: Ask to resolve conflict for backports
+    conditions:
+      - conflict
+      - author=mergify[bot]
+    actions:
+        comment:
+          message: This pull request is in conflict. Could you fix it @bmagyar @dstogl @christophfroehlich?
+
+  - name: development targets master branch
+    conditions:
+      - base!=master
+      - author!=bmagyar
+      - author!=dstogl
+      - author!=christophfroehlich
+      - author!=mergify[bot]
+    actions:
+        comment:
+          message: |
+            @{{author}}, all pull requests must be targeted towards the `master` development branch.
+            Once merged into `master`, it is possible to backport to @{{base}}, but it must be in `master`
+            to have these changes reflected into new distributions.


### PR DESCRIPTION
I saw that navigation2 is using more automatic warnings by mergify: I copied over one, which should notify non-maintainers if they open a PR against any other branch than master.

And I tried to avoid to mergify notifying itself with `This pull request is in conflict. Could you fix it mergify[bot]?`

Just a try, close if you don't like it!