### PR TITLE
Fix admittance controller interface read/write logic

### DIFF
--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -476,13 +476,13 @@ void AdmittanceController::read_state_from_hardware(
         state_interfaces_[pos_ind * num_joints_ + joint_ind].get_value();
       nan_position |= std::isnan(state_current.positions[joint_ind]);
     }
-    else if (has_velocity_state_interface_)
+    if (has_velocity_state_interface_)
     {
       state_current.velocities[joint_ind] =
         state_interfaces_[vel_ind * num_joints_ + joint_ind].get_value();
       nan_velocity |= std::isnan(state_current.velocities[joint_ind]);
     }
-    else if (has_acceleration_state_interface_)
+    if (has_acceleration_state_interface_)
     {
       state_current.accelerations[joint_ind] =
         state_interfaces_[acc_ind * num_joints_ + joint_ind].get_value();
@@ -528,12 +528,12 @@ void AdmittanceController::write_state_to_hardware(
       command_interfaces_[pos_ind * num_joints_ + joint_ind].set_value(
         state_commanded.positions[joint_ind]);
     }
-    else if (has_velocity_command_interface_)
+    if (has_velocity_command_interface_)
     {
       command_interfaces_[vel_ind * num_joints_ + joint_ind].set_value(
         state_commanded.velocities[joint_ind]);
     }
-    else if (has_acceleration_command_interface_)
+    if (has_acceleration_command_interface_)
     {
       command_interfaces_[acc_ind * num_joints_ + joint_ind].set_value(
         state_commanded.accelerations[joint_ind]);

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -531,12 +531,12 @@ void AdmittanceController::write_state_to_hardware(
     else if (has_velocity_command_interface_)
     {
       command_interfaces_[vel_ind * num_joints_ + joint_ind].set_value(
-        state_commanded.positions[joint_ind]);
+        state_commanded.velocities[joint_ind]);
     }
     else if (has_acceleration_command_interface_)
     {
       command_interfaces_[acc_ind * num_joints_ + joint_ind].set_value(
-        state_commanded.positions[joint_ind]);
+        state_commanded.accelerations[joint_ind]);
     }
   }
   last_commanded_ = state_commanded;


### PR DESCRIPTION
Using ROS `rolling` and gazebo `Harmonic`, I've found two bugs while trying to control a robot using _both_ `velocity` and `position` control.

1. In `write_state_to_hardware()`, `state_commanded.positions` are mistakenly being written to both `velocity` and `acceleration` command interfaces.
2. Both in `write_state_to_hardware()` and `read_state_from_hardware()`, checking whether the controller has `pos`/`vel`/`acc` interfaces is done using `if-else` clauses. This causes the block to **exit upon first true condition**, meaning, after confirming `position` interface exists, _`velocity` and `acceleration` interfaces never get written to or read from_

These fixes are verified in my use case, but seem obvious enough that no tests need to be written to verify these claims.

Nonetheless, let me know if you'd like some tests before merging. 

Cheers!
