### PR TITLE
[CI] Improvements and Cleanups

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -2,6 +2,30 @@ name: ROS Lint
 on:
   pull_request:
 
+env:
+  package-name:
+    ackermann_steering_controller
+    admittance_controller
+    bicycle_steering_controller
+    diff_drive_controller
+    effort_controllers
+    force_torque_sensor_broadcaster
+    forward_command_controller
+    gripper_controllers
+    imu_sensor_broadcaster
+    joint_state_broadcaster
+    joint_trajectory_controller
+    pid_controller
+    position_controllers
+    range_sensor_broadcaster
+    ros2_controllers
+    ros2_controllers_test_nodes
+    rqt_joint_trajectory_controller
+    steering_controllers_library
+    tricycle_controller
+    tricycle_steering_controller
+    velocity_controllers
+
 jobs:
   ament_lint:
     name: ament_${{ matrix.linter }}
@@ -19,28 +43,7 @@ jobs:
       with:
         distribution: rolling
         linter: ${{ matrix.linter }}
-        package-name:
-          ackermann_steering_controller
-          admittance_controller
-          bicycle_steering_controller
-          diff_drive_controller
-          effort_controllers
-          force_torque_sensor_broadcaster
-          forward_command_controller
-          gripper_controllers
-          imu_sensor_broadcaster
-          joint_state_broadcaster
-          joint_trajectory_controller
-          pid_controller
-          position_controllers
-          range_sensor_broadcaster
-          ros2_controllers
-          ros2_controllers_test_nodes
-          rqt_joint_trajectory_controller
-          steering_controllers_library
-          tricycle_controller
-          tricycle_steering_controller
-          velocity_controllers
+        package-name: ${{ env.package-name }}
 
 
   ament_lint_100:
@@ -58,25 +61,4 @@ jobs:
         distribution: rolling
         linter: cpplint
         arguments: "--linelength=100 --filter=-whitespace/newline"
-        package-name:
-          ackermann_steering_controller
-          admittance_controller
-          bicycle_steering_controller
-          diff_drive_controller
-          effort_controllers
-          force_torque_sensor_broadcaster
-          forward_command_controller
-          gripper_controllers
-          imu_sensor_broadcaster
-          joint_state_broadcaster
-          joint_trajectory_controller
-          pid_controller
-          position_controllers
-          range_sensor_broadcaster
-          ros2_controllers
-          ros2_controllers_test_nodes
-          rqt_joint_trajectory_controller
-          steering_controllers_library
-          tricycle_controller
-          tricycle_steering_controller
-          velocity_controllers
+        package-name: ${{ env.package-name }}

--- a/.github/workflows/humble-binary-build-main.yml
+++ b/.github/workflows/humble-binary-build-main.yml
@@ -4,8 +4,6 @@ name: Humble Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - humble
   pull_request:
     branches:
       - humble

--- a/.github/workflows/humble-binary-build-testing.yml
+++ b/.github/workflows/humble-binary-build-testing.yml
@@ -4,8 +4,6 @@ name: Humble Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - humble
   pull_request:
     branches:
       - humble

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -12,26 +12,9 @@ on:
 jobs:
   humble_debian:
     name: Humble debian build
-    runs-on: ubuntu-latest
-    env:
-      ROS_DISTRO: humble
-      skip-packages: rqt_joint_trajectory_controller
-    container: ghcr.io/ros-controls/ros:humble-debian
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: src/ros2_controllers
-          ref: ${{ github.event_name == 'schedule' && 'humble' || '' }}
-      - name: Build workspace
-        shell: bash
-        run: |
-          source /opt/ros2_ws/install/setup.bash
-          vcs import src < src/ros2_controllers/ros2_controllers.${{ env.ROS_DISTRO }}.repos
-          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
-      - name: Test workspace
-        shell: bash
-        continue-on-error: true
-        run: |
-          source /opt/ros2_ws/install/setup.bash
-          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
-          colcon test-result --verbose
+    uses: ./.github/workflows/reusable-debian-build.yml
+    with:
+      ros_distro: humble
+      upstream_workspace: ros2_controllers.humble.repos
+      ref_for_scheduled_build: humble
+      skip_packages: rqt_joint_trajectory_controller

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -30,6 +30,7 @@ jobs:
           colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
       - name: Test workspace
         shell: bash
+        continue-on-error: true
         run: |
           source /opt/ros2_ws/install/setup.bash
           colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -1,4 +1,4 @@
-name: Debian Humble Build
+name: Debian Humble Source Build
 on:
   workflow_dispatch:
   pull_request:
@@ -15,17 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: humble
+      skip-packages: rqt_joint_trajectory_controller
     container: ghcr.io/ros-controls/ros:humble-debian
     steps:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_controllers
           ref: ${{ github.event_name == 'schedule' && 'humble' || '' }}
-      - name: Build and test
+      - name: Build workspace
         shell: bash
         run: |
           source /opt/ros2_ws/install/setup.bash
           vcs import src < src/ros2_controllers/ros2_controllers.${{ env.ROS_DISTRO }}.repos
-          colcon build --packages-skip rqt_controller_manager rqt_joint_trajectory_controller
-          colcon test --packages-skip rqt_controller_manager rqt_joint_trajectory_controller control_msgs controller_manager_msgs
+          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        run: |
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -23,18 +23,20 @@ jobs:
           ref: ${{ github.event_name == 'schedule' && 'humble' || '' }}
       - name: Install dependencies
         run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           rosdep update
           rosdep install -iyr --from-path src/ros2_controllers || true
       - name: Build workspace
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
       - name: Test workspace
         shell: bash
         continue-on-error: true
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -11,32 +11,9 @@ on:
 jobs:
   humble_rhel_binary:
     name: Humble RHEL binary build
-    runs-on: ubuntu-latest
-    env:
-      ROS_DISTRO: humble
-      skip-packages: rqt_joint_trajectory_controller
-    container: ghcr.io/ros-controls/ros:humble-rhel
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: src/ros2_controllers
-          ref: ${{ github.event_name == 'schedule' && 'humble' || '' }}
-      - name: Install dependencies
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/local_setup.bash
-          rosdep update
-          rosdep install -iyr --from-path src/ros2_controllers || true
-      - name: Build workspace
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/local_setup.bash
-          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
-      - name: Test workspace
-        shell: bash
-        continue-on-error: true
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/local_setup.bash
-          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
-          colcon test-result --verbose
+    uses: ./.github/workflows/reusable-rhel-binary-build.yml
+    with:
+      ros_distro: humble
+      upstream_workspace: ros2_controllers.humble.repos
+      ref_for_scheduled_build: humble
+      skip_packages: rqt_joint_trajectory_controller

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: humble
+      skip-packages: rqt_joint_trajectory_controller
     container: ghcr.io/ros-controls/ros:humble-rhel
     steps:
       - uses: actions/checkout@v4
@@ -24,9 +25,15 @@ jobs:
         run: |
           rosdep update
           rosdep install -iyr --from-path src/ros2_controllers || true
-      - name: Build and test
+      - name: Build workspace
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          colcon build --packages-skip rqt_joint_trajectory_controller
-          colcon test --packages-skip rqt_joint_trajectory_controller
+          source /opt/ros2_ws/install/setup.bash
+          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -32,6 +32,7 @@ jobs:
           colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
       - name: Test workspace
         shell: bash
+        continue-on-error: true
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           source /opt/ros2_ws/install/setup.bash

--- a/.github/workflows/humble-semi-binary-build-main.yml
+++ b/.github/workflows/humble-semi-binary-build-main.yml
@@ -3,8 +3,6 @@ name: Humble Semi-Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - humble
   pull_request:
     branches:
       - humble

--- a/.github/workflows/humble-semi-binary-build-testing.yml
+++ b/.github/workflows/humble-semi-binary-build-testing.yml
@@ -3,8 +3,6 @@ name: Humble Semi-Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - humble
   pull_request:
     branches:
       - humble

--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -1,8 +1,6 @@
 name: Humble Source Build
 on:
   workflow_dispatch:
-    branches:
-      - humble
   push:
     branches:
       - humble

--- a/.github/workflows/iron-binary-build-main.yml
+++ b/.github/workflows/iron-binary-build-main.yml
@@ -4,10 +4,6 @@ name: Iron Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - iron
-      - '*feature*'
-      - '*feature/**'
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-binary-build-testing.yml
+++ b/.github/workflows/iron-binary-build-testing.yml
@@ -4,10 +4,6 @@ name: Iron Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - iron
-      - '*feature*'
-      - '*feature/**'
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-debian-build.yml
+++ b/.github/workflows/iron-debian-build.yml
@@ -1,4 +1,4 @@
-name: Debian Iron Build
+name: Debian Iron Source Build
 on:
   workflow_dispatch:
   pull_request:
@@ -15,17 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: iron
+      skip-packages: rqt_joint_trajectory_controller
     container: ghcr.io/ros-controls/ros:iron-debian
     steps:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_controllers
           ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
-      - name: Build and test
+      - name: Build workspace
         shell: bash
         run: |
           source /opt/ros2_ws/install/setup.bash
           vcs import src < src/ros2_controllers/ros2_controllers.${{ env.ROS_DISTRO }}.repos
-          colcon build --packages-skip rqt_controller_manager rqt_joint_trajectory_controller
-          colcon test --packages-skip rqt_controller_manager rqt_joint_trajectory_controller control_msgs controller_manager_msgs
+          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        run: |
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/iron-debian-build.yml
+++ b/.github/workflows/iron-debian-build.yml
@@ -30,6 +30,7 @@ jobs:
           colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
       - name: Test workspace
         shell: bash
+        continue-on-error: true
         run: |
           source /opt/ros2_ws/install/setup.bash
           colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}

--- a/.github/workflows/iron-debian-build.yml
+++ b/.github/workflows/iron-debian-build.yml
@@ -12,26 +12,9 @@ on:
 jobs:
   iron_debian:
     name: Iron debian build
-    runs-on: ubuntu-latest
-    env:
-      ROS_DISTRO: iron
-      skip-packages: rqt_joint_trajectory_controller
-    container: ghcr.io/ros-controls/ros:iron-debian
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: src/ros2_controllers
-          ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
-      - name: Build workspace
-        shell: bash
-        run: |
-          source /opt/ros2_ws/install/setup.bash
-          vcs import src < src/ros2_controllers/ros2_controllers.${{ env.ROS_DISTRO }}.repos
-          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
-      - name: Test workspace
-        shell: bash
-        continue-on-error: true
-        run: |
-          source /opt/ros2_ws/install/setup.bash
-          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
-          colcon test-result --verbose
+    uses: ./.github/workflows/reusable-debian-build.yml
+    with:
+      ros_distro: iron
+      upstream_workspace: ros2_controllers.iron.repos
+      ref_for_scheduled_build: iron
+      skip_packages: rqt_joint_trajectory_controller

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -12,33 +12,9 @@ on:
 jobs:
   iron_rhel_binary:
     name: Iron RHEL binary build
-    runs-on: ubuntu-latest
-    env:
-      ROS_DISTRO: iron
-      skip-packages: rqt_joint_trajectory_controller
-    container: ghcr.io/ros-controls/ros:iron-rhel
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: src/ros2_controllers
-          ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
-      - name: Install dependencies
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/local_setup.bash
-          rosdep update
-          rosdep install -iyr --from-path src/ros2_controllers || true
-      - name: Build workspace
-        # source also underlay workspace with generate_parameter_library on rhel9
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/local_setup.bash
-          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
-      - name: Test workspace
-        shell: bash
-        continue-on-error: true
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/local_setup.bash
-          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
-          colcon test-result --verbose
+    uses: ./.github/workflows/reusable-rhel-binary-build.yml
+    with:
+      ros_distro: iron
+      upstream_workspace: ros2_controllers.iron.repos
+      ref_for_scheduled_build: iron
+      skip_packages: rqt_joint_trajectory_controller

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -24,19 +24,21 @@ jobs:
           ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
       - name: Install dependencies
         run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           rosdep update
           rosdep install -iyr --from-path src/ros2_controllers || true
       - name: Build workspace
         # source also underlay workspace with generate_parameter_library on rhel9
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
       - name: Test workspace
         shell: bash
         continue-on-error: true
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: iron
+      skip-packages: rqt_joint_trajectory_controller
     container: ghcr.io/ros-controls/ros:iron-rhel
     steps:
       - uses: actions/checkout@v4
@@ -25,11 +26,16 @@ jobs:
         run: |
           rosdep update
           rosdep install -iyr --from-path src/ros2_controllers || true
-      - name: Build and test
-      # source also underlay workspace with generate_parameter_library on rhel9
+      - name: Build workspace
+        # source also underlay workspace with generate_parameter_library on rhel9
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           source /opt/ros2_ws/install/setup.bash
-          colcon build --packages-skip rqt_joint_trajectory_controller
-          colcon test --packages-skip rqt_joint_trajectory_controller
+          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -34,6 +34,7 @@ jobs:
           colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
       - name: Test workspace
         shell: bash
+        continue-on-error: true
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           source /opt/ros2_ws/install/setup.bash

--- a/.github/workflows/iron-semi-binary-build-main.yml
+++ b/.github/workflows/iron-semi-binary-build-main.yml
@@ -3,10 +3,6 @@ name: Iron Semi-Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - iron
-      - '*feature*'
-      - '*feature/**'
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-semi-binary-build-testing.yml
+++ b/.github/workflows/iron-semi-binary-build-testing.yml
@@ -3,10 +3,6 @@ name: Iron Semi-Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - iron
-      - '*feature*'
-      - '*feature/**'
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-source-build.yml
+++ b/.github/workflows/iron-source-build.yml
@@ -1,8 +1,6 @@
 name: Iron Source Build
 on:
   workflow_dispatch:
-    branches:
-      - iron
   push:
     branches:
       - iron

--- a/.github/workflows/reusable-debian-build.yml
+++ b/.github/workflows/reusable-debian-build.yml
@@ -1,0 +1,63 @@
+name: Reusable Debian Source Build
+# Reusable action to simplify dealing with debian source builds
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+
+on:
+  workflow_call:
+    inputs:
+      ros_distro:
+        description: 'ROS2 distribution name'
+        required: true
+        type: string
+      ref_for_scheduled_build:
+        description: 'Reference on which the repo should be checkout for scheduled build. Usually is this name of a branch or a tag.'
+        default: ''
+        required: false
+        type: string
+      upstream_workspace:
+        description: 'Path to local .repos file.'
+        default: ''
+        required: false
+        type: string
+      skip_packages:
+        description: 'Packages to skip from build and test'
+        default: ''
+        required: false
+        type: string
+
+
+jobs:
+  debian_source:
+    name: ${{ inputs.ros_distro }} debian build
+    runs-on: ubuntu-latest
+    env:
+      ROS_DISTRO: ${{ inputs.ros_distro }}
+      path: src/ros2_controllers
+    container: ghcr.io/ros-controls/ros:${{ inputs.ros_distro }}-debian
+    steps:
+      - name: Checkout default ref when build is not scheduled
+        if: ${{ github.event_name != 'schedule' }}
+        uses: actions/checkout@v4
+        with:
+          path: ${{ env.path }}
+      - name: Checkout ${{ inputs.ref_for_scheduled_build }} on scheduled build
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref_for_scheduled_build }}
+          path: ${{ env.path }}
+      - name: Build workspace
+        shell: bash
+        run: |
+          source /opt/ros2_ws/install/setup.bash
+          if [[ -n "${{ inputs.upstream_workspace }}" ]]; then
+            vcs import src < ${{ env.path }}/${{ inputs.upstream_workspace }}
+          fi
+          colcon build --packages-up-to $(colcon list --paths ${{ env.path }}/* --names-only) --packages-skip ${{ inputs.skip_packages }}
+      - name: Test workspace
+        shell: bash
+        continue-on-error: true
+        run: |
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths ${{ env.path }}/* --names-only) --packages-skip ${{ inputs.skip_packages }}
+          colcon test-result --verbose

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -56,10 +56,10 @@ jobs:
       BASEDIR: ${{ github.workspace }}/${{ inputs.basedir }}
       CACHE_PREFIX: ${{ inputs.ros_distro }}-${{ inputs.upstream_workspace }}-${{ inputs.ros_repo }}-${{ github.job }}
     steps:
-      - name: Checkout ${{ inputs.ref }} when build is not scheduled
+      - name: Checkout default ref when build is not scheduled
         if: ${{ github.event_name != 'schedule' }}
         uses: actions/checkout@v4
-      - name: Checkout ${{ inputs.ref }} on scheduled build
+      - name: Checkout ${{ inputs.ref_for_scheduled_build }} on scheduled build
         if: ${{ github.event_name == 'schedule' }}
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable-rhel-binary-build.yml
+++ b/.github/workflows/reusable-rhel-binary-build.yml
@@ -1,0 +1,69 @@
+name: Reusable RHEL Binary Build
+# Reusable action to simplify dealing with RHEL binary builds
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+
+on:
+  workflow_call:
+    inputs:
+      ros_distro:
+        description: 'ROS2 distribution name'
+        required: true
+        type: string
+      ref_for_scheduled_build:
+        description: 'Reference on which the repo should be checkout for scheduled build. Usually is this name of a branch or a tag.'
+        default: ''
+        required: false
+        type: string
+      upstream_workspace:
+        description: 'Path to local .repos file.'
+        default: ''
+        required: false
+        type: string
+      skip_packages:
+        description: 'Packages to skip from build and test'
+        default: ''
+        required: false
+        type: string
+
+jobs:
+  rhel_binary:
+    name: ${{ inputs.ros_distro }} RHEL binary build
+    runs-on: ubuntu-latest
+    env:
+      path: src/ros2_controllers
+    container: ghcr.io/ros-controls/ros:${{ inputs.ros_distro }}-rhel
+    steps:
+      - name: Checkout default ref when build is not scheduled
+        if: ${{ github.event_name != 'schedule' }}
+        uses: actions/checkout@v4
+        with:
+          path: ${{ env.path }}
+      - name: Checkout ${{ inputs.ref_for_scheduled_build }} on scheduled build
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref_for_scheduled_build }}
+          path: ${{ env.path }}
+      - name: Install dependencies
+        run: |
+          source /opt/ros/${{ inputs.ros_distro }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
+          if [[ -n "${{ inputs.upstream_workspace }}" ]]; then
+            vcs import src < ${{ env.path }}/${{ inputs.upstream_workspace }}
+          fi
+          rosdep update
+          rosdep install -iyr --from-path src || true
+      - name: Build workspace
+        # source also underlay workspace with generate_parameter_library on rhel9
+        run: |
+          source /opt/ros/${{ inputs.ros_distro }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
+          colcon build  --packages-up-to $(colcon list --paths ${{ env.path }}/* --names-only) --packages-skip ${{ inputs.skip_packages }}
+      - name: Test workspace
+        shell: bash
+        continue-on-error: true
+        run: |
+          source /opt/ros/${{ inputs.ros_distro }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
+          colcon test --packages-select $(colcon list --paths ${{ env.path }}/* --names-only) --packages-skip  ${{ inputs.skip_packages }}
+          colcon test-result --verbose

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -4,10 +4,6 @@ name: Rolling Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - master
-      - '*feature*'
-      - '*feature/**'
   pull_request:
     branches:
       - master

--- a/.github/workflows/rolling-binary-build-testing.yml
+++ b/.github/workflows/rolling-binary-build-testing.yml
@@ -4,10 +4,6 @@ name: Rolling Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - master
-      - '*feature*'
-      - '*feature/**'
   pull_request:
     branches:
       - master

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -12,27 +12,9 @@ on:
 jobs:
   rolling_debian:
     name: Rolling debian build
-    runs-on: ubuntu-latest
-    env:
-      ROS_DISTRO: rolling
-      skip-packages: rqt_joint_trajectory_controller
-    container: ghcr.io/ros-controls/ros:rolling-debian
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: src/ros2_controllers
-          # default behavior is correct on master branch
-          # ref: ${{ github.event_name == 'schedule' && 'master' || '' }}
-      - name: Build workspace
-        shell: bash
-        run: |
-          source /opt/ros2_ws/install/setup.bash
-          vcs import src < src/ros2_controllers/ros2_controllers.${{ env.ROS_DISTRO }}.repos
-          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
-      - name: Test workspace
-        shell: bash
-        continue-on-error: true
-        run: |
-          source /opt/ros2_ws/install/setup.bash
-          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
-          colcon test-result --verbose
+    uses: ./.github/workflows/reusable-debian-build.yml
+    with:
+      ros_distro: rolling
+      upstream_workspace: ros2_controllers.rolling.repos
+      ref_for_scheduled_build: master
+      skip_packages: rqt_joint_trajectory_controller

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -1,4 +1,4 @@
-name: Debian Rolling Build
+name: Debian Rolling Source Build
 on:
   workflow_dispatch:
   pull_request:
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: rolling
+      skip-packages: rqt_joint_trajectory_controller
     container: ghcr.io/ros-controls/ros:rolling-debian
     steps:
       - uses: actions/checkout@v4
@@ -22,11 +23,15 @@ jobs:
           path: src/ros2_controllers
           # default behavior is correct on master branch
           # ref: ${{ github.event_name == 'schedule' && 'master' || '' }}
-      - name: Build and test
+      - name: Build workspace
         shell: bash
         run: |
           source /opt/ros2_ws/install/setup.bash
           vcs import src < src/ros2_controllers/ros2_controllers.${{ env.ROS_DISTRO }}.repos
-          colcon build --packages-skip rqt_controller_manager rqt_joint_trajectory_controller
-          colcon test --packages-skip rqt_controller_manager rqt_joint_trajectory_controller
+          colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        run: |
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -31,6 +31,7 @@ jobs:
           colcon build --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
       - name: Test workspace
         shell: bash
+        continue-on-error: true
         run: |
           source /opt/ros2_ws/install/setup.bash
           colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -35,6 +35,7 @@ jobs:
           colcon build  --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
       - name: Test workspace
         shell: bash
+        continue-on-error: true
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           source /opt/ros2_ws/install/setup.bash

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -12,34 +12,9 @@ on:
 jobs:
   rolling_rhel_binary:
     name: Rolling RHEL binary build
-    runs-on: ubuntu-latest
-    env:
-      ROS_DISTRO: rolling
-      skip-packages: rqt_joint_trajectory_controller
-    container: ghcr.io/ros-controls/ros:rolling-rhel
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: src/ros2_controllers
-          # default behavior is correct on master branch
-          # ref: ${{ github.event_name == 'schedule' && 'master' || '' }}
-      - name: Install dependencies
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/local_setup.bash
-          rosdep update
-          rosdep install -iyr --from-path src/ros2_controllers || true
-      - name: Build workspace
-        # source also underlay workspace with generate_parameter_library on rhel9
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/local_setup.bash
-          colcon build  --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
-      - name: Test workspace
-        shell: bash
-        continue-on-error: true
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/local_setup.bash
-          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
-          colcon test-result --verbose
+    uses: ./.github/workflows/reusable-rhel-binary-build.yml
+    with:
+      ros_distro: rolling
+      upstream_workspace: ros2_controllers.rolling.repos
+      ref_for_scheduled_build: master
+      skip_packages: rqt_joint_trajectory_controller

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: rolling
+      skip-packages: rqt_joint_trajectory_controller
     container: ghcr.io/ros-controls/ros:rolling-rhel
     steps:
       - uses: actions/checkout@v4
@@ -26,11 +27,16 @@ jobs:
         run: |
           rosdep update
           rosdep install -iyr --from-path src/ros2_controllers || true
-      - name: Build and test
+      - name: Build workspace
         # source also underlay workspace with generate_parameter_library on rhel9
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           source /opt/ros2_ws/install/setup.bash
-          colcon build --packages-skip rqt_joint_trajectory_controller
-          colcon test --packages-skip rqt_joint_trajectory_controller
+          colcon build  --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -25,19 +25,21 @@ jobs:
           # ref: ${{ github.event_name == 'schedule' && 'master' || '' }}
       - name: Install dependencies
         run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           rosdep update
           rosdep install -iyr --from-path src/ros2_controllers || true
       - name: Build workspace
         # source also underlay workspace with generate_parameter_library on rhel9
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           colcon build  --packages-up-to $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip ${{ env.skip-packages }}
       - name: Test workspace
         shell: bash
         continue-on-error: true
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           colcon test --packages-select $(colcon list --paths src/ros2_controllers/* --names-only) --packages-skip  ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/rolling-semi-binary-build-main.yml
+++ b/.github/workflows/rolling-semi-binary-build-main.yml
@@ -3,10 +3,6 @@ name: Rolling Semi-Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - master
-      - '*feature*'
-      - '*feature/**'
   pull_request:
     branches:
       - master

--- a/.github/workflows/rolling-semi-binary-build-testing.yml
+++ b/.github/workflows/rolling-semi-binary-build-testing.yml
@@ -3,10 +3,6 @@ name: Rolling Semi-Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - master
-      - '*feature*'
-      - '*feature/**'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
RHEL/Debian
- Build and test only the packages from this repo, instead of all packages imported with the repos file. I used `colcon list` instead of hardcoding it as it is done with the lint jobs.
- Split build and test steps, and let the test step [`continue-on-error`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error): The main goal is to detect compilation problems with unsupported C++ features, which are now visible at first glance. Tests remain flaky on theses platforms, which is a different issue.
- use reusable workflows for both platforms
- use a semi-binary build for RHEL

Others
- Use a single package list for lint job
- Remove the wrong branch field below workflow_dispatch

Backport after #1016 and #1017/#1029 and #1030