### PR TITLE
Fix segfault at reconfigure of AdmittanceController

### DIFF
--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -46,15 +46,17 @@ controller_interface::return_type AdmittanceRule::configure(
   {
     try
     {
-      // Do not create a new instance in case of a reinit
-      if (!kinematics_loader_)
+      // Make sure we destroy the interface first. Otherwise we might run into a segfault
+      if (kinematics_loader_)
       {
-        kinematics_loader_ =
-          std::make_shared<pluginlib::ClassLoader<kinematics_interface::KinematicsInterface>>(
-            parameters_.kinematics.plugin_package, "kinematics_interface::KinematicsInterface");
-        kinematics_ = std::unique_ptr<kinematics_interface::KinematicsInterface>(
-          kinematics_loader_->createUnmanagedInstance(parameters_.kinematics.plugin_name));
+        kinematics_.reset();
       }
+      kinematics_loader_ =
+        std::make_shared<pluginlib::ClassLoader<kinematics_interface::KinematicsInterface>>(
+          parameters_.kinematics.plugin_package, "kinematics_interface::KinematicsInterface");
+      kinematics_ = std::unique_ptr<kinematics_interface::KinematicsInterface>(
+        kinematics_loader_->createUnmanagedInstance(parameters_.kinematics.plugin_name));
+
       if (!kinematics_->initialize(
             node->get_node_parameters_interface(), parameters_.kinematics.tip))
       {

--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -46,11 +46,14 @@ controller_interface::return_type AdmittanceRule::configure(
   {
     try
     {
-      kinematics_loader_ =
-        std::make_shared<pluginlib::ClassLoader<kinematics_interface::KinematicsInterface>>(
-          parameters_.kinematics.plugin_package, "kinematics_interface::KinematicsInterface");
-      kinematics_ = std::unique_ptr<kinematics_interface::KinematicsInterface>(
-        kinematics_loader_->createUnmanagedInstance(parameters_.kinematics.plugin_name));
+      //Do not create a new instance in case of a reinit
+      if(!kinematics_loader_ ){
+        kinematics_loader_ =
+          std::make_shared<pluginlib::ClassLoader<kinematics_interface::KinematicsInterface>>(
+            parameters_.kinematics.plugin_package, "kinematics_interface::KinematicsInterface");
+        kinematics_ = std::unique_ptr<kinematics_interface::KinematicsInterface>(
+          kinematics_loader_->createUnmanagedInstance(parameters_.kinematics.plugin_name));
+      }
       if (!kinematics_->initialize(
             node->get_node_parameters_interface(), parameters_.kinematics.tip))
       {

--- a/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp
@@ -46,8 +46,9 @@ controller_interface::return_type AdmittanceRule::configure(
   {
     try
     {
-      //Do not create a new instance in case of a reinit
-      if(!kinematics_loader_ ){
+      // Do not create a new instance in case of a reinit
+      if (!kinematics_loader_)
+      {
         kinematics_loader_ =
           std::make_shared<pluginlib::ClassLoader<kinematics_interface::KinematicsInterface>>(
             parameters_.kinematics.plugin_package, "kinematics_interface::KinematicsInterface");


### PR DESCRIPTION
This PR fixes #1181.


I tested it on iron and rebased it on rolling afterwards. 

This PR simply avoid recreating the kinematics plugin, but just reinitializes it - which seems to work. 
