### PR TITLE
[JTC] Remove manual angle-wraparound parameter

### DIFF
--- a/doc/release_notes/Jazzy.rst
+++ b/doc/release_notes/Jazzy.rst
@@ -32,7 +32,7 @@ joint_trajectory_controller
 * Empty trajectory messages are discarded (`#902 <https://github.com/ros-controls/ros2_controllers/pull/902>`_).
 * Action field ``error_string`` is now filled with meaningful strings (`#887 <https://github.com/ros-controls/ros2_controllers/pull/887>`_).
 * Angle wraparound behavior (continuous joints) was added from the current state to the first segment of the incoming trajectory (`#796 <https://github.com/ros-controls/ros2_controllers/pull/796>`_).
-* The URDF is now parsed for continuous joints and angle wraparound is automatically activated now (`#949 <https://github.com/ros-controls/ros2_controllers/pull/949>`_).
+* The URDF is now parsed for continuous joints and angle wraparound is automatically activated now (`#949 <https://github.com/ros-controls/ros2_controllers/pull/949>`_). ``angle_wraparound`` parameter was completely removed.
 
 pid_controller
 ************************

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -703,17 +703,6 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
   joints_angle_wraparound_.resize(dof_);
   for (size_t i = 0; i < dof_; ++i)
   {
-    const auto & gains = params_.gains.joints_map.at(params_.joints[i]);
-    if (gains.angle_wraparound)
-    {
-      // TODO(christophfroehlich): remove this warning in a future release (ROS-J)
-      RCLCPP_WARN(
-        logger,
-        "[Deprecated] Parameter 'gains.<joint>.angle_wraparound' is deprecated. The "
-        "angle_wraparound is now used if a continuous joint is configured in the URDF.");
-      joints_angle_wraparound_[i] = true;
-    }
-
     if (!urdf_.empty())
     {
       auto urdf_joint = model_.getJoint(params_.joints[i]);

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -122,12 +122,6 @@ joint_trajectory_controller:
         default_value: 0.0,
         description: "Feed-forward scaling :math:`k_{ff}` of velocity"
       }
-      angle_wraparound: {
-        type: bool,
-        default_value: false,
-        description: "[deprecated] For joints that wrap around (ie. are continuous).
-          Normalizes position-error to -pi to pi."
-      }
   constraints:
     stopped_velocity_tolerance: {
       type: double,


### PR DESCRIPTION
Remove manual angle-wraparound parameter as this info is parsed from the URDF, and got deprecated for some time now by #949 