### PR TITLE
Add parameter check for geometric values

### DIFF
--- a/ackermann_steering_controller/src/ackermann_steering_controller.yaml
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.yaml
@@ -5,6 +5,9 @@ ackermann_steering_controller:
       default_value: 0.0,
       description: "Front wheel track length. For details see: https://en.wikipedia.org/wiki/Wheelbase",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }
 
   rear_wheel_track:
@@ -13,6 +16,9 @@ ackermann_steering_controller:
       default_value: 0.0,
       description: "Rear wheel track length. For details see: https://en.wikipedia.org/wiki/Wheelbase",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }
 
   wheelbase:
@@ -21,6 +27,9 @@ ackermann_steering_controller:
       default_value: 0.0,
       description: "Distance between front and rear wheels. For details see: https://en.wikipedia.org/wiki/Wheelbase",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }
 
   front_wheels_radius:
@@ -29,6 +38,9 @@ ackermann_steering_controller:
       default_value: 0.0,
       description: "Front wheels radius.",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }
 
   rear_wheels_radius:
@@ -37,4 +49,7 @@ ackermann_steering_controller:
       default_value: 0.0,
       description: "Rear wheels radius.",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }

--- a/bicycle_steering_controller/src/bicycle_steering_controller.yaml
+++ b/bicycle_steering_controller/src/bicycle_steering_controller.yaml
@@ -5,6 +5,9 @@ bicycle_steering_controller:
       default_value: 0.0,
       description: "Distance between front and rear wheel. For details see: https://en.wikipedia.org/wiki/Wheelbase",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }
 
   front_wheel_radius:
@@ -13,6 +16,9 @@ bicycle_steering_controller:
       default_value: 0.0,
       description: "Front wheel radius.",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }
 
   rear_wheel_radius:
@@ -21,4 +27,7 @@ bicycle_steering_controller:
       default_value: 0.0,
       description: "Rear wheel radius.",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }

--- a/diff_drive_controller/src/diff_drive_controller_parameter.yaml
+++ b/diff_drive_controller/src/diff_drive_controller_parameter.yaml
@@ -19,11 +19,17 @@ diff_drive_controller:
     type: double,
     default_value: 0.0,
     description: "Shortest distance between the left and right wheels. If this parameter is wrong, the robot will not behave correctly in curves.",
+    validation: {
+      gt<>: [0.0]
+    }
   }
   wheel_radius: {
     type: double,
     default_value: 0.0,
     description: "Radius of a wheel, i.e., wheels size, used for transformation of linear velocity into wheel rotations. If this parameter is wrong the robot will move faster or slower then expected.",
+    validation: {
+      gt<>: [0.0]
+    }
   }
   wheel_separation_multiplier: {
     type: double,

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -186,8 +186,8 @@ protected:
       rclcpp::Parameter("right_wheel_names", rclcpp::ParameterValue(right_wheel_joints_init)));
     // default parameters
     parameter_overrides.push_back(
-      rclcpp::Parameter("wheel_separation", rclcpp::ParameterValue(0.4)));
-    parameter_overrides.push_back(rclcpp::Parameter("wheel_radius", rclcpp::ParameterValue(0.02)));
+      rclcpp::Parameter("wheel_separation", rclcpp::ParameterValue(1.0)));
+    parameter_overrides.push_back(rclcpp::Parameter("wheel_radius", rclcpp::ParameterValue(0.1)));
 
     parameter_overrides.insert(parameter_overrides.end(), parameters.begin(), parameters.end());
     node_options.parameter_overrides(parameter_overrides);

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -184,6 +184,10 @@ protected:
       rclcpp::Parameter("left_wheel_names", rclcpp::ParameterValue(left_wheel_joints_init)));
     parameter_overrides.push_back(
       rclcpp::Parameter("right_wheel_names", rclcpp::ParameterValue(right_wheel_joints_init)));
+    // default parameters
+    parameter_overrides.push_back(
+      rclcpp::Parameter("wheel_separation", rclcpp::ParameterValue(0.4)));
+    parameter_overrides.push_back(rclcpp::Parameter("wheel_radius", rclcpp::ParameterValue(0.02)));
 
     parameter_overrides.insert(parameter_overrides.end(), parameters.begin(), parameters.end());
     node_options.parameter_overrides(parameter_overrides);

--- a/tricycle_controller/src/tricycle_controller_parameter.yaml
+++ b/tricycle_controller/src/tricycle_controller_parameter.yaml
@@ -19,11 +19,17 @@ tricycle_controller:
     type: double,
     default_value: 0.0,
     description: "Shortest distance between the front wheel and the rear axle. If this parameter is wrong, the robot will not behave correctly in curves.",
+    validation: {
+      gt<>: [0.0]
+    }
   }
   wheel_radius: {
     type: double,
     default_value: 0.0,
     description: "Radius of a wheel, i.e., wheels size, used for transformation of linear velocity into wheel rotations. If this parameter is wrong the robot will move faster or slower then expected.",
+    validation: {
+      gt<>: [0.0]
+    }
   }
   odom_frame_id: {
     type: string,

--- a/tricycle_controller/test/test_tricycle_controller.cpp
+++ b/tricycle_controller/test/test_tricycle_controller.cpp
@@ -164,6 +164,9 @@ protected:
       rclcpp::Parameter("traction_joint_name", rclcpp::ParameterValue(traction_joint_name_init)));
     parameter_overrides.push_back(
       rclcpp::Parameter("steering_joint_name", rclcpp::ParameterValue(steering_joint_name_init)));
+    // default parameters
+    parameter_overrides.push_back(rclcpp::Parameter("wheelbase", rclcpp::ParameterValue(1.)));
+    parameter_overrides.push_back(rclcpp::Parameter("wheel_radius", rclcpp::ParameterValue(0.1)));
 
     parameter_overrides.insert(parameter_overrides.end(), parameters.begin(), parameters.end());
     node_options.parameter_overrides(parameter_overrides);

--- a/tricycle_steering_controller/src/tricycle_steering_controller.yaml
+++ b/tricycle_steering_controller/src/tricycle_steering_controller.yaml
@@ -5,6 +5,9 @@ tricycle_steering_controller:
       default_value: 0.0,
       description: "Wheel track length. For details see: https://en.wikipedia.org/wiki/Wheelbase",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }
 
   wheelbase:
@@ -13,6 +16,9 @@ tricycle_steering_controller:
       default_value: 0.0,
       description: "Distance between front and rear wheels. For details see: https://en.wikipedia.org/wiki/Wheelbase",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }
 
   front_wheels_radius:
@@ -21,6 +27,9 @@ tricycle_steering_controller:
       default_value: 0.0,
       description: "Front wheels radius.",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }
 
   rear_wheels_radius:
@@ -29,4 +38,7 @@ tricycle_steering_controller:
       default_value: 0.0,
       description: "Rear wheels radius.",
       read_only: false,
+      validation: {
+        gt<>: [0.0]
+      }
     }


### PR DESCRIPTION
Inspired by [this post at RSE](https://robotics.stackexchange.com/a/111066/33182), I thought it could be a good idea to add simple checks to geometric values of the controllers for mobile robots. For example, `wheel_radius` `wheel_base` and others must not be zero :arrow_right: I added a `gt<>: [0.0]` validator for them. This also should help if a user misspelled or forgot these parameters.