### PR TITLE
[JTC] Remove read_only from 'joints', 'state_interfaces' and 'command…

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -3,7 +3,6 @@ joint_trajectory_controller:
     type: string_array,
     default_value: [],
     description: "Names of joints used by the controller",
-    read_only: true,
     validation: {
       unique<>: null,
     }
@@ -21,7 +20,6 @@ joint_trajectory_controller:
     type: string_array,
     default_value: [],
     description: "Names of command interfaces to claim",
-    read_only: true,
     validation: {
       unique<>: null,
       subset_of<>: [["position", "velocity", "acceleration", "effort",]],
@@ -32,7 +30,6 @@ joint_trajectory_controller:
     type: string_array,
     default_value: [],
     description: "Names of state interfaces to claim",
-    read_only: true,
     validation: {
       unique<>: null,
       subset_of<>: [["position", "velocity", "acceleration",]],


### PR DESCRIPTION
Solves https://github.com/ros-controls/ros2_controllers/issues/966

Needs backport to `humble` and `iron`.