### PR TITLE
Change all read_only parameters to false to avoid issues when using s…

### DIFF
--- a/admittance_controller/src/admittance_controller_parameters.yaml
+++ b/admittance_controller/src/admittance_controller_parameters.yaml
@@ -2,33 +2,33 @@ admittance_controller:
   joints: {
     type: string_array,
     description: "Specifies which joints will be used by the controller. ",
-    read_only: true
+    read_only: false
   }
   command_joints: {
     type: string_array,
     default_value: [],
     description: "(optional) Specifies the joints for writing into another controllers reference. This parameter is only relevant when chaining the output of this controller to the input of another controller.",
-    read_only: true
+    read_only: false
   }
   command_interfaces:
     {
       type: string_array,
       description: "Specifies which command interfaces the controller will claim.",
-      read_only: true
+      read_only: false
     }
 
   state_interfaces:
     {
       type: string_array,
       description: "Specifies which state interfaces the controller will claim.",
-      read_only: true
+      read_only: false
     }
 
   chainable_command_interfaces:
     {
       type: string_array,
       description: "Specifies which reference interfaces the controller will export. Normally, the position and velocity are used.",
-      read_only: true
+      read_only: false
     }
 
   kinematics:

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -11,7 +11,7 @@ joint_trajectory_controller:
     type: string_array,
     default_value: [],
     description: "Names of the commanding joints used by the controller",
-    read_only: true,
+    read_only: false,
     validation: {
       unique<>: null,
     }
@@ -45,7 +45,7 @@ joint_trajectory_controller:
     type: bool,
     default_value: false,
     description: "Run the controller in open-loop, i.e., read hardware states only when starting controller. This is useful when robot is not exactly following the commanded trajectory.",
-    read_only: true,
+    read_only: false,
   }
   allow_integration_in_goal_trajectories: {
     type: bool,
@@ -56,7 +56,7 @@ joint_trajectory_controller:
     type: double,
     default_value: 20.0,
     description: "Rate status changes will be monitored",
-    read_only: true,
+    read_only: false,
     validation: {
       gt_eq: [0.1]
     }
@@ -65,7 +65,7 @@ joint_trajectory_controller:
     type: string,
     default_value: "splines",
     description: "The type of interpolation to use, if any",
-    read_only: true,
+    read_only: false,
     validation: {
       one_of<>: [["splines", "none"]],
     }

--- a/pid_controller/src/pid_controller.yaml
+++ b/pid_controller/src/pid_controller.yaml
@@ -3,7 +3,7 @@ pid_controller:
     type: string_array,
     default_value: [],
     description: "Specifies dof_names or axes used by the controller. If 'reference_and_state_dof_names' parameter is defined, then only command dof names are defined with this parameter.",
-    read_only: true,
+    read_only: false,
     validation: {
       unique<>: null,
       not_empty<>: null,
@@ -13,7 +13,7 @@ pid_controller:
     type: string_array,
     default_value: [],
     description: "(optional) Specifies dof_names or axes for getting reference and reading states. This parameter is only relevant when state dof names are different then command dof names, i.e., when a following controller is used.",
-    read_only: true,
+    read_only: false,
     validation: {
       unique<>: null,
     }
@@ -22,7 +22,7 @@ pid_controller:
     type: string,
     default_value: "",
     description: "Name of the interface used by the controller for writing commands to the hardware.",
-    read_only: true,
+    read_only: false,
     validation: {
       not_empty<>: null,
     }
@@ -31,7 +31,7 @@ pid_controller:
     type: string_array,
     default_value: [],
     description: "Name of the interfaces used by the controller getting hardware states and reference commands. The second interface should be the derivative of the first.",
-    read_only: true,
+    read_only: false,
     validation: {
       not_empty<>: null,
       size_lt<>: 3,

--- a/steering_controllers_library/src/steering_controllers_library.yaml
+++ b/steering_controllers_library/src/steering_controllers_library.yaml
@@ -9,13 +9,13 @@ steering_controllers_library:
     type: bool,
     default_value: true,
     description: "Is the steering on the front of the robot?",
-    read_only: true,
+    read_only: false,
   }
 
   rear_wheels_names: {
     type: string_array,
     description: "Names of rear wheel joints.",
-    read_only: true,
+    read_only: false,
     validation: {
       size_lt<>: [5],
       unique<>: null,
@@ -26,7 +26,7 @@ steering_controllers_library:
   front_wheels_names: {
     type: string_array,
     description: "Names of front wheel joints.",
-    read_only: true,
+    read_only: false,
     validation: {
       size_lt<>: [5],
       unique<>: null,
@@ -38,7 +38,7 @@ steering_controllers_library:
     type: string_array,
     description: "(Optional) Names of rear wheel joints to read states from. If not set joint names from 'rear_wheels_names' will be used.",
     default_value: [],
-    read_only: true,
+    read_only: false,
     validation: {
       size_lt<>: [5],
       unique<>: null,
@@ -49,7 +49,7 @@ steering_controllers_library:
     type: string_array,
     description: "(Optional) Names of front wheel joints to read states from. If not set joint names from 'front_wheels_names' will be used.",
     default_value: [],
-    read_only: true,
+    read_only: false,
     validation: {
       size_lt<>: [5],
       unique<>: null,


### PR DESCRIPTION
Related to the issue reported: https://github.com/ros-controls/ros2_controllers/issues/966

We need to change all the read_only to false for the moment to avoid issues when using spawners with parameter file. The read-only parameters cannot be loaded as they are expected to exist at the startup of the LifeCycle node. Spawners tend to load the passed parameter files before configuring the controllers. 

The above deduction is made from the following references:

http://design.ros2.org/articles/qos_configurability.html#read-only-parameters

https://docs.ros.org/en/galactic/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Parameters/Understanding-ROS2-Parameters.html#ros2-param-load 

@christophfroehlich @bmagyar It would be great to get your insight on this