### PR TITLE
Revert "[JTC] Remove read_only from 'joints', 'state_interfaces' and 'command_interfaces' parameters (#967)"

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -3,6 +3,7 @@ joint_trajectory_controller:
     type: string_array,
     default_value: [],
     description: "Names of joints used by the controller",
+    read_only: true,
     validation: {
       unique<>: null,
     }
@@ -20,6 +21,7 @@ joint_trajectory_controller:
     type: string_array,
     default_value: [],
     description: "Names of command interfaces to claim",
+    read_only: true,
     validation: {
       unique<>: null,
       subset_of<>: [["position", "velocity", "acceleration", "effort",]],
@@ -30,6 +32,7 @@ joint_trajectory_controller:
     type: string_array,
     default_value: [],
     description: "Names of state interfaces to claim",
+    read_only: true,
     validation: {
       unique<>: null,
       subset_of<>: [["position", "velocity", "acceleration",]],


### PR DESCRIPTION
This reverts commit 6e2736b0ed521e1b236dcf8ab2ede4ef565e97d4.

This should be merged after https://github.com/ros-controls/ros2_control/pull/1293, which resolves the issue reported in https://github.com/ros-controls/ros2_controllers/issues/966.