### PR TITLE
Fix usage of M_PI on Windows

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -58,6 +58,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_trajectory test/test_trajectory.cpp)
   target_link_libraries(test_trajectory joint_trajectory_controller)
+  target_compile_definitions(test_trajectory PRIVATE _USE_MATH_DEFINES)
 
   ament_add_gmock(test_trajectory_controller
     test/test_trajectory_controller.cpp)
@@ -65,6 +66,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_trajectory_controller
     joint_trajectory_controller
   )
+  target_compile_definitions(joint_trajectory_controller PRIVATE _USE_MATH_DEFINES)
 
   ament_add_gmock(test_load_joint_trajectory_controller
     test/test_load_joint_trajectory_controller.cpp

--- a/steering_controllers_library/CMakeLists.txt
+++ b/steering_controllers_library/CMakeLists.txt
@@ -51,7 +51,7 @@ ament_target_dependencies(steering_controllers_library PUBLIC ${THIS_PACKAGE_INC
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(steering_controllers_library PRIVATE "STEERING_CONTROLLERS_BUILDING_DLL")
+target_compile_definitions(steering_controllers_library PRIVATE "STEERING_CONTROLLERS_BUILDING_DLL" "_USE_MATH_DEFINES")
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)

--- a/tricycle_controller/CMakeLists.txt
+++ b/tricycle_controller/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(tricycle_controller PUBLIC
 )
 target_link_libraries(tricycle_controller PUBLIC tricycle_controller_parameters)
 ament_target_dependencies(tricycle_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_compile_definitions(tricycle_controller PRIVATE _USE_MATH_DEFINES)
 
 pluginlib_export_plugin_description_file(controller_interface tricycle_controller.xml)
 


### PR DESCRIPTION
`M_PI` and `M_PI_2` are not part of the C or C++ standard. However, they are available in almost all major compilers. On Windows, to make sure that they are defined, `_USE_MATH_DEFINES` needs to be defined when `#include <cmath>` or `#include <math.h>` is included. This PR make sure that `_USE_MATH_DEFINES` is defined whenever `M_PI` or `M_PI_2` is used, for Windows compatibility.

Checklist:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
