### PR TITLE
[Steering controllers library] Reference interfaces are body twist

### DIFF
--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.cpp
@@ -84,7 +84,7 @@ TEST_F(AckermannSteeringControllerTest, check_exported_interfaces)
     controller_->front_wheels_state_names_[1] + "/" + steering_interface_name_);
   EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  // check ref itfsTIME
+  // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
   ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
   for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)

--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
@@ -302,7 +302,7 @@ protected:
 
   std::array<double, 4> joint_state_values_ = {0.5, 0.5, 0.0, 0.0};
   std::array<double, 4> joint_command_values_ = {1.1, 3.3, 2.2, 4.4};
-  std::array<std::string, 2> joint_reference_interfaces_ = {"linear/velocity", "angular/position"};
+  std::array<std::string, 2> joint_reference_interfaces_ = {"linear/velocity", "angular/velocity"};
   std::string steering_interface_name_ = "position";
   // defined in setup
   std::string traction_interface_name_ = "";

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
@@ -68,7 +68,7 @@ TEST_F(BicycleSteeringControllerTest, check_exported_interfaces)
     controller_->front_wheels_state_names_[0] + "/" + steering_interface_name_);
   EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  // check ref itfsTIME
+  // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
   ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
   for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -266,7 +266,7 @@ protected:
 
   std::array<double, 2> joint_state_values_ = {3.3, 0.5};
   std::array<double, 2> joint_command_values_ = {1.1, 2.2};
-  std::array<std::string, 2> joint_reference_interfaces_ = {"linear/velocity", "angular/position"};
+  std::array<std::string, 2> joint_reference_interfaces_ = {"linear/velocity", "angular/velocity"};
   std::string steering_interface_name_ = "position";
 
   // defined in setup

--- a/steering_controllers_library/doc/userdoc.rst
+++ b/steering_controllers_library/doc/userdoc.rst
@@ -56,7 +56,9 @@ References (from a preceding controller)
 Used when controller is in chained mode (``in_chained_mode == true``).
 
 - ``<controller_name>/linear/velocity``      double, in m/s
-- ``<controller_name>/angular/position``     double, in rad
+- ``<controller_name>/angular/velocity``     double, in rad/s
+
+representing the body twist.
 
 Command interfaces
 ,,,,,,,,,,,,,,,,,,,

--- a/steering_controllers_library/include/steering_controllers_library/steering_controllers_library.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_controllers_library.hpp
@@ -131,7 +131,7 @@ protected:
   // name constants for reference interfaces
   size_t nr_ref_itfs_;
 
-  // store last velocity
+  // last velocity commands for open loop odometry
   double last_linear_velocity_ = 0.0;
   double last_angular_velocity_ = 0.0;
 

--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -324,7 +324,7 @@ SteeringControllersLibrary::on_export_reference_interfaces()
     &reference_interfaces_[0]));
 
   reference_interfaces.push_back(hardware_interface::CommandInterface(
-    get_node()->get_name(), std::string("angular/") + hardware_interface::HW_IF_POSITION,
+    get_node()->get_name(), std::string("angular/") + hardware_interface::HW_IF_VELOCITY,
     &reference_interfaces_[1]));
 
   return reference_interfaces;
@@ -396,7 +396,7 @@ controller_interface::return_type SteeringControllersLibrary::update_and_write_c
 
   if (!std::isnan(reference_interfaces_[0]) && !std::isnan(reference_interfaces_[1]))
   {
-    // store and set commands
+    // store (for open loop odometry) and set commands
     last_linear_velocity_ = reference_interfaces_[0];
     last_angular_velocity_ = reference_interfaces_[1];
 

--- a/steering_controllers_library/test/test_steering_controllers_library.cpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.cpp
@@ -66,7 +66,7 @@ TEST_F(SteeringControllersLibraryTest, check_exported_interfaces)
     controller_->front_wheels_state_names_[1] + "/" + steering_interface_name_);
   EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  // check ref itfsTIME
+  // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
   ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
   for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -324,7 +324,7 @@ protected:
   std::array<double, 4> joint_state_values_ = {0.5, 0.5, 0.0, 0.0};
   std::array<double, 4> joint_command_values_ = {1.1, 3.3, 2.2, 4.4};
 
-  std::array<std::string, 2> joint_reference_interfaces_ = {"linear/velocity", "angular/position"};
+  std::array<std::string, 2> joint_reference_interfaces_ = {"linear/velocity", "angular/velocity"};
   std::string steering_interface_name_ = "position";
   // defined in setup
   std::string traction_interface_name_ = "";

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
@@ -285,7 +285,7 @@ protected:
 
   std::array<double, 3> joint_state_values_ = {0.5, 0.5, 0.0};
   std::array<double, 3> joint_command_values_ = {1.1, 3.3, 2.2};
-  std::array<std::string, 2> joint_reference_interfaces_ = {"linear/velocity", "angular/position"};
+  std::array<std::string, 2> joint_reference_interfaces_ = {"linear/velocity", "angular/velocity"};
   std::string steering_interface_name_ = "position";
   // defined in setup
   std::string traction_interface_name_ = "";


### PR DESCRIPTION
Fixes #1167 

I'm not sure if the intention of the author was to have position input, but as it is implemented we have a body twist input on reference interfaces (velocity, not position). This PR fixes this, without any attempt to deprecate the old behavior because it was just wrong.

Tests succeed on iron distro
```
$ colcon test --packages-select steering_controllers_library ackermann_steering_controller bicycle_steering_controller tricycl
e_steering_controller
Starting >>> steering_controllers_library
Finished <<< steering_controllers_library [0.48s]          
Starting >>> ackermann_steering_controller
Starting >>> bicycle_steering_controller
Starting >>> tricycle_steering_controller
Finished <<< tricycle_steering_controller [7.25s]                                                                                                  
Finished <<< ackermann_steering_controller [7.28s]
Finished <<< bicycle_steering_controller [7.33s]

Summary: 4 packages finished [8.33s]
```