### PR TITLE
[JTC] Deprecate `start_with_holding`

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -930,6 +930,14 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
   {
     add_new_trajectory_msg(set_hold_position());
   }
+  else
+  {
+    RCLCPP_WARN(
+      get_node()->get_logger(),
+      "Parameter \"start_with_holding\" is deprecated. "
+      "It will be removed in a future release and start with holding position will be the default "
+      "behavior.");
+  }
   rt_is_holding_.writeFromNonRT(true);
 
   // parse timeout parameter

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -85,7 +85,7 @@ joint_trajectory_controller:
   start_with_holding: {
     type: bool,
     default_value: true,
-    description: "If true, start with holding position after activation. Otherwise, no command will be sent until the first trajectory is received.",
+    description: "(Deprecated) If true, start with holding position after activation. Otherwise, no command will be sent until the first trajectory is received.",
   }
   allow_nonzero_velocity_at_trajectory_end: {
     type: bool,


### PR DESCRIPTION
It was decided not to remove `start_with_holding` in iron/humble, see #839 and #876.
So let's deprecate it.