### PR TITLE
Ported scaled_jtc

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -41,6 +41,7 @@
 #include "realtime_tools/realtime_buffer.h"
 #include "realtime_tools/realtime_publisher.h"
 #include "realtime_tools/realtime_server_goal_handle.h"
+#include "std_msgs/msg/float64.hpp"
 #include "trajectory_msgs/msg/joint_trajectory.hpp"
 #include "trajectory_msgs/msg/joint_trajectory_point.hpp"
 #include "urdf/model.h"
@@ -287,6 +288,15 @@ protected:
     const std::shared_ptr<control_msgs::srv::QueryTrajectoryState::Request> request,
     std::shared_ptr<control_msgs::srv::QueryTrajectoryState::Response> response);
 
+  // TimeData struct used for trajectory scaling information
+  struct TimeData
+  {
+    TimeData() : time(0.0), period(rclcpp::Duration::from_nanoseconds(0.0)), uptime(0.0) {}
+    rclcpp::Time time;
+    rclcpp::Duration period;
+    rclcpp::Time uptime;
+  };
+
 private:
   void update_pids();
 
@@ -300,6 +310,12 @@ private:
     trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size);
 
   urdf::Model model_;
+
+  using ScalingFactorMsg = std_msgs::msg::Float64;
+  double scaling_factor_{1.0};
+  rclcpp::Subscription<ScalingFactorMsg>::SharedPtr scaling_factor_sub_;
+
+  TimeData time_data_;
 
   /**
    * @brief Assigns the values from a trajectory point interface to a joint interface.

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -95,6 +95,12 @@ joint_trajectory_controller:
      ``cmd_timeout`` must be greater than ``constraints.goal_time``, otherwise ignored.
      If zero, timeout is deactivated",
   }
+  speed_scaling_topic_name: {
+      type: string,
+      default_value: "~/speed_scaling_factor",
+      description: "Topic name for the speed scaling factor - set to an empty string in order to disable it"
+  }
+
   gains:
     __map_joints:
       p: {


### PR DESCRIPTION
This is a remake of https://github.com/ros-controls/ros2_controllers/pull/301 given that neither @fmauch  nor @bmagyar 
are reacting why this PR has been closed.

## Differences to the original PR

1. This PR simply adds the functionality to the normal JTC
2. Instead of using the speed scaling interface a transient local speed scaling factor topic is used. This has various advantageous especially in a multiarm / multi JTC setups. (See https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/883#issuecomment-2126323231 for more information)
3. It contains a fix if a goal time is set: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/882 (Note: @fmauch  and I disagree what the correct behavior would be in that case - but he agreed to merge because otherwise the controller would not be usable) 
4. It does not store the `time_data_` field in a RealTimeBox as the access solely happens from the RT thread. 
5. The scaling factor is not clipped to [0,1] as it is really useful for sim environments to be able to upscale the execution speed

## Testing

I tested it by cherry-picking the commit back to the iron branch and running it on my setup with multiple joint motions. They were looking fine. We are using basically the same code (but added to the original scaled jtc) on our production setup for more than 3/4 of a year now.  (https://github.com/firesurfer/Universal_Robots_ROS2_Driver/tree/fixed_jtc)


## Configuration

The PR adds the following configuration entry:

>   speed_scaling_topic_name: {
      type: string,
      default_value: "~/speed_scaling_factor",
      description: "Topic name for the speed scaling factor - set to an empty string in order to disable it"
  }

For a multiarm scenario one would set this topic to the same topic name for all involved JTCs.

Up to discussion: Should it be _disabled_ per default?

## Notes

The `scaling_factor_` field does not need to be in a RealTime box (it does not matter if it is updated an update cycle earlier or later) but it might make sense to use an `std::atomic<double>` double as some platforms might not guarantee atomic access to the variable. 

It has the same issue as the original PR bei @fmauch. It does not scale velocities and efforts at the moment. But never the less I think it is a really useful addition and bringing this feature upstream will avoid issues such as #1182 where the bug has been fixed upstream but not backported yet. 


iron backport I used for testing: https://github.com/firesurfer/ros2_controllers/tree/scaled_jtc_iron