### PR TITLE
Improved tf_prefix based on namespace

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -411,7 +411,15 @@ controller_interface::CallbackReturn DiffDriveController::on_configure(
     }
     else
     {
-      tf_prefix = tf_prefix + "/";
+      // Make sure prefix does not start with '/' and always ends with '/'
+      if (tf_prefix.front() == '/')
+      {
+        tf_prefix.erase(0,1);
+      }
+      if (tf_prefix.back() != '/')
+      {
+        tf_prefix = tf_prefix + "/";
+      }
     }
   }
 


### PR DESCRIPTION
Solves #1048. 

When using robot namespace as `tf_prefix`, it now removes any starting '/' and only adds an ending '/' if not present already. 
Starting with '/' is not common in TF2 and showed compatibility issues with for instance `robot_localization`. 

