### PR TITLE
Fix parallel gripper controller CI

### DIFF
--- a/parallel_gripper_controller/include/parallel_gripper_controller/parallel_gripper_action_controller_impl.hpp
+++ b/parallel_gripper_controller/include/parallel_gripper_controller/parallel_gripper_action_controller_impl.hpp
@@ -322,7 +322,6 @@ controller_interface::CallbackReturn GripperActionController::on_activate(
     }
   }
 
-
   // Command - non RT version
   command_struct_.position_cmd_ = joint_position_state_interface_->get().get_value();
   command_struct_.max_effort_ = params_.max_effort;

--- a/parallel_gripper_controller/test/test_load_parallel_gripper_action_controller.cpp
+++ b/parallel_gripper_controller/test/test_load_parallel_gripper_action_controller.cpp
@@ -28,9 +28,7 @@ TEST(TestLoadGripperActionControllers, load_controller)
     std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
   controller_manager::ControllerManager cm(
-    std::make_unique<hardware_interface::ResourceManager>(
-      ros2_control_test_assets::minimal_robot_urdf),
-    executor, "test_controller_manager");
+    executor, ros2_control_test_assets::minimal_robot_urdf, "test_controller_manager");
 
   ASSERT_NE(
     cm.load_controller(


### PR DESCRIPTION
There is a pre-formatting fix and also the failing build in the CI reported by @bmagyar and this is due to the recent change in the API of ros2_control
