### PR TITLE
[JTC] Remove action_msg dependency

### DIFF
--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -27,7 +27,6 @@
 #include <thread>
 #include <vector>
 
-#include "action_msgs/msg/goal_status_array.hpp"
 #include "control_msgs/action/detail/follow_joint_trajectory__struct.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "gtest/gtest.h"


### PR DESCRIPTION
We included a message header from action_msgs, but there is no need for that.
:eyes: https://github.com/ros-controls/control_msgs/pull/115