### PR TITLE
[Admittance] multiple state/command interfaces

### DIFF
--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -480,13 +480,13 @@ void AdmittanceController::read_state_from_hardware(
         state_interfaces_[pos_ind * num_joints_ + joint_ind].get_value();
       nan_position |= std::isnan(state_current.positions[joint_ind]);
     }
-    else if (has_velocity_state_interface_)
+    if (has_velocity_state_interface_)
     {
       state_current.velocities[joint_ind] =
         state_interfaces_[vel_ind * num_joints_ + joint_ind].get_value();
       nan_velocity |= std::isnan(state_current.velocities[joint_ind]);
     }
-    else if (has_acceleration_state_interface_)
+    if (has_acceleration_state_interface_)
     {
       state_current.accelerations[joint_ind] =
         state_interfaces_[acc_ind * num_joints_ + joint_ind].get_value();
@@ -532,15 +532,15 @@ void AdmittanceController::write_state_to_hardware(
       command_interfaces_[pos_ind * num_joints_ + joint_ind].set_value(
         state_commanded.positions[joint_ind]);
     }
-    else if (has_velocity_command_interface_)
+    if (has_velocity_command_interface_)
     {
       command_interfaces_[vel_ind * num_joints_ + joint_ind].set_value(
-        state_commanded.positions[joint_ind]);
+        state_commanded.velocities[joint_ind]);
     }
-    else if (has_acceleration_command_interface_)
+    if (has_acceleration_command_interface_)
     {
       command_interfaces_[acc_ind * num_joints_ + joint_ind].set_value(
-        state_commanded.positions[joint_ind]);
+        state_commanded.accelerations[joint_ind]);
     }
   }
   last_commanded_ = state_commanded;

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -470,7 +470,7 @@ void AdmittanceController::read_state_from_hardware(
   bool nan_acceleration = false;
 
   size_t pos_ind = 0;
-  size_t vel_ind = pos_ind + has_velocity_command_interface_;
+  size_t vel_ind = pos_ind + has_velocity_state_interface_;
   size_t acc_ind = vel_ind + has_acceleration_state_interface_;
   for (size_t joint_ind = 0; joint_ind < num_joints_; ++joint_ind)
   {
@@ -524,7 +524,7 @@ void AdmittanceController::write_state_to_hardware(
   // if any interface has nan values, assume state_commanded is the last command state
   size_t pos_ind = 0;
   size_t vel_ind = pos_ind + has_velocity_command_interface_;
-  size_t acc_ind = vel_ind + has_acceleration_state_interface_;
+  size_t acc_ind = vel_ind + has_acceleration_command_interface_;
   for (size_t joint_ind = 0; joint_ind < num_joints_; ++joint_ind)
   {
     if (has_position_command_interface_)

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -244,6 +244,12 @@ controller_interface::CallbackReturn AdmittanceController::on_configure(
   has_acceleration_state_interface_ = contains_interface_type(
     admittance_->parameters_.state_interfaces, hardware_interface::HW_IF_ACCELERATION);
 
+  if (!has_position_state_interface_)
+  {
+    RCLCPP_ERROR(get_node()->get_logger(), "Position state interface is required.");
+    return CallbackReturn::FAILURE;
+  }
+
   auto get_interface_list = [](const std::vector<std::string> & interface_types)
   {
     std::stringstream ss_command_interfaces;
@@ -523,7 +529,7 @@ void AdmittanceController::write_state_to_hardware(
 {
   // if any interface has nan values, assume state_commanded is the last command state
   size_t pos_ind = 0;
-  size_t vel_ind = pos_ind + has_velocity_command_interface_;
+  size_t vel_ind = (has_position_command_interface_) ? has_velocity_command_interface_ : pos_ind;
   size_t acc_ind = vel_ind + has_acceleration_command_interface_;
   for (size_t joint_ind = 0; joint_ind < num_joints_; ++joint_ind)
   {


### PR DESCRIPTION
This PR aims to address the following issues:
1. Fix wrong `has` flags used in write and read methods 
2. Fix wrong fields of `state_commanded` used in `write_state_to_hardware`
3. Fix that multiple state interfaces are configured only the position state interface is considered due to `else if` statement.

Moreover:
1. Makes position state interface mandatory, otherwise the controller will not be able to perform computations. The controller will not be configured if not provided.
2. Adds compatibility with velocity command interface without position command interface.