### PR TITLE
[CI] Use correct ref for scheduled workflows

### DIFF
--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_controllers
+          ref: ${{ github.event_name == 'schedule' && 'humble' || '' }}
       - name: Build and test
         shell: bash
         run: |

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_controllers
+          ref: ${{ github.event_name == 'schedule' && 'humble' || '' }}
       - name: Install dependencies
         run: |
           rosdep update

--- a/.github/workflows/iron-debian-build.yml
+++ b/.github/workflows/iron-debian-build.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_controllers
+          ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
       - name: Build and test
         shell: bash
         run: |

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_controllers
+          ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
       - name: Install dependencies
         run: |
           rosdep update

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_controllers
+          # default behavior is correct on master branch
+          # ref: ${{ github.event_name == 'schedule' && 'master' || '' }}
       - name: Build and test
         shell: bash
         run: |

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_controllers
+          # default behavior is correct on master branch
+          # ref: ${{ github.event_name == 'schedule' && 'master' || '' }}
       - name: Install dependencies
         run: |
           rosdep update


### PR DESCRIPTION
- workflow schedules are (only) run from master branch
- without giving an explicit ref argument the humble+iron workflows have checked out the master branch, which [obviously fails](https://github.com/ros-controls/ros2_controllers/actions/runs/7750292355/job/21136291633)
- fixed now with this if-clause in the [ref field](https://github.com/actions/checkout/tree/v4/?tab=readme-ov-file#usage)

See also https://github.com/ros-controls/ros2_control/pull/1361