### PR TITLE
Fix usage of visibility macros

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -44,7 +44,7 @@ ament_target_dependencies(ackermann_steering_controller PUBLIC ${THIS_PACKAGE_IN
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(ackermann_steering_controller PRIVATE "ACKERMANN_STEERING_CONTROLLER_BUILDING_DLL")
+target_compile_definitions(ackermann_steering_controller PRIVATE "ACKERMANN_STEERING_CONTROLLER__VISIBILITY_BUILDING_DLL")
 
 pluginlib_export_plugin_description_file(
   controller_interface ackermann_steering_controller.xml)

--- a/bicycle_steering_controller/CMakeLists.txt
+++ b/bicycle_steering_controller/CMakeLists.txt
@@ -44,7 +44,7 @@ ament_target_dependencies(bicycle_steering_controller PUBLIC ${THIS_PACKAGE_INCL
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(bicycle_steering_controller PRIVATE "ACKERMANN_STEERING_CONTROLLER_BUILDING_DLL")
+target_compile_definitions(bicycle_steering_controller PRIVATE "BICYCLE_STEERING_CONTROLLER__VISIBILITY_BUILDING_DLL")
 
 pluginlib_export_plugin_description_file(
   controller_interface bicycle_steering_controller.xml)

--- a/gripper_controllers/CMakeLists.txt
+++ b/gripper_controllers/CMakeLists.txt
@@ -45,6 +45,10 @@ target_link_libraries(gripper_action_controller PUBLIC
 )
 ament_target_dependencies(gripper_action_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(gripper_action_controller PRIVATE "GRIPPER_ACTION_CONTROLLER_BUILDING_DLL")
+
 pluginlib_export_plugin_description_file(controller_interface ros_control_plugins.xml)
 
 if(BUILD_TESTING)

--- a/pid_controller/CMakeLists.txt
+++ b/pid_controller/CMakeLists.txt
@@ -45,7 +45,7 @@ ament_target_dependencies(pid_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(pid_controller PRIVATE "PID_CONTROLLER_BUILDING_DLL")
+target_compile_definitions(pid_controller PRIVATE "PID_CONTROLLER__VISIBILITY_BUILDING_DLL")
 
 pluginlib_export_plugin_description_file(controller_interface pid_controller.xml)
 

--- a/steering_controllers_library/CMakeLists.txt
+++ b/steering_controllers_library/CMakeLists.txt
@@ -51,7 +51,7 @@ ament_target_dependencies(steering_controllers_library PUBLIC ${THIS_PACKAGE_INC
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(steering_controllers_library PRIVATE "STEERING_CONTROLLERS_BUILDING_DLL" "_USE_MATH_DEFINES")
+target_compile_definitions(steering_controllers_library PRIVATE "STEERING_CONTROLLERS__VISIBILITY_BUILDING_DLL" "_USE_MATH_DEFINES")
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)

--- a/tricycle_controller/CMakeLists.txt
+++ b/tricycle_controller/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(tricycle_controller PUBLIC tricycle_controller_parameters)
 ament_target_dependencies(tricycle_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(tricycle_controller PRIVATE "TRICYCLE_STEERING_CONTROLLER__VISIBILITY_BUILDING_DLL" "_USE_MATH_DEFINES")
+target_compile_definitions(tricycle_controller PRIVATE "TRICYCLE_CONTROLLER_BUILDING_DLL" "_USE_MATH_DEFINES")
 
 pluginlib_export_plugin_description_file(controller_interface tricycle_controller.xml)
 

--- a/tricycle_controller/CMakeLists.txt
+++ b/tricycle_controller/CMakeLists.txt
@@ -47,7 +47,9 @@ target_include_directories(tricycle_controller PUBLIC
 )
 target_link_libraries(tricycle_controller PUBLIC tricycle_controller_parameters)
 ament_target_dependencies(tricycle_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
-target_compile_definitions(tricycle_controller PRIVATE _USE_MATH_DEFINES)
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(tricycle_controller PRIVATE "TRICYCLE_STEERING_CONTROLLER__VISIBILITY_BUILDING_DLL" "_USE_MATH_DEFINES")
 
 pluginlib_export_plugin_description_file(controller_interface tricycle_controller.xml)
 

--- a/tricycle_steering_controller/CMakeLists.txt
+++ b/tricycle_steering_controller/CMakeLists.txt
@@ -44,7 +44,7 @@ ament_target_dependencies(tricycle_steering_controller PUBLIC ${THIS_PACKAGE_INC
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(tricycle_steering_controller PRIVATE "ACKERMANN_STEERING_CONTROLLER_BUILDING_DLL")
+target_compile_definitions(tricycle_steering_controller PRIVATE "TRICYCLE_STEERING_CONTROLLER__VISIBILITY_BUILDING_DLL")
 
 pluginlib_export_plugin_description_file(
   controller_interface tricycle_steering_controller.xml)

--- a/tricycle_steering_controller/include/tricycle_steering_controller/tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/include/tricycle_steering_controller/tricycle_steering_controller.hpp
@@ -45,14 +45,14 @@ class TricycleSteeringController : public steering_controllers_library::Steering
 public:
   TricycleSteeringController();
 
-  TRICYCLE_STEERING_CONTROLLER__VISIBILITY_PUBLIC controller_interface::CallbackReturn configure_odometry()
-    override;
+  TRICYCLE_STEERING_CONTROLLER__VISIBILITY_PUBLIC controller_interface::CallbackReturn
+  configure_odometry() override;
 
   TRICYCLE_STEERING_CONTROLLER__VISIBILITY_PUBLIC bool update_odometry(
     const rclcpp::Duration & period) override;
 
-  TRICYCLE_STEERING_CONTROLLER__VISIBILITY_PUBLIC void initialize_implementation_parameter_listener()
-    override;
+  TRICYCLE_STEERING_CONTROLLER__VISIBILITY_PUBLIC void
+  initialize_implementation_parameter_listener() override;
 
 protected:
   std::shared_ptr<tricycle_steering_controller::ParamListener> tricycle_param_listener_;

--- a/tricycle_steering_controller/include/tricycle_steering_controller/tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/include/tricycle_steering_controller/tricycle_steering_controller.hpp
@@ -45,13 +45,13 @@ class TricycleSteeringController : public steering_controllers_library::Steering
 public:
   TricycleSteeringController();
 
-  STEERING_CONTROLLERS__VISIBILITY_PUBLIC controller_interface::CallbackReturn configure_odometry()
+  TRICYCLE_STEERING_CONTROLLER__VISIBILITY_PUBLIC controller_interface::CallbackReturn configure_odometry()
     override;
 
-  STEERING_CONTROLLERS__VISIBILITY_PUBLIC bool update_odometry(
+  TRICYCLE_STEERING_CONTROLLER__VISIBILITY_PUBLIC bool update_odometry(
     const rclcpp::Duration & period) override;
 
-  STEERING_CONTROLLERS__VISIBILITY_PUBLIC void initialize_implementation_parameter_listener()
+  TRICYCLE_STEERING_CONTROLLER__VISIBILITY_PUBLIC void initialize_implementation_parameter_listener()
     override;
 
 protected:


### PR DESCRIPTION
While working on getting the repo to compile on Windows, I noticed some inconsistencies in the use of visibility macros in this repo:
* In some cases, the macro that was defined when building the library was different from the one then.
* In case of `tricycle_steering_controller`, the wrong export macro was used.

For what regards the first point, note that in general there is no need to define anything, it is possible to use the `<libraryName>_EXPORTS` macro automatically defined by CMake, see https://cmake.org/cmake/help/latest/prop_tgt/DEFINE_SYMBOL.html . However, this style of manually defining macros is widespread across ROS, so it is out of scope cleaning this.

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
