### PR TITLE
[CI] Use reviewer lottery from ros2_control_ci

### DIFF
--- a/.github/workflows/reviewer_lottery.yml
+++ b/.github/workflows/reviewer_lottery.yml
@@ -1,15 +1,10 @@
 name: Reviewer lottery
+# pull_request_target takes the same events as pull_request,
+# but it runs on the base branch instead of the head branch.
 on:
   pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && github.actor != 'mergify[bot]'
-    steps:
-    - uses: actions/checkout@v4
-    - uses: uesteibar/reviewer-lottery@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        config: ros-controls/ros2_control_ci/.github/reviewer-lottery.yml
+  assign_reviewers:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-reviewer-lottery.yml@master


### PR DESCRIPTION
Fixes reviewer lottery from #1047, see https://github.com/ros-controls/ros2_control/pull/1402 for more details.