### PR TITLE
add missing compiler definitions of RCPPUTILS_VERSION

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+add_compile_definitions(RCPPUTILS_VERSION_MAJOR=${rcpputils_VERSION_MAJOR})
+add_compile_definitions(RCPPUTILS_VERSION_MINOR=${rcpputils_VERSION_MINOR})
 
 generate_parameter_library(ackermann_steering_controller_parameters
   src/ackermann_steering_controller.yaml

--- a/bicycle_steering_controller/CMakeLists.txt
+++ b/bicycle_steering_controller/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+add_compile_definitions(RCPPUTILS_VERSION_MAJOR=${rcpputils_VERSION_MAJOR})
+add_compile_definitions(RCPPUTILS_VERSION_MINOR=${rcpputils_VERSION_MINOR})
 
 generate_parameter_library(bicycle_steering_controller_parameters
   src/bicycle_steering_controller.yaml

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -25,6 +25,8 @@ find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+add_compile_definitions(RCPPUTILS_VERSION_MAJOR=${rcpputils_VERSION_MAJOR})
+add_compile_definitions(RCPPUTILS_VERSION_MINOR=${rcpputils_VERSION_MINOR})
 
 generate_parameter_library(diff_drive_controller_parameters
   src/diff_drive_controller_parameter.yaml

--- a/steering_controllers_library/CMakeLists.txt
+++ b/steering_controllers_library/CMakeLists.txt
@@ -30,6 +30,8 @@ find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+add_compile_definitions(RCPPUTILS_VERSION_MAJOR=${rcpputils_VERSION_MAJOR})
+add_compile_definitions(RCPPUTILS_VERSION_MINOR=${rcpputils_VERSION_MINOR})
 
 generate_parameter_library(steering_controllers_library_parameters
   src/steering_controllers_library.yaml

--- a/tricycle_controller/CMakeLists.txt
+++ b/tricycle_controller/CMakeLists.txt
@@ -29,6 +29,8 @@ find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+add_compile_definitions(RCPPUTILS_VERSION_MAJOR=${rcpputils_VERSION_MAJOR})
+add_compile_definitions(RCPPUTILS_VERSION_MINOR=${rcpputils_VERSION_MINOR})
 
 generate_parameter_library(tricycle_controller_parameters
   src/tricycle_controller_parameter.yaml

--- a/tricycle_steering_controller/CMakeLists.txt
+++ b/tricycle_steering_controller/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+add_compile_definitions(RCPPUTILS_VERSION_MAJOR=${rcpputils_VERSION_MAJOR})
+add_compile_definitions(RCPPUTILS_VERSION_MINOR=${rcpputils_VERSION_MINOR})
 
 generate_parameter_library(tricycle_steering_controller_parameters
   src/tricycle_steering_controller.yaml


### PR DESCRIPTION
Similar to https://github.com/ros-controls/ros2_control/pull/1440, there is a missing compile definition of the `rcpputils` to use the proper non-deprecated namespace of `RollingMeanAccumulator` library starting from Humble, these compile definitions are needed to use the proper version. 

I have opened a PR on `rcpputils` repo also to have the `version.h` header in their library, It's waiting to be merged, once it is merged, we can directly use the `version.h` instead of these compile definitions. 

<details>

```
In file included from /home/user/ros2_control_state_itf_ws/src/ros2_controllers/tricycle_controller/include/tricycle_controller/tricycle_controller.hpp:43,
                 from /home/user/ros2_control_state_itf_ws/src/ros2_controllers/tricycle_controller/src/tricycle_controller.cpp:29:
/home/user/ros2_control_state_itf_ws/src/ros2_controllers/tricycle_controller/include/tricycle_controller/odometry.hpp:57:74: warning: ‘using RollingMeanAccumulator = class rcpputils::RollingMeanAccumulator<double>’ is deprecated: use rcpputils::RollingMeanAccumulator instead [-Wdeprecated-declarations]
   57 |   using RollingMeanAccumulator = rcppmath::RollingMeanAccumulator<double>;
      |                                                                          ^
In file included from /home/user/ros2_control_state_itf_ws/src/ros2_controllers/tricycle_controller/include/tricycle_controller/odometry.hpp:29,
                 from /home/user/ros2_control_state_itf_ws/src/ros2_controllers/tricycle_controller/include/tricycle_controller/tricycle_controller.hpp:43,
                 from /home/user/ros2_control_state_itf_ws/src/ros2_controllers/tricycle_controller/src/tricycle_controller.cpp:29:
/home/user/ros2_control_state_itf_ws/src/rcpputils/include/rcppmath/rolling_mean_accumulator.hpp:27:7: note: declared here
   27 | using RollingMeanAccumulator [[deprecated("use rcpputils::RollingMeanAccumulator instead")]] =
      |       ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/user/ros2_control_state_itf_ws/src/ros2_controllers/tricycle_controller/include/tricycle_controller/odometry.hpp:29,
                 from /home/user/ros2_control_state_itf_ws/src/ros2_controllers/tricycle_controller/include/tricycle_controller/tricycle_controller.hpp:43,
                 from /home/user/ros2_control_state_itf_ws/src/ros2_controllers/tricycle_controller/test/test_tricycle_controller.cpp:33:
/home/user/ros2_control_state_itf_ws/src/rcpputils/include/rcppmath/rolling_mean_accumulator.hpp:20:2: warning: #warning "the rcppmath namespace is deprecated, include rcpputils/rolling_mean_accumulator.hpp instead" [-Wcpp]
   20 | #warning \
```

</details>