### PR TITLE
[diff_drive] Remove non-existing parameter

### DIFF
--- a/diff_drive_controller/test/config/test_diff_drive_controller.yaml
+++ b/diff_drive_controller/test/config/test_diff_drive_controller.yaml
@@ -4,7 +4,6 @@ test_diff_drive_controller:
     right_wheel_names: ["right_wheels"]
 
     wheel_separation: 0.40
-    wheels_per_side: 1  # actually 2, but both are controlled by 1 signal
     wheel_radius: 0.02
 
     wheel_separation_multiplier: 1.0


### PR DESCRIPTION
I removed the unused wheels_per_side parameter with #958 but forgot to remove it from the test-yaml printed into the docs.