### PR TITLE
[JTC] Use the internal methods instead of using the variables directly

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -43,9 +43,10 @@ JointTrajectoryController::JointTrajectoryController()
 
 controller_interface::CallbackReturn JointTrajectoryController::on_init()
 {
-  if (!urdf_.empty())
+  const std::string & urdf = get_robot_description();
+  if (!urdf.empty())
   {
-    if (!model_.initString(urdf_))
+    if (!model_.initString(urdf))
     {
       RCLCPP_ERROR(get_node()->get_logger(), "Failed to parse URDF file");
     }
@@ -701,7 +702,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
   joints_angle_wraparound_.resize(dof_);
   for (size_t i = 0; i < dof_; ++i)
   {
-    if (!urdf_.empty())
+    if (!get_robot_description().empty())
     {
       auto urdf_joint = model_.getJoint(params_.joints[i]);
       if (urdf_joint && urdf_joint->type == urdf::Joint::CONTINUOUS)


### PR DESCRIPTION
These changes make the JTC use the internal method to retrieve the URDF rather than using the variables directly. I think it is safer and clear this way.

Once the https://github.com/ros-controls/ros2_control/pull/1623 is merged, we would definitely need these changes. These changes can also be merged even without 1623.

Thank you!