### PR TITLE
[CI] Do not run reviewer lottery for dependabot and mergify

### DIFF
--- a/.github/workflows/reviewer_lottery.yml
+++ b/.github/workflows/reviewer_lottery.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'mergify[bot]'
     steps:
     - uses: actions/checkout@v4
     - uses: uesteibar/reviewer-lottery@v3


### PR DESCRIPTION
Do not run reviewer lottery for PRs created by dependabot or mergify.