### PR TITLE
Use the urdf_ to set the robot_description in admittance controller

### DIFF
--- a/admittance_controller/include/admittance_controller/admittance_rule.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule.hpp
@@ -109,7 +109,8 @@ public:
 
   /// Configure admittance rule memory using number of joints.
   controller_interface::return_type configure(
-    const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node, const size_t num_joint);
+    const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node, const size_t num_joint,
+    const std::string & robot_description);
 
   /// Reset all values back to default
   controller_interface::return_type reset(const size_t num_joints);

--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -20,6 +20,7 @@
 #include "admittance_controller/admittance_rule.hpp"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "rclcpp/duration.hpp"
@@ -33,7 +34,8 @@ constexpr auto NUM_CARTESIAN_DOF = 6;  // (3 translation + 3 rotation)
 
 /// Configure admittance rule memory for num joints and load kinematics interface
 controller_interface::return_type AdmittanceRule::configure(
-  const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node, const size_t num_joints)
+  const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node, const size_t num_joints,
+  const std::string & robot_description)
 {
   num_joints_ = num_joints;
 
@@ -51,7 +53,7 @@ controller_interface::return_type AdmittanceRule::configure(
       kinematics_ = std::unique_ptr<kinematics_interface::KinematicsInterface>(
         kinematics_loader_->createUnmanagedInstance(parameters_.kinematics.plugin_name));
       if (!kinematics_->initialize(
-            node->get_node_parameters_interface(), parameters_.kinematics.tip))
+            node->get_node_parameters_interface(), parameters_.kinematics.tip, robot_description))
       {
         return controller_interface::return_type::ERROR;
       }

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -283,14 +283,10 @@ controller_interface::CallbackReturn AdmittanceController::on_configure(
   force_torque_sensor_ = std::make_unique<semantic_components::ForceTorqueSensor>(
     semantic_components::ForceTorqueSensor(admittance_->parameters_.ft_sensor.name));
 
-  // The AdmittanceRule / kinematics_interface::KinematicsInterfaceKDL requires
-  // the robot_description as a parameter. The controller manager stores the
-  // robot description in the urdf_ variable.
-  get_node()->declare_parameter("robot_description", rclcpp::PARAMETER_STRING);
-  get_node()->set_parameter(rclcpp::Parameter("robot_description", urdf_));
-
   // configure admittance rule
-  if (admittance_->configure(get_node(), num_joints_) == controller_interface::return_type::ERROR)
+  if (
+    admittance_->configure(get_node(), num_joints_, urdf_) ==
+    controller_interface::return_type::ERROR)
   {
     return controller_interface::CallbackReturn::ERROR;
   }

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -283,6 +283,12 @@ controller_interface::CallbackReturn AdmittanceController::on_configure(
   force_torque_sensor_ = std::make_unique<semantic_components::ForceTorqueSensor>(
     semantic_components::ForceTorqueSensor(admittance_->parameters_.ft_sensor.name));
 
+  // The AdmittanceRule / kinematics_interface::KinematicsInterfaceKDL requires
+  // the robot_description as a parameter. The controller manager stores the
+  // robot description in the urdf_ variable.
+  get_node()->declare_parameter("robot_description", rclcpp::PARAMETER_STRING);
+  get_node()->set_parameter(rclcpp::Parameter("robot_description", urdf_));
+
   // configure admittance rule
   if (admittance_->configure(get_node(), num_joints_) == controller_interface::return_type::ERROR)
   {

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -396,6 +396,12 @@ controller_interface::return_type AdmittanceController::update_and_write_command
     return controller_interface::return_type::ERROR;
   }
 
+  if (period.seconds() > 5.0) {
+    RCLCPP_WARN(
+        get_node()->get_logger(), "Large dt, skipping!");
+    return controller_interface::return_type::OK;
+  }
+
   // update input reference from chainable interfaces
   read_state_reference_interfaces(reference_);
 


### PR DESCRIPTION
I'm running ROS2 Iron, building ros2_control and ros2_controllers from their master branches, but the admittance controller was complaining about the lack of the `robot_description` parameter in `kinematics_interface_kdl` (https://github.com/ros-controls/kinematics_interface/blob/master/kinematics_interface_kdl/src/kinematics_interface_kdl.cpp#L34). 

The `controller_manager` now requires that the `robot_description` to not be a parameter, but come from a topic. I'm doing that. However, it seems that the admittance controller is still expecting `robot_description` as a parameter. In this PR, I set the `robot_description` parameter for the admittance controller using the `urdf_` member variable. This feels a little hacky. Am I doing something wrong? Is anyone using the latest admittance controller successfully?

Thanks!