### PR TITLE
Add test_depend on `hardware_interface_testing`

### DIFF
--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -27,6 +27,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>hardware_interface</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 

--- a/admittance_controller/package.xml
+++ b/admittance_controller/package.xml
@@ -34,6 +34,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>kinematics_interface_kdl</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 

--- a/bicycle_steering_controller/package.xml
+++ b/bicycle_steering_controller/package.xml
@@ -28,6 +28,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>hardware_interface</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/diff_drive_controller/test/test_load_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_load_diff_drive_controller.cpp
@@ -16,6 +16,9 @@
 #include <memory>
 
 #include "controller_manager/controller_manager.hpp"
+#include "hardware_interface/resource_manager.hpp"
+#include "rclcpp/executor.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/utilities.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -18,6 +18,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>hardware_interface_testing</test_depend>
+  <test_depend>hardware_interface</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -17,6 +17,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/effort_controllers/test/test_load_joint_group_effort_controller.cpp
+++ b/effort_controllers/test/test_load_joint_group_effort_controller.cpp
@@ -17,7 +17,9 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "hardware_interface/resource_manager.hpp"
+#include "rclcpp/executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
 TEST(TestLoadJointGroupVelocityController, load_controller)

--- a/force_torque_sensor_broadcaster/package.xml
+++ b/force_torque_sensor_broadcaster/package.xml
@@ -23,6 +23,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/forward_command_controller/package.xml
+++ b/forward_command_controller/package.xml
@@ -22,6 +22,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/gripper_controllers/package.xml
+++ b/gripper_controllers/package.xml
@@ -27,6 +27,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/gripper_controllers/test/test_load_gripper_action_controllers.cpp
+++ b/gripper_controllers/test/test_load_gripper_action_controllers.cpp
@@ -17,7 +17,9 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "hardware_interface/resource_manager.hpp"
+#include "rclcpp/executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
 TEST(TestLoadGripperActionControllers, load_controller)

--- a/imu_sensor_broadcaster/package.xml
+++ b/imu_sensor_broadcaster/package.xml
@@ -25,6 +25,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/joint_state_broadcaster/package.xml
+++ b/joint_state_broadcaster/package.xml
@@ -25,8 +25,8 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
-  <test_depend>hardware_interface</test_depend>
   <test_depend>hardware_interface_testing</test_depend>
+  <test_depend>hardware_interface</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 

--- a/joint_state_broadcaster/package.xml
+++ b/joint_state_broadcaster/package.xml
@@ -26,6 +26,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>hardware_interface</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -28,6 +28,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/pid_controller/package.xml
+++ b/pid_controller/package.xml
@@ -27,6 +27,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/position_controllers/package.xml
+++ b/position_controllers/package.xml
@@ -18,6 +18,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>hardware_interface_testing</test_depend>
+  <test_depend>hardware_interface</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/position_controllers/package.xml
+++ b/position_controllers/package.xml
@@ -17,6 +17,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/position_controllers/test/test_load_joint_group_position_controller.cpp
+++ b/position_controllers/test/test_load_joint_group_position_controller.cpp
@@ -17,7 +17,9 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "hardware_interface/resource_manager.hpp"
+#include "rclcpp/executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
 TEST(TestLoadJointGroupPositionController, load_controller)

--- a/range_sensor_broadcaster/package.xml
+++ b/range_sensor_broadcaster/package.xml
@@ -23,6 +23,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>hardware_interface</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/range_sensor_broadcaster/package.xml
+++ b/range_sensor_broadcaster/package.xml
@@ -22,7 +22,6 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
-  <test_depend>hardware_interface</test_depend>
   <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 

--- a/tricycle_controller/package.xml
+++ b/tricycle_controller/package.xml
@@ -30,6 +30,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/tricycle_controller/test/test_load_tricycle_controller.cpp
+++ b/tricycle_controller/test/test_load_tricycle_controller.cpp
@@ -21,7 +21,9 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "hardware_interface/resource_manager.hpp"
+#include "rclcpp/executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
 TEST(TestLoadTricycleController, load_controller)

--- a/tricycle_steering_controller/package.xml
+++ b/tricycle_steering_controller/package.xml
@@ -30,6 +30,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>hardware_interface</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/tricycle_steering_controller/package.xml
+++ b/tricycle_steering_controller/package.xml
@@ -29,7 +29,6 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
-  <test_depend>hardware_interface</test_depend>
   <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 

--- a/velocity_controllers/package.xml
+++ b/velocity_controllers/package.xml
@@ -18,6 +18,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>hardware_interface</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/velocity_controllers/package.xml
+++ b/velocity_controllers/package.xml
@@ -17,8 +17,8 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
-  <test_depend>hardware_interface</test_depend>
   <test_depend>hardware_interface_testing</test_depend>
+  <test_depend>hardware_interface</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/velocity_controllers/test/test_load_joint_group_velocity_controller.cpp
+++ b/velocity_controllers/test/test_load_joint_group_velocity_controller.cpp
@@ -17,7 +17,9 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "hardware_interface/resource_manager.hpp"
+#include "rclcpp/executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
 TEST(TestLoadJointGroupVelocityController, load_controller)


### PR DESCRIPTION
We moved the test_actuator class into a different package with https://github.com/ros-controls/ros2_control/pull/1325

Now the tests here using the `ros2_control_test_assets::minimal_robot_urdf` fail, see [here](https://github.com/ros-controls/ros2_controllers/actions/runs/7732780973/job/21083467742). Adding the new package to the test_depend should fix this.

I also updated all includes of the test_load_*-files as well as dependencies on hardware_interface (direct include of resource_manager.hpp).

Binary jobs fail now because of https://github.com/ros-controls/ros2_control/pull/1169 not being released.