### PR TITLE
[PID] Remove joint_jog include

### DIFF
--- a/pid_controller/include/pid_controller/pid_controller.hpp
+++ b/pid_controller/include/pid_controller/pid_controller.hpp
@@ -35,7 +35,6 @@
 #include "std_srvs/srv/set_bool.hpp"
 
 #include "control_msgs/msg/joint_controller_state.hpp"
-#include "control_msgs/msg/joint_jog.hpp"
 
 #include "control_msgs/msg/pid_state.hpp"
 #include "trajectory_msgs/msg/joint_trajectory_point.hpp"


### PR DESCRIPTION
While looking for a [reference to JointJog message](https://robotics.stackexchange.com/questions/107608/what-is-the-difference-between-jointjog-msgs-and-jointtrajectory-msg-in-ros2/107610#107610) I found the include in the PID header, but the message type isn't used anywhere.