### PR TITLE
[PID] Add example yaml to docs

### DIFF
--- a/pid_controller/doc/userdoc.rst
+++ b/pid_controller/doc/userdoc.rst
@@ -83,4 +83,13 @@ Parameters
 
 The PID controller uses the `generate_parameter_library <https://github.com/PickNikRobotics/generate_parameter_library>`_ to handle its parameters.
 
+List of parameters
+=========================
 .. generate_parameter_library_details:: ../src/pid_controller.yaml
+
+
+An example parameter file
+=========================
+
+.. generate_parameter_library_default::
+  ../src/pid_controller.yaml

--- a/pid_controller/doc/userdoc.rst
+++ b/pid_controller/doc/userdoc.rst
@@ -91,5 +91,13 @@ List of parameters
 An example parameter file
 =========================
 
-.. generate_parameter_library_default::
-  ../src/pid_controller.yaml
+
+An example parameter file for this controller can be found in `the test folder (standalone) <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/pid_controller/test/pid_controller_params.yaml>`_:
+
+.. literalinclude:: ../test/pid_controller_params.yaml
+   :language: yaml
+
+or as `preceding controller <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/pid_controller/test/pid_controller_preceding_params.yaml>`_:
+
+.. literalinclude:: ../test/pid_controller_preceding_params.yaml
+   :language: yaml


### PR DESCRIPTION
Addition to #652, but PID-Controller is not backported to iron/humble yet -> no backport now of this PR.

![image](https://github.com/ros-controls/ros2_controllers/assets/3367244/7bf0fe3c-b75d-4649-a804-9f172da223df)

