### PR TITLE
Remove robot description param from admittance YAML

### DIFF
--- a/admittance_controller/src/admittance_controller_parameters.yaml
+++ b/admittance_controller/src/admittance_controller_parameters.yaml
@@ -147,11 +147,6 @@ admittance_controller:
     }
 
   # general settings
-  robot_description: {
-    type: string,
-    description: "Contains robot description in URDF format. The description is used for forward and inverse kinematics.",
-    read_only: true
-  }
   enable_parameter_update_without_reactivation: {
     type: bool,
     default_value: true,


### PR DESCRIPTION
The following error was thrown at admittance controller initialization - 
```
Exception thrown during init stage with message: expected [string] got [not set]
```

Looks like it was coming from the robot description parameter and it is not used anywhere. Therefore, I am deleting it as part of this PR