### PR TITLE
[JTC] Report on deprecated feedback

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1180,6 +1180,12 @@ void JointTrajectoryController::publish_state(
     state_publisher_->msg_.reference.velocities = desired_state.velocities;
     state_publisher_->msg_.reference.accelerations = desired_state.accelerations;
     state_publisher_->msg_.feedback.positions = current_state.positions;
+    // DESIRED and ACTUAL are deprecated in the message but we are still
+    // reporting on them
+    state_publisher_legacy_->msg_.desired.positions = desired_state.positions;
+    state_publisher_legacy_->msg_.desired.velocities = desired_state.velocities;
+    state_publisher_legacy_->msg_.desired.accelerations = desired_state.accelerations;
+    state_publisher_legacy_->msg_.actual.positions = current_state.positions;
     state_publisher_->msg_.error.positions = state_error.positions;
     if (has_velocity_state_interface_)
     {


### PR DESCRIPTION
Even though the `desired` and `actual` fields are deprecated, we should still fill them in.