### PR TITLE
steering_controllers: Fix deprecation warning

### DIFF
--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -116,15 +116,15 @@ controller_interface::CallbackReturn SteeringControllersLibrary::on_configure(
   ref_timeout_ = rclcpp::Duration::from_seconds(params_.reference_timeout);
   if (params_.use_stamped_vel)
   {
-    RCLCPP_WARN(
-      get_node()->get_logger(),
-      "[Deprecated] Using geometry_msgs::msg::Twist instead of TwistStamped is deprecated.");
     ref_subscriber_twist_ = get_node()->create_subscription<ControllerTwistReferenceMsg>(
       "~/reference", subscribers_qos,
       std::bind(&SteeringControllersLibrary::reference_callback, this, std::placeholders::_1));
   }
   else
   {
+    RCLCPP_WARN(
+      get_node()->get_logger(),
+      "[Deprecated] Using geometry_msgs::msg::Twist instead of TwistStamped is deprecated.");
     ref_subscriber_unstamped_ = get_node()->create_subscription<geometry_msgs::msg::Twist>(
       "~/reference_unstamped", subscribers_qos,
       std::bind(


### PR DESCRIPTION
I made a mistake with #1093: The deprecation warning was inserted in the wrong place.
Will be removed with #1151 on rolling, but let's fix this on iron.