### PR TITLE
Fix steering controllers library code documentation and naming

### DIFF
--- a/ackermann_steering_controller/src/ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.cpp
@@ -66,25 +66,25 @@ bool AckermannSteeringController::update_odometry(const rclcpp::Duration & perio
       state_interfaces_[STATE_TRACTION_RIGHT_WHEEL].get_value();
     const double traction_left_wheel_value =
       state_interfaces_[STATE_TRACTION_LEFT_WHEEL].get_value();
-    const double right_steer_position = state_interfaces_[STATE_STEER_RIGHT_WHEEL].get_value();
-    const double left_steer_position = state_interfaces_[STATE_STEER_LEFT_WHEEL].get_value();
+    const double steering_right_position = state_interfaces_[STATE_STEER_RIGHT_WHEEL].get_value();
+    const double steering_left_position = state_interfaces_[STATE_STEER_LEFT_WHEEL].get_value();
     if (
       std::isfinite(traction_right_wheel_value) && std::isfinite(traction_left_wheel_value) &&
-      std::isfinite(right_steer_position) && std::isfinite(left_steer_position))
+      std::isfinite(steering_right_position) && std::isfinite(steering_left_position))
     {
       if (params_.position_feedback)
       {
         // Estimate linear and angular velocity using joint information
         odometry_.update_from_position(
-          traction_right_wheel_value, traction_left_wheel_value, right_steer_position,
-          left_steer_position, period.seconds());
+          traction_right_wheel_value, traction_left_wheel_value, steering_right_position,
+          steering_left_position, period.seconds());
       }
       else
       {
         // Estimate linear and angular velocity using joint information
         odometry_.update_from_velocity(
-          traction_right_wheel_value, traction_left_wheel_value, right_steer_position,
-          left_steer_position, period.seconds());
+          traction_right_wheel_value, traction_left_wheel_value, steering_right_position,
+          steering_left_position, period.seconds());
       }
     }
   }

--- a/ackermann_steering_controller/src/ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.cpp
@@ -62,28 +62,29 @@ bool AckermannSteeringController::update_odometry(const rclcpp::Duration & perio
   }
   else
   {
-    const double rear_right_wheel_value = state_interfaces_[STATE_TRACTION_RIGHT_WHEEL].get_value();
-    const double rear_left_wheel_value = state_interfaces_[STATE_TRACTION_LEFT_WHEEL].get_value();
-    const double front_right_steer_position =
-      state_interfaces_[STATE_STEER_RIGHT_WHEEL].get_value();
-    const double front_left_steer_position = state_interfaces_[STATE_STEER_LEFT_WHEEL].get_value();
+    const double traction_right_wheel_value =
+      state_interfaces_[STATE_TRACTION_RIGHT_WHEEL].get_value();
+    const double traction_left_wheel_value =
+      state_interfaces_[STATE_TRACTION_LEFT_WHEEL].get_value();
+    const double right_steer_position = state_interfaces_[STATE_STEER_RIGHT_WHEEL].get_value();
+    const double left_steer_position = state_interfaces_[STATE_STEER_LEFT_WHEEL].get_value();
     if (
-      !std::isnan(rear_right_wheel_value) && !std::isnan(rear_left_wheel_value) &&
-      !std::isnan(front_right_steer_position) && !std::isnan(front_left_steer_position))
+      !std::isnan(traction_right_wheel_value) && !std::isnan(traction_left_wheel_value) &&
+      !std::isnan(right_steer_position) && !std::isnan(left_steer_position))
     {
       if (params_.position_feedback)
       {
         // Estimate linear and angular velocity using joint information
         odometry_.update_from_position(
-          rear_right_wheel_value, rear_left_wheel_value, front_right_steer_position,
-          front_left_steer_position, period.seconds());
+          traction_right_wheel_value, traction_left_wheel_value, right_steer_position,
+          left_steer_position, period.seconds());
       }
       else
       {
         // Estimate linear and angular velocity using joint information
         odometry_.update_from_velocity(
-          rear_right_wheel_value, rear_left_wheel_value, front_right_steer_position,
-          front_left_steer_position, period.seconds());
+          traction_right_wheel_value, traction_left_wheel_value, right_steer_position,
+          left_steer_position, period.seconds());
       }
     }
   }

--- a/ackermann_steering_controller/src/ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.cpp
@@ -69,8 +69,8 @@ bool AckermannSteeringController::update_odometry(const rclcpp::Duration & perio
     const double right_steer_position = state_interfaces_[STATE_STEER_RIGHT_WHEEL].get_value();
     const double left_steer_position = state_interfaces_[STATE_STEER_LEFT_WHEEL].get_value();
     if (
-      !std::isnan(traction_right_wheel_value) && !std::isnan(traction_left_wheel_value) &&
-      !std::isnan(right_steer_position) && !std::isnan(left_steer_position))
+      std::isfinite(traction_right_wheel_value) && std::isfinite(traction_left_wheel_value) &&
+      std::isfinite(right_steer_position) && std::isfinite(left_steer_position))
     {
       if (params_.position_feedback)
       {

--- a/bicycle_steering_controller/src/bicycle_steering_controller.cpp
+++ b/bicycle_steering_controller/src/bicycle_steering_controller.cpp
@@ -60,19 +60,19 @@ bool BicycleSteeringController::update_odometry(const rclcpp::Duration & period)
   }
   else
   {
-    const double rear_wheel_value = state_interfaces_[STATE_TRACTION_WHEEL].get_value();
+    const double traction_wheel_value = state_interfaces_[STATE_TRACTION_WHEEL].get_value();
     const double steer_position = state_interfaces_[STATE_STEER_AXIS].get_value();
-    if (!std::isnan(rear_wheel_value) && !std::isnan(steer_position))
+    if (!std::isnan(traction_wheel_value) && !std::isnan(steer_position))
     {
       if (params_.position_feedback)
       {
         // Estimate linear and angular velocity using joint information
-        odometry_.update_from_position(rear_wheel_value, steer_position, period.seconds());
+        odometry_.update_from_position(traction_wheel_value, steer_position, period.seconds());
       }
       else
       {
         // Estimate linear and angular velocity using joint information
-        odometry_.update_from_velocity(rear_wheel_value, steer_position, period.seconds());
+        odometry_.update_from_velocity(traction_wheel_value, steer_position, period.seconds());
       }
     }
   }

--- a/bicycle_steering_controller/src/bicycle_steering_controller.cpp
+++ b/bicycle_steering_controller/src/bicycle_steering_controller.cpp
@@ -62,7 +62,7 @@ bool BicycleSteeringController::update_odometry(const rclcpp::Duration & period)
   {
     const double traction_wheel_value = state_interfaces_[STATE_TRACTION_WHEEL].get_value();
     const double steer_position = state_interfaces_[STATE_STEER_AXIS].get_value();
-    if (!std::isnan(traction_wheel_value) && !std::isnan(steer_position))
+    if (std::isfinite(traction_wheel_value) && std::isfinite(steer_position))
     {
       if (params_.position_feedback)
       {

--- a/bicycle_steering_controller/src/bicycle_steering_controller.cpp
+++ b/bicycle_steering_controller/src/bicycle_steering_controller.cpp
@@ -61,18 +61,18 @@ bool BicycleSteeringController::update_odometry(const rclcpp::Duration & period)
   else
   {
     const double traction_wheel_value = state_interfaces_[STATE_TRACTION_WHEEL].get_value();
-    const double steer_position = state_interfaces_[STATE_STEER_AXIS].get_value();
-    if (std::isfinite(traction_wheel_value) && std::isfinite(steer_position))
+    const double steering_position = state_interfaces_[STATE_STEER_AXIS].get_value();
+    if (std::isfinite(traction_wheel_value) && std::isfinite(steering_position))
     {
       if (params_.position_feedback)
       {
         // Estimate linear and angular velocity using joint information
-        odometry_.update_from_position(traction_wheel_value, steer_position, period.seconds());
+        odometry_.update_from_position(traction_wheel_value, steering_position, period.seconds());
       }
       else
       {
         // Estimate linear and angular velocity using joint information
-        odometry_.update_from_velocity(traction_wheel_value, steer_position, period.seconds());
+        odometry_.update_from_velocity(traction_wheel_value, steering_position, period.seconds());
       }
     }
   }

--- a/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
@@ -130,11 +130,11 @@ public:
 
   /**
    * \brief Updates the odometry class with latest velocity command
-   * \param linear  Linear velocity [m/s]
-   * \param angular Angular velocity [rad/s]
+   * \param v_bx  Linear velocity   [m/s]
+   * \param omega_bz Angular velocity [rad/s]
    * \param dt      time difference to last call
    */
-  void update_open_loop(const double linear, const double angular, const double dt);
+  void update_open_loop(const double v_bx, const double omega_bz, const double dt);
 
   /**
    * \brief Set odometry type
@@ -186,8 +186,8 @@ public:
 
   /**
    * \brief Calculates inverse kinematics for the desired linear and angular velocities
-   * \param v_bx     Linear velocity of the robot in x_b-axis direction
-   * \param omega_bz Angular velocity of the robot around x_z-axis
+   * \param v_bx     Desired linear velocity of the robot in x_b-axis direction
+   * \param omega_bz Desired angular velocity of the robot around x_z-axis
    * \return Tuple of velocity commands and steering commands
    */
   std::tuple<std::vector<double>, std::vector<double>> get_commands(

--- a/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
@@ -208,32 +208,18 @@ private:
   bool update_odometry(const double v_bx, const double omega_bz, const double dt);
 
   /**
-   * \brief Integrates the displacements (linear and angular) using 2nd order Runge-Kutta
-   * \param v_bx  Linear displacement [m], i.e. m/s * dt computed by encoders
-   * \param omega_bz Angular displaycement [rad], i.e. m/s * dt computed by encoders
-   */
-  void integrate_runge_kutta_2(const double v_bx, const double omega_bz);
-
-  /**
    * \brief Integrates the velocities (linear and angular) using 2nd order Runge-Kutta
-   * \param v_bx  Linear velocity [m/s]
+   * \param v_bx Linear velocity [m/s]
    * \param omega_bz Angular velocity [rad/s]
-   * \param dt      time difference to last call
+   * \param dt time difference to last call
    */
   void integrate_runge_kutta_2(const double v_bx, const double omega_bz, const double dt);
 
   /**
-   * \brief Integrates the discplacements (linear and angular) using exact method
-   * \param v_bx  Linear displacement [m], i.e. m/s * dt computed by encoders
-   * \param omega_bz Angular displaycement [rad], i.e. m/s * dt computed by encoders
-   */
-  void integrate_exact(const double v_bx, const double omega_bz);
-
-  /**
    * \brief Integrates the velocities (linear and angular) using exact method
-   * \param v_bx  Linear velocity [m/s]
+   * \param v_bx Linear velocity [m/s]
    * \param omega_bz Angular velocity [rad/s]
-   * \param dt      time difference to last call
+   * \param dt time difference to last call
    */
   void integrate_exact(const double v_bx, const double omega_bz, const double dt);
 

--- a/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
@@ -61,7 +61,7 @@ public:
   /**
    * \brief Updates the odometry class with latest wheels position
    * \param traction_wheel_pos  traction wheel position [rad]
-   * \param steer_pos Front Steer position [rad]
+   * \param steer_pos Steer wheel position [rad]
    * \param dt      time difference to last call
    * \return true if the odometry is actually updated
    */
@@ -72,7 +72,7 @@ public:
    * \brief Updates the odometry class with latest wheels position
    * \param right_traction_wheel_pos  Right traction wheel velocity [rad]
    * \param left_traction_wheel_pos  Left traction wheel velocity [rad]
-   * \param front_steer_pos Steer wheel position [rad]
+   * \param steer_pos Steer wheel position [rad]
    * \param dt      time difference to last call
    * \return true if the odometry is actually updated
    */
@@ -96,7 +96,7 @@ public:
   /**
    * \brief Updates the odometry class with latest wheels position
    * \param traction_wheel_vel  Traction wheel velocity [rad/s]
-   * \param front_steer_pos Steer wheel position [rad]
+   * \param steer_pos Steer wheel position [rad]
    * \param dt      time difference to last call
    * \return true if the odometry is actually updated
    */
@@ -107,7 +107,7 @@ public:
    * \brief Updates the odometry class with latest wheels position
    * \param right_traction_wheel_vel  Right traction wheel velocity [rad/s]
    * \param left_traction_wheel_vel  Left traction wheel velocity [rad/s]
-   * \param front_steer_pos Steer wheel position [rad]
+   * \param steer_pos Steer wheel position [rad]
    * \param dt      time difference to last call
    * \return true if the odometry is actually updated
    */

--- a/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
@@ -216,12 +216,12 @@ private:
   void integrate_runge_kutta_2(const double v_bx, const double omega_bz, const double dt);
 
   /**
-   * \brief Integrates the velocities (linear and angular) using exact method
+   * \brief Integrates the velocities (linear and angular)
    * \param v_bx Linear velocity [m/s]
    * \param omega_bz Angular velocity [rad/s]
    * \param dt time difference to last call
    */
-  void integrate_exact(const double v_bx, const double omega_bz, const double dt);
+  void integrate(const double v_bx, const double omega_bz, const double dt);
 
   /**
    * \brief Calculates steering angle from the desired translational and rotational velocity

--- a/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
@@ -221,7 +221,7 @@ private:
    * \param omega_bz Angular velocity [rad/s]
    * \param dt time difference to last call
    */
-  void integrate(const double v_bx, const double omega_bz, const double dt);
+  void integrate_fk(const double v_bx, const double omega_bz, const double dt);
 
   /**
    * \brief Calculates steering angle from the desired translational and rotational velocity

--- a/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
@@ -224,11 +224,11 @@ private:
   void integrate_fk(const double v_bx, const double omega_bz, const double dt);
 
   /**
-   * \brief Calculates steering angle from the desired translational and rotational velocity
+   * \brief Calculates steering angle from the desired twist
    * \param v_bx     Linear velocity of the robot in x_b-axis direction
    * \param omega_bz Angular velocity of the robot around x_z-axis
    */
-  double convert_trans_rot_vel_to_steering_angle(const double v_bx, const double omega_bz);
+  double convert_twist_to_steering_angle(const double v_bx, const double omega_bz);
 
   /**
    *  \brief Reset linear and angular accumulators

--- a/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
@@ -132,7 +132,7 @@ public:
    * \brief Updates the odometry class with latest velocity command
    * \param linear  Linear velocity [m/s]
    * \param angular Angular velocity [rad/s]
-   * \param time    Current time
+   * \param dt      time difference to last call
    */
   void update_open_loop(const double linear, const double angular, const double dt);
 
@@ -175,22 +175,23 @@ public:
   /**
    * \brief Sets the wheel parameters: radius, separation and wheelbase
    */
-  void set_wheel_params(double wheel_radius, double wheelbase = 0.0, double wheel_track = 0.0);
+  void set_wheel_params(
+    const double wheel_radius, const double wheelbase = 0.0, const double wheel_track = 0.0);
 
   /**
    * \brief Velocity rolling window size setter
    * \param velocity_rolling_window_size Velocity rolling window size
    */
-  void set_velocity_rolling_window_size(size_t velocity_rolling_window_size);
+  void set_velocity_rolling_window_size(const size_t velocity_rolling_window_size);
 
   /**
    * \brief Calculates inverse kinematics for the desired linear and angular velocities
-   * \param Vx  Desired linear velocity [m/s]
-   * \param theta_dot Desired angular velocity [rad/s]
+   * \param v_bx     Linear velocity of the robot in x_b-axis direction
+   * \param omega_bz Angular velocity of the robot around x_z-axis
    * \return Tuple of velocity commands and steering commands
    */
   std::tuple<std::vector<double>, std::vector<double>> get_commands(
-    const double Vx, const double theta_dot);
+    const double v_bx, const double omega_bz);
 
   /**
    *  \brief Reset poses, heading, and accumulators
@@ -199,35 +200,49 @@ public:
 
 private:
   /**
-   * \brief Uses precomputed linear and angular velocities to compute dometry and update
-   * accumulators \param linear  Linear  velocity   [m] (linear  displacement, i.e. m/s * dt)
-   * computed by previous odometry method \param angular Angular velocity [rad] (angular
-   * displacement, i.e. m/s * dt) computed by previous odometry method
+   * \brief Uses precomputed linear and angular velocities to compute odometry
+   * \param v_bx  Linear  velocity   [m/s]
+   * \param omega_bz Angular velocity [rad/s]
+   * \param dt      time difference to last call
    */
-  bool update_odometry(const double linear_velocity, const double angular, const double dt);
+  bool update_odometry(const double v_bx, const double omega_bz, const double dt);
+
+  /**
+   * \brief Integrates the displacements (linear and angular) using 2nd order Runge-Kutta
+   * \param v_bx  Linear displacement [m], i.e. m/s * dt computed by encoders
+   * \param omega_bz Angular displaycement [rad], i.e. m/s * dt computed by encoders
+   */
+  void integrate_runge_kutta_2(const double v_bx, const double omega_bz);
 
   /**
    * \brief Integrates the velocities (linear and angular) using 2nd order Runge-Kutta
-   * \param linear  Linear  velocity   [m] (linear  displacement, i.e. m/s * dt) computed by
-   * encoders \param angular Angular velocity [rad] (angular displacement, i.e. m/s * dt) computed
-   * by encoders
+   * \param v_bx  Linear velocity [m/s]
+   * \param omega_bz Angular velocity [rad/s]
+   * \param dt      time difference to last call
    */
-  void integrate_runge_kutta_2(double linear, double angular);
+  void integrate_runge_kutta_2(const double v_bx, const double omega_bz, const double dt);
+
+  /**
+   * \brief Integrates the discplacements (linear and angular) using exact method
+   * \param v_bx  Linear displacement [m], i.e. m/s * dt computed by encoders
+   * \param omega_bz Angular displaycement [rad], i.e. m/s * dt computed by encoders
+   */
+  void integrate_exact(const double v_bx, const double omega_bz);
 
   /**
    * \brief Integrates the velocities (linear and angular) using exact method
-   * \param linear  Linear  velocity   [m] (linear  displacement, i.e. m/s * dt) computed by
-   * encoders \param angular Angular velocity [rad] (angular displacement, i.e. m/s * dt) computed
-   * by encoders
+   * \param v_bx  Linear velocity [m/s]
+   * \param omega_bz Angular velocity [rad/s]
+   * \param dt      time difference to last call
    */
-  void integrate_exact(double linear, double angular);
+  void integrate_exact(const double v_bx, const double omega_bz, const double dt);
 
   /**
    * \brief Calculates steering angle from the desired translational and rotational velocity
-   * \param Vx   Linear  velocity   [m]
-   * \param theta_dot Angular velocity [rad]
+   * \param v_bx     Linear velocity of the robot in x_b-axis direction
+   * \param omega_bz Angular velocity of the robot around x_z-axis
    */
-  double convert_trans_rot_vel_to_steering_angle(double Vx, double theta_dot);
+  double convert_trans_rot_vel_to_steering_angle(const double v_bx, const double omega_bz);
 
   /**
    *  \brief Reset linear and angular accumulators

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -174,14 +174,14 @@ bool SteeringOdometry::update_from_velocity(
   return update_odometry(linear_velocity, angular_velocity, dt);
 }
 
-void SteeringOdometry::update_open_loop(const double linear, const double angular, const double dt)
+void SteeringOdometry::update_open_loop(const double v_bx, const double omega_bz, const double dt)
 {
   /// Save last linear and angular velocity:
-  linear_ = linear;
-  angular_ = angular;
+  linear_ = v_bx;
+  angular_ = omega_bz;
 
   /// Integrate odometry:
-  integrate_fk(linear, angular, dt);
+  integrate_fk(v_bx, omega_bz, dt);
 }
 
 void SteeringOdometry::set_wheel_params(double wheel_radius, double wheelbase, double wheel_track)

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -51,7 +51,7 @@ void SteeringOdometry::init(const rclcpp::Time & time)
 bool SteeringOdometry::update_odometry(const double linear, const double angular, const double dt)
 {
   /// Integrate odometry:
-  integrate_exact(linear, angular, dt);
+  integrate(linear, angular, dt);
 
   /// We cannot estimate the speed with very small time intervals:
   if (dt < 0.0001)
@@ -180,7 +180,7 @@ void SteeringOdometry::update_open_loop(const double linear, const double angula
   angular_ = angular;
 
   /// Integrate odometry:
-  integrate_exact(linear, angular, dt);
+  integrate(linear, angular, dt);
 }
 
 void SteeringOdometry::set_wheel_params(double wheel_radius, double wheelbase, double wheel_track)
@@ -302,7 +302,7 @@ void SteeringOdometry::integrate_runge_kutta_2(
   heading_ += omega_bz * dt;
 }
 
-void SteeringOdometry::integrate_exact(const double v_bx, const double omega_bz, const double dt)
+void SteeringOdometry::integrate(const double v_bx, const double omega_bz, const double dt)
 {
   const double delta_x_b = v_bx * dt;
   const double delta_Theta = omega_bz * dt;

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -35,6 +35,8 @@ SteeringOdometry::SteeringOdometry(size_t velocity_rolling_window_size)
   wheelbase_(0.0),
   wheel_radius_(0.0),
   traction_wheel_old_pos_(0.0),
+  traction_right_wheel_old_pos_(0.0),
+  traction_left_wheel_old_pos_(0.0),
   velocity_rolling_window_size_(velocity_rolling_window_size),
   linear_acc_(velocity_rolling_window_size),
   angular_acc_(velocity_rolling_window_size)

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -243,9 +243,9 @@ std::tuple<std::vector<double>, std::vector<double>> SteeringOdometry::get_comma
     }
     else
     {
-      double turning_radius = wheelbase_ / std::tan(steer_pos_);
-      double Wr = Ws * (turning_radius + wheel_track_ * 0.5) / turning_radius;
-      double Wl = Ws * (turning_radius - wheel_track_ * 0.5) / turning_radius;
+      const double turning_radius = wheelbase_ / std::tan(steer_pos_);
+      const double Wr = Ws * (turning_radius + wheel_track_ * 0.5) / turning_radius;
+      const double Wl = Ws * (turning_radius - wheel_track_ * 0.5) / turning_radius;
       traction_commands = {Wr, Wl};
     }
     steering_commands = {phi};
@@ -262,17 +262,19 @@ std::tuple<std::vector<double>, std::vector<double>> SteeringOdometry::get_comma
     }
     else
     {
-      double turning_radius = wheelbase_ / std::tan(steer_pos_);
-      double Wr = Ws * (turning_radius + wheel_track_ * 0.5) / turning_radius;
-      double Wl = Ws * (turning_radius - wheel_track_ * 0.5) / turning_radius;
+      const double turning_radius = wheelbase_ / std::tan(steer_pos_);
+      const double Wr = Ws * (turning_radius + wheel_track_ * 0.5) / turning_radius;
+      const double Wl = Ws * (turning_radius - wheel_track_ * 0.5) / turning_radius;
       traction_commands = {Wr, Wl};
 
-      double numerator = 2 * wheelbase_ * std::sin(phi);
-      double denominator_first_member = 2 * wheelbase_ * std::cos(phi);
-      double denominator_second_member = wheel_track_ * std::sin(phi);
+      const double numerator = 2 * wheelbase_ * std::sin(phi);
+      const double denominator_first_member = 2 * wheelbase_ * std::cos(phi);
+      const double denominator_second_member = wheel_track_ * std::sin(phi);
 
-      double alpha_r = std::atan2(numerator, denominator_first_member + denominator_second_member);
-      double alpha_l = std::atan2(numerator, denominator_first_member - denominator_second_member);
+      const double alpha_r =
+        std::atan2(numerator, denominator_first_member + denominator_second_member);
+      const double alpha_l =
+        std::atan2(numerator, denominator_first_member - denominator_second_member);
       steering_commands = {alpha_r, alpha_l};
     }
     return std::make_tuple(traction_commands, steering_commands);

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -48,10 +48,11 @@ void SteeringOdometry::init(const rclcpp::Time & time)
   timestamp_ = time;
 }
 
-bool SteeringOdometry::update_odometry(const double linear, const double angular, const double dt)
+bool SteeringOdometry::update_odometry(
+  const double linear_velocity, const double angular_velocity, const double dt)
 {
   /// Integrate odometry:
-  integrate(linear, angular, dt);
+  integrate_fk(linear_velocity, angular_velocity, dt);
 
   /// We cannot estimate the speed with very small time intervals:
   if (dt < 0.0001)
@@ -60,8 +61,8 @@ bool SteeringOdometry::update_odometry(const double linear, const double angular
   }
 
   /// Estimate speeds using a rolling mean to filter them out:
-  linear_acc_.accumulate(linear);
-  angular_acc_.accumulate(angular);
+  linear_acc_.accumulate(linear_velocity);
+  angular_acc_.accumulate(angular_velocity);
 
   linear_ = linear_acc_.getRollingMean();
   angular_ = angular_acc_.getRollingMean();
@@ -180,7 +181,7 @@ void SteeringOdometry::update_open_loop(const double linear, const double angula
   angular_ = angular;
 
   /// Integrate odometry:
-  integrate(linear, angular, dt);
+  integrate_fk(linear, angular, dt);
 }
 
 void SteeringOdometry::set_wheel_params(double wheel_radius, double wheelbase, double wheel_track)
@@ -302,7 +303,7 @@ void SteeringOdometry::integrate_runge_kutta_2(
   heading_ += omega_bz * dt;
 }
 
-void SteeringOdometry::integrate(const double v_bx, const double omega_bz, const double dt)
+void SteeringOdometry::integrate_fk(const double v_bx, const double omega_bz, const double dt)
 {
   const double delta_x_b = v_bx * dt;
   const double delta_Theta = omega_bz * dt;

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -200,7 +200,7 @@ void SteeringOdometry::set_velocity_rolling_window_size(size_t velocity_rolling_
 
 void SteeringOdometry::set_odometry_type(const unsigned int type) { config_type_ = type; }
 
-double SteeringOdometry::convert_trans_rot_vel_to_steering_angle(double v_bx, double omega_bz)
+double SteeringOdometry::convert_twist_to_steering_angle(double v_bx, double omega_bz)
 {
   if (omega_bz == 0 || v_bx == 0)
   {
@@ -223,7 +223,7 @@ std::tuple<std::vector<double>, std::vector<double>> SteeringOdometry::get_comma
   }
   else
   {
-    phi = SteeringOdometry::convert_trans_rot_vel_to_steering_angle(v_bx, omega_bz);
+    phi = SteeringOdometry::convert_twist_to_steering_angle(v_bx, omega_bz);
     Ws = v_bx / (wheel_radius_ * std::cos(steer_pos_));
   }
 

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -295,20 +295,20 @@ void SteeringOdometry::integrate_runge_kutta_2(
   const double v_bx, const double omega_bz, const double dt)
 {
   // Compute intermediate value of the heading
-  const double Theta_mid = heading_ + omega_bz * 0.5 * dt;
+  const double theta_mid = heading_ + omega_bz * 0.5 * dt;
 
   // Use the intermediate values to update the state
-  x_ += v_bx * cos(Theta_mid) * dt;
-  y_ += v_bx * sin(Theta_mid) * dt;
+  x_ += v_bx * cos(theta_mid) * dt;
+  y_ += v_bx * sin(theta_mid) * dt;
   heading_ += omega_bz * dt;
 }
 
 void SteeringOdometry::integrate_fk(const double v_bx, const double omega_bz, const double dt)
 {
   const double delta_x_b = v_bx * dt;
-  const double delta_Theta = omega_bz * dt;
+  const double delta_theta = omega_bz * dt;
 
-  if (fabs(delta_Theta) < 1e-6)
+  if (fabs(delta_theta) < 1e-6)
   {
     /// Runge-Kutta 2nd Order (should solve problems when omega_bz is zero):
     integrate_runge_kutta_2(v_bx, omega_bz, dt);
@@ -317,8 +317,8 @@ void SteeringOdometry::integrate_fk(const double v_bx, const double omega_bz, co
   {
     /// Exact integration
     const double heading_old = heading_;
-    const double R = delta_x_b / delta_Theta;
-    heading_ += delta_Theta;
+    const double R = delta_x_b / delta_theta;
+    heading_ += delta_theta;
     x_ += R * (sin(heading_) - sin(heading_old));
     y_ += -R * (cos(heading_) - cos(heading_old));
   }

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -73,70 +73,47 @@ bool SteeringOdometry::update_odometry(
 bool SteeringOdometry::update_from_position(
   const double traction_wheel_pos, const double steer_pos, const double dt)
 {
-  /// Get current wheel joint positions:
-  const double traction_wheel_cur_pos = traction_wheel_pos * wheel_radius_;
-  const double traction_wheel_est_pos_diff = traction_wheel_cur_pos - traction_wheel_old_pos_;
+  const double traction_wheel_est_pos_diff = traction_wheel_pos - traction_wheel_old_pos_;
 
   /// Update old position with current:
-  traction_wheel_old_pos_ = traction_wheel_cur_pos;
+  traction_wheel_old_pos_ = traction_wheel_pos;
 
-  /// Compute linear and angular diff:
-  const double linear_velocity = traction_wheel_est_pos_diff / dt;
-  steer_pos_ = steer_pos;
-  const double angular_velocity = tan(steer_pos) * linear_velocity / wheelbase_;
-
-  return update_odometry(linear_velocity, angular_velocity, dt);
+  return update_from_velocity(traction_wheel_est_pos_diff / dt, steer_pos, dt);
 }
 
 bool SteeringOdometry::update_from_position(
   const double traction_right_wheel_pos, const double traction_left_wheel_pos,
   const double steer_pos, const double dt)
 {
-  /// Get current wheel joint positions:
-  const double traction_right_wheel_cur_pos = traction_right_wheel_pos * wheel_radius_;
-  const double traction_left_wheel_cur_pos = traction_left_wheel_pos * wheel_radius_;
-
   const double traction_right_wheel_est_pos_diff =
-    traction_right_wheel_cur_pos - traction_right_wheel_old_pos_;
+    traction_right_wheel_pos - traction_right_wheel_old_pos_;
   const double traction_left_wheel_est_pos_diff =
-    traction_left_wheel_cur_pos - traction_left_wheel_old_pos_;
+    traction_left_wheel_pos - traction_left_wheel_old_pos_;
 
   /// Update old position with current:
-  traction_right_wheel_old_pos_ = traction_right_wheel_cur_pos;
-  traction_left_wheel_old_pos_ = traction_left_wheel_cur_pos;
+  traction_right_wheel_old_pos_ = traction_right_wheel_pos;
+  traction_left_wheel_old_pos_ = traction_left_wheel_pos;
 
-  const double linear_velocity =
-    (traction_right_wheel_est_pos_diff + traction_left_wheel_est_pos_diff) * 0.5 / dt;
-  steer_pos_ = steer_pos;
-  const double angular_velocity = tan(steer_pos_) * linear_velocity / wheelbase_;
-
-  return update_odometry(linear_velocity, angular_velocity, dt);
+  return update_from_velocity(
+    traction_right_wheel_est_pos_diff / dt, traction_left_wheel_est_pos_diff / dt, steer_pos, dt);
 }
 
 bool SteeringOdometry::update_from_position(
   const double traction_right_wheel_pos, const double traction_left_wheel_pos,
   const double right_steer_pos, const double left_steer_pos, const double dt)
 {
-  /// Get current wheel joint positions:
-  const double traction_right_wheel_cur_pos = traction_right_wheel_pos * wheel_radius_;
-  const double traction_left_wheel_cur_pos = traction_left_wheel_pos * wheel_radius_;
-
   const double traction_right_wheel_est_pos_diff =
-    traction_right_wheel_cur_pos - traction_right_wheel_old_pos_;
+    traction_right_wheel_pos - traction_right_wheel_old_pos_;
   const double traction_left_wheel_est_pos_diff =
-    traction_left_wheel_cur_pos - traction_left_wheel_old_pos_;
+    traction_left_wheel_pos - traction_left_wheel_old_pos_;
 
   /// Update old position with current:
-  traction_right_wheel_old_pos_ = traction_right_wheel_cur_pos;
-  traction_left_wheel_old_pos_ = traction_left_wheel_cur_pos;
+  traction_right_wheel_old_pos_ = traction_right_wheel_pos;
+  traction_left_wheel_old_pos_ = traction_left_wheel_pos;
 
-  /// Compute linear and angular diff:
-  const double linear_velocity =
-    (traction_right_wheel_est_pos_diff + traction_left_wheel_est_pos_diff) * 0.5 / dt;
-  steer_pos_ = (right_steer_pos + left_steer_pos) * 0.5;
-  const double angular_velocity = tan(steer_pos_) * linear_velocity / wheelbase_;
-
-  return update_odometry(linear_velocity, angular_velocity, dt);
+  return update_from_velocity(
+    traction_right_wheel_est_pos_diff / dt, traction_left_wheel_est_pos_diff / dt, right_steer_pos,
+    left_steer_pos, dt);
 }
 
 bool SteeringOdometry::update_from_velocity(

--- a/tricycle_steering_controller/src/tricycle_steering_controller.cpp
+++ b/tricycle_steering_controller/src/tricycle_steering_controller.cpp
@@ -60,24 +60,26 @@ bool TricycleSteeringController::update_odometry(const rclcpp::Duration & period
   }
   else
   {
-    const double rear_right_wheel_value = state_interfaces_[STATE_TRACTION_RIGHT_WHEEL].get_value();
-    const double rear_left_wheel_value = state_interfaces_[STATE_TRACTION_LEFT_WHEEL].get_value();
+    const double traction_right_wheel_value =
+      state_interfaces_[STATE_TRACTION_RIGHT_WHEEL].get_value();
+    const double traction_left_wheel_value =
+      state_interfaces_[STATE_TRACTION_LEFT_WHEEL].get_value();
     const double steer_position = state_interfaces_[STATE_STEER_AXIS].get_value();
     if (
-      !std::isnan(rear_right_wheel_value) && !std::isnan(rear_left_wheel_value) &&
+      !std::isnan(traction_right_wheel_value) && !std::isnan(traction_left_wheel_value) &&
       !std::isnan(steer_position))
     {
       if (params_.position_feedback)
       {
         // Estimate linear and angular velocity using joint information
         odometry_.update_from_position(
-          rear_right_wheel_value, rear_left_wheel_value, steer_position, period.seconds());
+          traction_right_wheel_value, traction_left_wheel_value, steer_position, period.seconds());
       }
       else
       {
         // Estimate linear and angular velocity using joint information
         odometry_.update_from_velocity(
-          rear_right_wheel_value, rear_left_wheel_value, steer_position, period.seconds());
+          traction_right_wheel_value, traction_left_wheel_value, steer_position, period.seconds());
       }
     }
   }

--- a/tricycle_steering_controller/src/tricycle_steering_controller.cpp
+++ b/tricycle_steering_controller/src/tricycle_steering_controller.cpp
@@ -66,8 +66,8 @@ bool TricycleSteeringController::update_odometry(const rclcpp::Duration & period
       state_interfaces_[STATE_TRACTION_LEFT_WHEEL].get_value();
     const double steer_position = state_interfaces_[STATE_STEER_AXIS].get_value();
     if (
-      !std::isnan(traction_right_wheel_value) && !std::isnan(traction_left_wheel_value) &&
-      !std::isnan(steer_position))
+      std::isfinite(traction_right_wheel_value) && std::isfinite(traction_left_wheel_value) &&
+      std::isfinite(steer_position))
     {
       if (params_.position_feedback)
       {

--- a/tricycle_steering_controller/src/tricycle_steering_controller.cpp
+++ b/tricycle_steering_controller/src/tricycle_steering_controller.cpp
@@ -64,22 +64,24 @@ bool TricycleSteeringController::update_odometry(const rclcpp::Duration & period
       state_interfaces_[STATE_TRACTION_RIGHT_WHEEL].get_value();
     const double traction_left_wheel_value =
       state_interfaces_[STATE_TRACTION_LEFT_WHEEL].get_value();
-    const double steer_position = state_interfaces_[STATE_STEER_AXIS].get_value();
+    const double steering_position = state_interfaces_[STATE_STEER_AXIS].get_value();
     if (
       std::isfinite(traction_right_wheel_value) && std::isfinite(traction_left_wheel_value) &&
-      std::isfinite(steer_position))
+      std::isfinite(steering_position))
     {
       if (params_.position_feedback)
       {
         // Estimate linear and angular velocity using joint information
         odometry_.update_from_position(
-          traction_right_wheel_value, traction_left_wheel_value, steer_position, period.seconds());
+          traction_right_wheel_value, traction_left_wheel_value, steering_position,
+          period.seconds());
       }
       else
       {
         // Estimate linear and angular velocity using joint information
         odometry_.update_from_velocity(
-          traction_right_wheel_value, traction_left_wheel_value, steer_position, period.seconds());
+          traction_right_wheel_value, traction_left_wheel_value, steering_position,
+          period.seconds());
       }
     }
   }


### PR DESCRIPTION
A follow-up to #1118, using consistent nomenclature introduced in #954

My commits do not change any logic or behavior, just make the code more readable.