### PR TITLE
Add tests for `interface_configuration_type` consistently

### DIFF
--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.cpp
@@ -46,41 +46,43 @@ TEST_F(AckermannSteeringControllerTest, all_parameters_set_configure_success)
   ASSERT_EQ(controller_->ackermann_params_.rear_wheel_track, rear_wheel_track_);
 }
 
-TEST_F(AckermannSteeringControllerTest, check_exported_intefaces)
+TEST_F(AckermannSteeringControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  auto command_intefaces = controller_->command_interface_configuration();
-  ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_RIGHT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_RIGHT_WHEEL],
     rear_wheels_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_LEFT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_LEFT_WHEEL],
     rear_wheels_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_RIGHT_WHEEL],
+    cmd_if_conf.names[CMD_STEER_RIGHT_WHEEL],
     front_wheels_names_[0] + "/" + steering_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_LEFT_WHEEL],
+    cmd_if_conf.names[CMD_STEER_LEFT_WHEEL],
     front_wheels_names_[1] + "/" + steering_interface_name_);
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_intefaces = controller_->state_interface_configuration();
-  ASSERT_EQ(state_intefaces.names.size(), joint_state_values_.size());
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), joint_state_values_.size());
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_RIGHT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_RIGHT_WHEEL],
     controller_->rear_wheels_state_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_LEFT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_LEFT_WHEEL],
     controller_->rear_wheels_state_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_RIGHT_WHEEL],
+    state_if_conf.names[STATE_STEER_RIGHT_WHEEL],
     controller_->front_wheels_state_names_[0] + "/" + steering_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_LEFT_WHEEL],
+    state_if_conf.names[STATE_STEER_LEFT_WHEEL],
     controller_->front_wheels_state_names_[1] + "/" + steering_interface_name_);
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // check ref itfsTIME
   auto reference_interfaces = controller_->export_reference_interfaces();

--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
@@ -62,7 +62,7 @@ class TestableAckermannSteeringController
 : public ackermann_steering_controller::AckermannSteeringController
 {
   FRIEND_TEST(AckermannSteeringControllerTest, all_parameters_set_configure_success);
-  FRIEND_TEST(AckermannSteeringControllerTest, check_exported_intefaces);
+  FRIEND_TEST(AckermannSteeringControllerTest, check_exported_interfaces);
   FRIEND_TEST(AckermannSteeringControllerTest, activate_success);
   FRIEND_TEST(AckermannSteeringControllerTest, update_success);
   FRIEND_TEST(AckermannSteeringControllerTest, deactivate_success);

--- a/ackermann_steering_controller/test/test_ackermann_steering_controller_preceeding.cpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller_preceeding.cpp
@@ -48,41 +48,43 @@ TEST_F(AckermannSteeringControllerTest, all_parameters_set_configure_success)
   ASSERT_EQ(controller_->ackermann_params_.rear_wheel_track, rear_wheel_track_);
 }
 
-TEST_F(AckermannSteeringControllerTest, check_exported_intefaces)
+TEST_F(AckermannSteeringControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  auto command_intefaces = controller_->command_interface_configuration();
-  ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_RIGHT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_RIGHT_WHEEL],
     preceeding_prefix_ + "/" + rear_wheels_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_LEFT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_LEFT_WHEEL],
     preceeding_prefix_ + "/" + rear_wheels_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_RIGHT_WHEEL],
+    cmd_if_conf.names[CMD_STEER_RIGHT_WHEEL],
     preceeding_prefix_ + "/" + front_wheels_names_[0] + "/" + steering_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_LEFT_WHEEL],
+    cmd_if_conf.names[CMD_STEER_LEFT_WHEEL],
     preceeding_prefix_ + "/" + front_wheels_names_[1] + "/" + steering_interface_name_);
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_intefaces = controller_->state_interface_configuration();
-  ASSERT_EQ(state_intefaces.names.size(), joint_state_values_.size());
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), joint_state_values_.size());
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_RIGHT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_RIGHT_WHEEL],
     controller_->rear_wheels_state_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_LEFT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_LEFT_WHEEL],
     controller_->rear_wheels_state_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_RIGHT_WHEEL],
+    state_if_conf.names[STATE_STEER_RIGHT_WHEEL],
     controller_->front_wheels_state_names_[0] + "/" + steering_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_LEFT_WHEEL],
+    state_if_conf.names[STATE_STEER_LEFT_WHEEL],
     controller_->front_wheels_state_names_[1] + "/" + steering_interface_name_);
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();

--- a/admittance_controller/test/test_admittance_controller.cpp
+++ b/admittance_controller/test/test_admittance_controller.cpp
@@ -157,12 +157,15 @@ TEST_F(AdmittanceControllerTest, check_interfaces)
 
   auto command_interfaces = controller_->command_interface_configuration();
   ASSERT_EQ(command_interfaces.names.size(), joint_command_values_.size());
+  EXPECT_EQ(
+    command_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   ASSERT_EQ(
     controller_->command_interfaces_.size(), command_interface_types_.size() * joint_names_.size());
 
   auto state_interfaces = controller_->state_interface_configuration();
   ASSERT_EQ(state_interfaces.names.size(), joint_state_values_.size() + fts_state_values_.size());
+  EXPECT_EQ(state_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   ASSERT_EQ(
     controller_->state_interfaces_.size(),

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
@@ -44,29 +44,29 @@ TEST_F(BicycleSteeringControllerTest, all_parameters_set_configure_success)
   ASSERT_EQ(controller_->bicycle_params_.rear_wheel_radius, rear_wheels_radius_);
 }
 
-TEST_F(BicycleSteeringControllerTest, check_exported_intefaces)
+TEST_F(BicycleSteeringControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  auto command_intefaces = controller_->command_interface_configuration();
-  ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_WHEEL],
-    rear_wheels_names_[0] + "/" + traction_interface_name_);
+    cmd_if_conf.names[CMD_TRACTION_WHEEL], rear_wheels_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_WHEEL],
-    front_wheels_names_[0] + "/" + steering_interface_name_);
+    cmd_if_conf.names[CMD_STEER_WHEEL], front_wheels_names_[0] + "/" + steering_interface_name_);
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_intefaces = controller_->state_interface_configuration();
-  ASSERT_EQ(state_intefaces.names.size(), joint_state_values_.size());
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), joint_state_values_.size());
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_WHEEL],
+    state_if_conf.names[STATE_TRACTION_WHEEL],
     controller_->rear_wheels_state_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_AXIS],
+    state_if_conf.names[STATE_STEER_AXIS],
     controller_->front_wheels_state_names_[0] + "/" + steering_interface_name_);
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // check ref itfsTIME
   auto reference_interfaces = controller_->export_reference_interfaces();

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -60,7 +60,7 @@ class TestableBicycleSteeringController
 : public bicycle_steering_controller::BicycleSteeringController
 {
   FRIEND_TEST(BicycleSteeringControllerTest, all_parameters_set_configure_success);
-  FRIEND_TEST(BicycleSteeringControllerTest, check_exported_intefaces);
+  FRIEND_TEST(BicycleSteeringControllerTest, check_exported_interfaces);
   FRIEND_TEST(BicycleSteeringControllerTest, activate_success);
   FRIEND_TEST(BicycleSteeringControllerTest, update_success);
   FRIEND_TEST(BicycleSteeringControllerTest, deactivate_success);

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller_preceeding.cpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller_preceeding.cpp
@@ -46,31 +46,31 @@ TEST_F(BicycleSteeringControllerTest, all_parameters_set_configure_success)
   ASSERT_EQ(controller_->bicycle_params_.rear_wheel_radius, rear_wheels_radius_);
 }
 
-TEST_F(BicycleSteeringControllerTest, check_exported_intefaces)
+TEST_F(BicycleSteeringControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  auto command_intefaces = controller_->command_interface_configuration();
-  ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_WHEEL],
     preceeding_prefix_ + "/" + rear_wheels_names_[0] + "/" + traction_interface_name_);
-
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_WHEEL],
+    cmd_if_conf.names[CMD_STEER_WHEEL],
     preceeding_prefix_ + "/" + front_wheels_names_[0] + "/" + steering_interface_name_);
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_intefaces = controller_->state_interface_configuration();
-  ASSERT_EQ(state_intefaces.names.size(), joint_state_values_.size());
-
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), joint_state_values_.size());
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_WHEEL],
+    state_if_conf.names[STATE_TRACTION_WHEEL],
     controller_->rear_wheels_state_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_AXIS],
+    state_if_conf.names[STATE_STEER_AXIS],
     controller_->front_wheels_state_names_[0] + "/" + steering_interface_name_);
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -249,12 +249,12 @@ TEST_F(TestDiffDriveController, configure_succeeds_when_wheels_are_specified)
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
-  ASSERT_THAT(
-    controller_->state_interface_configuration().names,
-    SizeIs(left_wheel_names.size() + right_wheel_names.size()));
-  ASSERT_THAT(
-    controller_->command_interface_configuration().names,
-    SizeIs(left_wheel_names.size() + right_wheel_names.size()));
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_THAT(state_if_conf.names, SizeIs(left_wheel_names.size() + right_wheel_names.size()));
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_THAT(cmd_if_conf.names, SizeIs(left_wheel_names.size() + right_wheel_names.size()));
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 }
 
 TEST_F(TestDiffDriveController, configure_succeeds_tf_test_prefix_false_no_namespace)

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
@@ -163,8 +163,10 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_Configure_Success)
   // check interface configuration
   auto cmd_if_conf = fts_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  ASSERT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = fts_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(6lu));
+  ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 }
 
 TEST_F(ForceTorqueSensorBroadcasterTest, InterfaceNames_Configure_Success)
@@ -198,8 +200,10 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_ActivateDeactivate_Success)
   // check interface configuration
   auto cmd_if_conf = fts_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  ASSERT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = fts_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(6lu));
+  ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // deactivate passed
   ASSERT_EQ(fts_broadcaster_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
@@ -207,8 +211,10 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_ActivateDeactivate_Success)
   // check interface configuration
   cmd_if_conf = fts_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  ASSERT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   state_if_conf = fts_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(6lu));  // did not change
+  ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 }
 
 TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_Update_Success)

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -137,6 +137,7 @@ TEST_F(ForwardCommandControllerTest, ConfigureParamsSuccess)
   ASSERT_THAT(cmd_if_conf.names, SizeIs(2lu));
   auto state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 }
 
 TEST_F(ForwardCommandControllerTest, ActivateWithWrongJointsNamesFails)
@@ -189,6 +190,7 @@ TEST_F(ForwardCommandControllerTest, ActivateSuccess)
   ASSERT_THAT(cmd_if_conf.names, SizeIs(joint_names_.size()));
   auto state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 
   ASSERT_EQ(
     controller_->on_activate(rclcpp_lifecycle::State()),
@@ -197,8 +199,10 @@ TEST_F(ForwardCommandControllerTest, ActivateSuccess)
   // check interface configuration
   cmd_if_conf = controller_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, SizeIs(joint_names_.size()));
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
   state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 }
 
 TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
@@ -352,6 +356,7 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
   EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
   auto state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 
   node_state = controller_->get_node()->activate();
   ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
@@ -359,8 +364,10 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
   // check interface configuration
   cmd_if_conf = controller_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, SizeIs(joint_names_.size()));
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
   state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 
   auto command_msg = std::make_shared<std_msgs::msg::Float64MultiArray>();
   command_msg->data = {10.0, 20.0, 30.0};
@@ -383,8 +390,10 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
   // check interface configuration
   cmd_if_conf = controller_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, SizeIs(joint_names_.size()));  // did not change
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
   state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 
   // command ptr should be reset (nullptr) after deactivation - same check as in `update`
   ASSERT_FALSE(

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
@@ -297,6 +297,7 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateDeactivateCommandsRes
   EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
   auto state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 
   // send command
   auto command_ptr = std::make_shared<forward_command_controller::CmdType>();
@@ -322,6 +323,7 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateDeactivateCommandsRes
   EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
   state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 
   // command ptr should be reset (nullptr) after deactivation - same check as in `update`
   ASSERT_FALSE(

--- a/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
@@ -119,8 +119,10 @@ TEST_F(IMUSensorBroadcasterTest, SensorName_Configure_Success)
   // check interface configuration
   auto cmd_if_conf = imu_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = imu_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(10lu));
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 }
 
 TEST_F(IMUSensorBroadcasterTest, SensorName_Activate_Success)
@@ -138,8 +140,10 @@ TEST_F(IMUSensorBroadcasterTest, SensorName_Activate_Success)
   // check interface configuration
   auto cmd_if_conf = imu_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = imu_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(10lu));
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // deactivate passed
   ASSERT_EQ(imu_broadcaster_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
@@ -147,8 +151,10 @@ TEST_F(IMUSensorBroadcasterTest, SensorName_Activate_Success)
   // check interface configuration
   cmd_if_conf = imu_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   state_if_conf = imu_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(10lu));  // did not change
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 }
 
 TEST_F(IMUSensorBroadcasterTest, SensorName_Update_Success)

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -180,8 +180,10 @@ TEST_F(JointStateBroadcasterTest, ActivateEmptyTest)
   // check interface configuration
   auto cmd_if_conf = state_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = state_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::ALL);
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->realtime_joint_state_publisher_);
@@ -227,8 +229,10 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutJointsParameter)
   // check interface configuration
   auto cmd_if_conf = state_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = state_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::ALL);
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->realtime_joint_state_publisher_);
@@ -274,8 +278,10 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutInterfacesParameter)
   // check interface configuration
   auto cmd_if_conf = state_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = state_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::ALL);
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->realtime_joint_state_publisher_);
@@ -321,8 +327,10 @@ TEST_F(JointStateBroadcasterTest, ActivateDeactivateTestTwoJointsOneInterface)
   // check interface configuration
   auto cmd_if_conf = state_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = state_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(JOINT_NAMES.size() * IF_NAMES.size()));
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->realtime_joint_state_publisher_);
@@ -360,9 +368,11 @@ TEST_F(JointStateBroadcasterTest, ActivateDeactivateTestTwoJointsOneInterface)
   // check interface configuration
   cmd_if_conf = state_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   state_if_conf = state_broadcaster_->state_interface_configuration();
   ASSERT_THAT(
     state_if_conf.names, SizeIs(JOINT_NAMES.size() * IF_NAMES.size()));  // does not change
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 }
 
 TEST_F(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces)
@@ -381,8 +391,10 @@ TEST_F(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces)
   // check interface configuration
   auto cmd_if_conf = state_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = state_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(JOINT_NAMES.size() * IF_NAMES.size()));
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->realtime_joint_state_publisher_);
@@ -455,8 +467,10 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing)
   // check interface configuration
   auto cmd_if_conf = state_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = state_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(JOINT_NAMES.size() * IF_NAMES.size()));
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->realtime_joint_state_publisher_);
@@ -504,8 +518,10 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceWithoutMapping)
   // check interface configuration
   auto cmd_if_conf = state_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = state_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(JOINT_NAMES.size() * IF_NAMES.size()));
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
@@ -547,8 +563,10 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceMapping)
   // check interface configuration
   auto cmd_if_conf = state_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = state_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(JOINT_NAMES.size() * IF_NAMES.size()));
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -120,13 +120,13 @@ TEST_P(TrajectoryControllerTestParameterized, activate)
   auto state = traj_controller_->get_node()->configure();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 
-  auto cmd_interface_config = traj_controller_->command_interface_configuration();
-  ASSERT_EQ(
-    cmd_interface_config.names.size(), joint_names_.size() * command_interface_types_.size());
+  auto cmd_if_conf = traj_controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), joint_names_.size() * command_interface_types_.size());
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_interface_config = traj_controller_->state_interface_configuration();
-  ASSERT_EQ(
-    state_interface_config.names.size(), joint_names_.size() * state_interface_types_.size());
+  auto state_if_conf = traj_controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), joint_names_.size() * state_interface_types_.size());
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   state = ActivateTrajectoryController();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);

--- a/pid_controller/test/test_pid_controller.cpp
+++ b/pid_controller/test/test_pid_controller.cpp
@@ -61,34 +61,36 @@ TEST_F(PidControllerTest, all_parameters_set_configure_success)
   ASSERT_FALSE(controller_->params_.use_external_measured_states);
 }
 
-TEST_F(PidControllerTest, check_exported_intefaces)
+TEST_F(PidControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  auto command_interfaces = controller_->command_interface_configuration();
-  ASSERT_EQ(command_interfaces.names.size(), dof_command_values_.size());
-  for (size_t i = 0; i < command_interfaces.names.size(); ++i)
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), dof_command_values_.size());
+  for (size_t i = 0; i < cmd_if_conf.names.size(); ++i)
   {
-    EXPECT_EQ(command_interfaces.names[i], dof_names_[i] + "/" + command_interface_);
+    EXPECT_EQ(cmd_if_conf.names[i], dof_names_[i] + "/" + command_interface_);
   }
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_intefaces = controller_->state_interface_configuration();
-  ASSERT_EQ(state_intefaces.names.size(), dof_state_values_.size());
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), dof_state_values_.size());
   size_t si_index = 0;
   for (const auto & interface : state_interfaces_)
   {
     for (const auto & dof_name : dof_names_)
     {
-      EXPECT_EQ(state_intefaces.names[si_index], dof_name + "/" + interface);
+      EXPECT_EQ(state_if_conf.names[si_index], dof_name + "/" + interface);
       ++si_index;
     }
   }
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // check ref itfs
-  auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), dof_state_values_.size());
+  auto ref_if_conf = controller_->export_reference_interfaces();
+  ASSERT_EQ(ref_if_conf.size(), dof_state_values_.size());
   size_t ri_index = 0;
   for (const auto & interface : state_interfaces_)
   {
@@ -96,10 +98,9 @@ TEST_F(PidControllerTest, check_exported_intefaces)
     {
       const std::string ref_itf_name =
         std::string(controller_->get_node()->get_name()) + "/" + dof_name + "/" + interface;
-      EXPECT_EQ(reference_interfaces[ri_index].get_name(), ref_itf_name);
-      EXPECT_EQ(
-        reference_interfaces[ri_index].get_prefix_name(), controller_->get_node()->get_name());
-      EXPECT_EQ(reference_interfaces[ri_index].get_interface_name(), dof_name + "/" + interface);
+      EXPECT_EQ(ref_if_conf[ri_index].get_name(), ref_itf_name);
+      EXPECT_EQ(ref_if_conf[ri_index].get_prefix_name(), controller_->get_node()->get_name());
+      EXPECT_EQ(ref_if_conf[ri_index].get_interface_name(), dof_name + "/" + interface);
       ++ri_index;
     }
   }

--- a/pid_controller/test/test_pid_controller_preceding.cpp
+++ b/pid_controller/test/test_pid_controller_preceding.cpp
@@ -49,34 +49,36 @@ TEST_F(PidControllerTest, all_parameters_set_configure_success)
   ASSERT_EQ(controller_->params_.command_interface, command_interface_);
 }
 
-TEST_F(PidControllerTest, check_exported_intefaces)
+TEST_F(PidControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  auto command_intefaces = controller_->command_interface_configuration();
-  ASSERT_EQ(command_intefaces.names.size(), dof_command_values_.size());
-  for (size_t i = 0; i < command_intefaces.names.size(); ++i)
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), dof_command_values_.size());
+  for (size_t i = 0; i < cmd_if_conf.names.size(); ++i)
   {
-    EXPECT_EQ(command_intefaces.names[i], dof_names_[i] + "/" + command_interface_);
+    EXPECT_EQ(cmd_if_conf.names[i], dof_names_[i] + "/" + command_interface_);
   }
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_intefaces = controller_->state_interface_configuration();
-  ASSERT_EQ(state_intefaces.names.size(), dof_state_values_.size());
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), dof_state_values_.size());
   size_t si_index = 0;
   for (const auto & interface : state_interfaces_)
   {
     for (const auto & dof_name : reference_and_state_dof_names_)
     {
-      EXPECT_EQ(state_intefaces.names[si_index], dof_name + "/" + interface);
+      EXPECT_EQ(state_if_conf.names[si_index], dof_name + "/" + interface);
       ++si_index;
     }
   }
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // check ref itfs
-  auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), dof_state_values_.size());
+  auto ref_if_conf = controller_->export_reference_interfaces();
+  ASSERT_EQ(ref_if_conf.size(), dof_state_values_.size());
   size_t ri_index = 0;
   for (const auto & interface : state_interfaces_)
   {
@@ -84,10 +86,9 @@ TEST_F(PidControllerTest, check_exported_intefaces)
     {
       const std::string ref_itf_name =
         std::string(controller_->get_node()->get_name()) + "/" + dof_name + "/" + interface;
-      EXPECT_EQ(reference_interfaces[ri_index].get_name(), ref_itf_name);
-      EXPECT_EQ(
-        reference_interfaces[ri_index].get_prefix_name(), controller_->get_node()->get_name());
-      EXPECT_EQ(reference_interfaces[ri_index].get_interface_name(), dof_name + "/" + interface);
+      EXPECT_EQ(ref_if_conf[ri_index].get_name(), ref_itf_name);
+      EXPECT_EQ(ref_if_conf[ri_index].get_prefix_name(), controller_->get_node()->get_name());
+      EXPECT_EQ(ref_if_conf[ri_index].get_interface_name(), dof_name + "/" + interface);
       ++ri_index;
     }
   }

--- a/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
+++ b/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
@@ -154,8 +154,10 @@ TEST_F(RangeSensorBroadcasterTest, ActivateDeactivate_RangeBroadcaster_Success)
   // check interface configuration
   auto cmd_if_conf = range_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  ASSERT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   auto state_if_conf = range_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(1lu));
+  ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   ASSERT_EQ(
     range_broadcaster_->on_deactivate(rclcpp_lifecycle::State()),
@@ -164,8 +166,10 @@ TEST_F(RangeSensorBroadcasterTest, ActivateDeactivate_RangeBroadcaster_Success)
   // check interface configuration
   cmd_if_conf = range_broadcaster_->command_interface_configuration();
   ASSERT_THAT(cmd_if_conf.names, IsEmpty());
+  ASSERT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::NONE);
   state_if_conf = range_broadcaster_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(1lu));  // did not change
+  ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 }
 
 TEST_F(RangeSensorBroadcasterTest, Update_RangeBroadcaster_Success)

--- a/steering_controllers_library/test/test_steering_controllers_library.cpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.cpp
@@ -28,41 +28,43 @@ class SteeringControllersLibraryTest
 };
 
 // checking if all interfaces, command, state and reference are exported as expected
-TEST_F(SteeringControllersLibraryTest, check_exported_intefaces)
+TEST_F(SteeringControllersLibraryTest, check_exported_interfaces)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  auto command_intefaces = controller_->command_interface_configuration();
-  ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_RIGHT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_RIGHT_WHEEL],
     rear_wheels_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_LEFT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_LEFT_WHEEL],
     rear_wheels_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_RIGHT_WHEEL],
+    cmd_if_conf.names[CMD_STEER_RIGHT_WHEEL],
     front_wheels_names_[0] + "/" + steering_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_LEFT_WHEEL],
+    cmd_if_conf.names[CMD_STEER_LEFT_WHEEL],
     front_wheels_names_[1] + "/" + steering_interface_name_);
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_intefaces = controller_->state_interface_configuration();
-  ASSERT_EQ(state_intefaces.names.size(), joint_state_values_.size());
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), joint_state_values_.size());
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_RIGHT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_RIGHT_WHEEL],
     controller_->rear_wheels_state_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_LEFT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_LEFT_WHEEL],
     controller_->rear_wheels_state_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_RIGHT_WHEEL],
+    state_if_conf.names[STATE_STEER_RIGHT_WHEEL],
     controller_->front_wheels_state_names_[0] + "/" + steering_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_LEFT_WHEEL],
+    state_if_conf.names[STATE_STEER_LEFT_WHEEL],
     controller_->front_wheels_state_names_[1] + "/" + steering_interface_name_);
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // check ref itfsTIME
   auto reference_interfaces = controller_->export_reference_interfaces();

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -73,7 +73,7 @@ constexpr auto NODE_ERROR = controller_interface::CallbackReturn::ERROR;
 class TestableSteeringControllersLibrary
 : public steering_controllers_library::SteeringControllersLibrary
 {
-  FRIEND_TEST(SteeringControllersLibraryTest, check_exported_intefaces);
+  FRIEND_TEST(SteeringControllersLibraryTest, check_exported_interfaces);
   FRIEND_TEST(SteeringControllersLibraryTest, test_both_update_methods_for_ref_timeout);
 
 public:

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.cpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.cpp
@@ -45,46 +45,47 @@ TEST_F(TricycleSteeringControllerTest, all_parameters_set_configure_success)
   ASSERT_EQ(controller_->tricycle_params_.wheel_track, wheel_track_);
 }
 
-TEST_F(TricycleSteeringControllerTest, check_exported_intefaces)
+TEST_F(TricycleSteeringControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  auto command_intefaces = controller_->command_interface_configuration();
-  ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_RIGHT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_RIGHT_WHEEL],
     rear_wheels_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_LEFT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_LEFT_WHEEL],
     rear_wheels_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_WHEEL],
-    front_wheels_names_[0] + "/" + steering_interface_name_);
+    cmd_if_conf.names[CMD_STEER_WHEEL], front_wheels_names_[0] + "/" + steering_interface_name_);
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_intefaces = controller_->state_interface_configuration();
-  ASSERT_EQ(state_intefaces.names.size(), joint_state_values_.size());
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), joint_state_values_.size());
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_RIGHT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_RIGHT_WHEEL],
     controller_->rear_wheels_state_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_LEFT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_LEFT_WHEEL],
     controller_->rear_wheels_state_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_AXIS],
+    state_if_conf.names[STATE_STEER_AXIS],
     controller_->front_wheels_state_names_[0] + "/" + steering_interface_name_);
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  // check ref itfsTIME
-  auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
+  // check ref itfs
+  auto ref_if_conf = controller_->export_reference_interfaces();
+  ASSERT_EQ(ref_if_conf.size(), joint_reference_interfaces_.size());
   for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)
   {
     const std::string ref_itf_name =
       std::string(controller_->get_node()->get_name()) + "/" + joint_reference_interfaces_[i];
-    EXPECT_EQ(reference_interfaces[i].get_name(), ref_itf_name);
-    EXPECT_EQ(reference_interfaces[i].get_prefix_name(), controller_->get_node()->get_name());
-    EXPECT_EQ(reference_interfaces[i].get_interface_name(), joint_reference_interfaces_[i]);
+    EXPECT_EQ(ref_if_conf[i].get_name(), ref_itf_name);
+    EXPECT_EQ(ref_if_conf[i].get_prefix_name(), controller_->get_node()->get_name());
+    EXPECT_EQ(ref_if_conf[i].get_interface_name(), joint_reference_interfaces_[i]);
   }
 }
 

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
@@ -61,7 +61,7 @@ class TestableTricycleSteeringController
 : public tricycle_steering_controller::TricycleSteeringController
 {
   FRIEND_TEST(TricycleSteeringControllerTest, all_parameters_set_configure_success);
-  FRIEND_TEST(TricycleSteeringControllerTest, check_exported_intefaces);
+  FRIEND_TEST(TricycleSteeringControllerTest, check_exported_interfaces);
   FRIEND_TEST(TricycleSteeringControllerTest, activate_success);
   FRIEND_TEST(TricycleSteeringControllerTest, update_success);
   FRIEND_TEST(TricycleSteeringControllerTest, deactivate_success);

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller_preceeding.cpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller_preceeding.cpp
@@ -47,46 +47,48 @@ TEST_F(TricycleSteeringControllerTest, all_parameters_set_configure_success)
   ASSERT_EQ(controller_->tricycle_params_.wheel_track, wheel_track_);
 }
 
-TEST_F(TricycleSteeringControllerTest, check_exported_intefaces)
+TEST_F(TricycleSteeringControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  auto command_intefaces = controller_->command_interface_configuration();
-  ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());
+  auto cmd_if_conf = controller_->command_interface_configuration();
+  ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_RIGHT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_RIGHT_WHEEL],
     preceeding_prefix_ + "/" + rear_wheels_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_TRACTION_LEFT_WHEEL],
+    cmd_if_conf.names[CMD_TRACTION_LEFT_WHEEL],
     preceeding_prefix_ + "/" + rear_wheels_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    command_intefaces.names[CMD_STEER_WHEEL],
+    cmd_if_conf.names[CMD_STEER_WHEEL],
     preceeding_prefix_ + "/" + front_wheels_names_[0] + "/" + steering_interface_name_);
+  EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  auto state_intefaces = controller_->state_interface_configuration();
-  ASSERT_EQ(state_intefaces.names.size(), joint_state_values_.size());
+  auto state_if_conf = controller_->state_interface_configuration();
+  ASSERT_EQ(state_if_conf.names.size(), joint_state_values_.size());
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_RIGHT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_RIGHT_WHEEL],
     controller_->rear_wheels_state_names_[0] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_TRACTION_LEFT_WHEEL],
+    state_if_conf.names[STATE_TRACTION_LEFT_WHEEL],
     controller_->rear_wheels_state_names_[1] + "/" + traction_interface_name_);
   EXPECT_EQ(
-    state_intefaces.names[STATE_STEER_AXIS],
+    state_if_conf.names[STATE_STEER_AXIS],
     controller_->front_wheels_state_names_[0] + "/" + steering_interface_name_);
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // check ref itfs
-  auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
+  auto ref_if_conf = controller_->export_reference_interfaces();
+  ASSERT_EQ(ref_if_conf.size(), joint_reference_interfaces_.size());
   for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)
   {
     const std::string ref_itf_name =
       std::string(controller_->get_node()->get_name()) + "/" + joint_reference_interfaces_[i];
-    EXPECT_EQ(reference_interfaces[i].get_name(), ref_itf_name);
-    EXPECT_EQ(reference_interfaces[i].get_prefix_name(), controller_->get_node()->get_name());
-    EXPECT_EQ(reference_interfaces[i].get_interface_name(), joint_reference_interfaces_[i]);
+    EXPECT_EQ(ref_if_conf[i].get_name(), ref_itf_name);
+    EXPECT_EQ(ref_if_conf[i].get_prefix_name(), controller_->get_node()->get_name());
+    EXPECT_EQ(ref_if_conf[i].get_interface_name(), joint_reference_interfaces_[i]);
   }
 }
 


### PR DESCRIPTION
I added tests for every `controller_interface::interface_configuration_type` as @saikishor mentioned [here](https://github.com/ros-controls/ros2_controllers/pull/865#discussion_r1417269843). (and fixed some typos)