### PR TITLE
Update deprecated topic name

### DIFF
--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -168,7 +168,7 @@ Subscriber [#f1]_
 
 The topic interface is a fire-and-forget alternative. Use this interface if you don't care about execution monitoring.
 The goal tolerance specification is not used in this case, as there is no mechanism to notify the sender about tolerance violations. If state tolerances are violated, the trajectory is aborted and the current position is held.
-Note that although some degree of monitoring is available through the ``~/query_state`` service and ``~/state`` topic it is much more cumbersome to realize than with the action interface.
+Note that although some degree of monitoring is available through the ``~/query_state`` service and ``~/controller_state`` topic it is much more cumbersome to realize than with the action interface.
 
 
 Publishers


### PR DESCRIPTION
/state is changed in favour of /controller_state
