### PR TITLE
[doc] Fix controller idx page

### DIFF
--- a/doc/controllers_index.rst
+++ b/doc/controllers_index.rst
@@ -16,9 +16,9 @@ Guidelines and Best Practices
 
 .. toctree::
    :titlesonly:
-   :glob:
 
-   *
+   mobile_robot_kinematics.rst
+   writing_new_controller.rst
 
 
 Controllers for Wheeled Mobile Robots

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/doc/migration/Jazzy.rst
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/doc/migration.rst
 
 Migration Guides: Iron to Jazzy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -1,6 +1,6 @@
 :github_url: https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/doc/migration/Jazzy.rst
 
-Iron to Jazzy
+Migration Guides: Iron to Jazzy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This list summarizes important changes between Iron (previous) and Jazzy (current) releases, where changes to user code might be necessary.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/doc/release_notes/Jazzy.rst
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/doc/release_notes.rst
 
 Release Notes: Iron to Jazzy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,6 +1,6 @@
 :github_url: https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/doc/release_notes/Jazzy.rst
 
-Iron to Jazzy
+Release Notes: Iron to Jazzy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This list summarizes the changes between Iron (previous) and Jazzy (current) releases.
 


### PR DESCRIPTION
A fix to #1204 , there was a glob in the TOC showing also the release + migration notes there.
old:
![image](https://github.com/user-attachments/assets/1b251147-48de-4b88-b42f-a04b51287b0d)
