### PR TITLE
Fix pid_controller build on ROS 2 Rolling on Ubuntu 24.04

### DIFF
--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -16,6 +16,7 @@
 
   <build_depend>generate_parameter_library</build_depend>
 
+  <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>
   <depend>hardware_interface</depend>

--- a/bicycle_steering_controller/package.xml
+++ b/bicycle_steering_controller/package.xml
@@ -16,6 +16,7 @@
 
   <build_depend>generate_parameter_library</build_depend>
 
+  <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>
   <depend>hardware_interface</depend>

--- a/pid_controller/package.xml
+++ b/pid_controller/package.xml
@@ -14,6 +14,7 @@
   <build_depend>generate_parameter_library</build_depend>
 
   <depend>angles</depend>
+  <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>control_toolbox</depend>
   <depend>controller_interface</depend>

--- a/pid_controller/src/pid_controller.cpp
+++ b/pid_controller/src/pid_controller.cpp
@@ -26,8 +26,8 @@
 #include "control_msgs/msg/single_dof_state.hpp"
 #include "controller_interface/helpers.hpp"
 
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp/version.h>
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/version.h"
 
 namespace
 {  // utility

--- a/pid_controller/src/pid_controller.cpp
+++ b/pid_controller/src/pid_controller.cpp
@@ -26,6 +26,9 @@
 #include "control_msgs/msg/single_dof_state.hpp"
 #include "controller_interface/helpers.hpp"
 
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/version.h>
+
 namespace
 {  // utility
 

--- a/tricycle_steering_controller/package.xml
+++ b/tricycle_steering_controller/package.xml
@@ -18,6 +18,7 @@
 
   <build_depend>generate_parameter_library</build_depend>
 
+  <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>
   <depend>hardware_interface</depend>


### PR DESCRIPTION
Two things are needed to make this compile:
1.  Make sure to add a package.xml dependency on backward_ros, which is necessary to compile.
2.  Make sure to #include <rclcpp/version.h>, so the correct rclcpp::QoS object is chosen.

With both of these in place, this package compiles cleanly on Ubuntu 24.04.

This should fix the CI build like in https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__pid_controller__ubuntu_noble_amd64__binary/13/console

Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. Don’t be afraid to request reviews from maintainers.
5. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
