### PR TITLE
rqt_joint_controller fix for getting feedback

### DIFF
--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -335,7 +335,7 @@ class JointTrajectoryController(Plugin):
 
         # Setup ROS interfaces
         jtc_ns = _resolve_controller_ns(self._cm_ns, self._jtc_name)
-        state_topic = jtc_ns + "/controller_state"
+        state_topic = jtc_ns + "/state"
         cmd_topic = jtc_ns + "/joint_trajectory"
         self._state_sub = self._node.create_subscription(
             JointTrajectoryControllerState, state_topic, self._state_cb, 1
@@ -410,7 +410,7 @@ class JointTrajectoryController(Plugin):
         current_pos = {}
         for i in range(len(msg.joint_names)):
             joint_name = msg.joint_names[i]
-            joint_pos = msg.feedback.positions[i]
+            joint_pos = msg.actual.positions[i]
             current_pos[joint_name] = joint_pos
         self.jointStateChanged.emit(current_pos)
 


### PR DESCRIPTION
At some point there has been a change in the feedback that joint_trajectory_controllers publish and that has not propagated tot the rqt plugin. I've deduced the correct place to get the joint state values would be from /controller_name/state.actual instead of /controller_name/controller_state.feedback. Tested change with current humble release and gazebo plugin, seems to work fine for me.