### PR TITLE
Fixes tests to work with use_global_arguments NodeOptions parameter 

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -58,10 +58,8 @@ if(BUILD_TESTING)
   find_package(ros2_control_test_assets REQUIRED)
 
 
-  add_rostest_with_parameters_gmock(test_load_ackermann_steering_controller
-    test/test_load_ackermann_steering_controller.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/ackermann_steering_controller_params.yaml
-  )
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_ackermann_steering_controller test/test_load_ackermann_steering_controller.cpp)
   ament_target_dependencies(test_load_ackermann_steering_controller
     controller_manager
     hardware_interface

--- a/ackermann_steering_controller/test/test_load_ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/test/test_load_ackermann_steering_controller.cpp
@@ -29,12 +29,15 @@ TEST(TestLoadAckermannSteeringController, load_controller)
 
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/ackermann_steering_controller_params.yaml";
 
-  ASSERT_NE(
-    cm.load_controller(
-      "test_ackermann_steering_controller",
-      "ackermann_steering_controller/AckermannSteeringController"),
-    nullptr);
+  cm.set_parameter({"test_ackermann_steering_controller.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_ackermann_steering_controller.type",
+     "ackermann_steering_controller/AckermannSteeringController"});
+
+  ASSERT_NE(cm.load_controller("test_ackermann_steering_controller"), nullptr);
 }
 
 int main(int argc, char ** argv)

--- a/admittance_controller/CMakeLists.txt
+++ b/admittance_controller/CMakeLists.txt
@@ -68,10 +68,8 @@ if(BUILD_TESTING)
   find_package(kinematics_interface_kdl REQUIRED)
 
   # test loading admittance controller
-  add_rostest_with_parameters_gmock(test_load_admittance_controller
-    test/test_load_admittance_controller.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_params.yaml
-  )
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_admittance_controller test/test_load_admittance_controller.cpp)
   ament_target_dependencies(test_load_admittance_controller
     controller_manager
     hardware_interface

--- a/admittance_controller/test/test_load_admittance_controller.cpp
+++ b/admittance_controller/test/test_load_admittance_controller.cpp
@@ -30,10 +30,13 @@ TEST(TestLoadAdmittanceController, load_controller)
 
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
+  const std::string test_file_path = std::string(TEST_FILES_DIRECTORY) + "/test_params.yaml";
 
-  ASSERT_EQ(
-    cm.load_controller("load_admittance_controller", "admittance_controller/AdmittanceController"),
-    nullptr);
+  cm.set_parameter({"load_admittance_controller.params_file", test_file_path});
+  cm.set_parameter(
+    {"load_admittance_controller.type", "admittance_controller/AdmittanceController"});
+
+  ASSERT_EQ(cm.load_controller("load_admittance_controller"), nullptr);
 }
 
 int main(int argc, char ** argv)

--- a/bicycle_steering_controller/CMakeLists.txt
+++ b/bicycle_steering_controller/CMakeLists.txt
@@ -57,10 +57,8 @@ if(BUILD_TESTING)
   find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
-  add_rostest_with_parameters_gmock(test_load_bicycle_steering_controller
-    test/test_load_bicycle_steering_controller.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/bicycle_steering_controller_params.yaml
-  )
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_bicycle_steering_controller test/test_load_bicycle_steering_controller.cpp)
   ament_target_dependencies(test_load_bicycle_steering_controller
     controller_manager
     hardware_interface

--- a/bicycle_steering_controller/test/test_load_bicycle_steering_controller.cpp
+++ b/bicycle_steering_controller/test/test_load_bicycle_steering_controller.cpp
@@ -29,11 +29,15 @@ TEST(TestLoadBicycleSteeringController, load_controller)
 
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/bicycle_steering_controller_params.yaml";
 
-  ASSERT_NE(
-    cm.load_controller(
-      "test_bicycle_steering_controller", "bicycle_steering_controller/BicycleSteeringController"),
-    nullptr);
+  cm.set_parameter({"test_bicycle_steering_controller.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_bicycle_steering_controller.type",
+     "bicycle_steering_controller/BicycleSteeringController"});
+
+  ASSERT_NE(cm.load_controller("test_bicycle_steering_controller"), nullptr);
 }
 
 int main(int argc, char ** argv)

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -70,10 +70,8 @@ if(BUILD_TESTING)
     tf2_msgs
   )
 
-  add_rostest_with_parameters_gmock(test_load_diff_drive_controller
-    test/test_load_diff_drive_controller.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/config/test_diff_drive_controller.yaml
-  )
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_diff_drive_controller test/test_load_diff_drive_controller.cpp)
   ament_target_dependencies(test_load_diff_drive_controller
     controller_manager
     ros2_control_test_assets

--- a/diff_drive_controller/test/test_load_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_load_diff_drive_controller.cpp
@@ -29,10 +29,14 @@ TEST(TestLoadDiffDriveController, load_controller)
 
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::diffbot_urdf, true, "test_controller_manager");
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/config/test_diff_drive_controller.yaml";
 
-  ASSERT_NE(
-    cm.load_controller("test_diff_drive_controller", "diff_drive_controller/DiffDriveController"),
-    nullptr);
+  cm.set_parameter({"test_diff_drive_controller.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_diff_drive_controller.type", "diff_drive_controller/DiffDriveController"});
+
+  ASSERT_NE(cm.load_controller("test_diff_drive_controller"), nullptr);
 }
 
 int main(int argc, char ** argv)

--- a/force_torque_sensor_broadcaster/CMakeLists.txt
+++ b/force_torque_sensor_broadcaster/CMakeLists.txt
@@ -53,9 +53,8 @@ if(BUILD_TESTING)
   find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
-  add_rostest_with_parameters_gmock(test_load_force_torque_sensor_broadcaster
-    test/test_load_force_torque_sensor_broadcaster.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/force_torque_sensor_broadcaster_params.yaml)
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_force_torque_sensor_broadcaster test/test_load_force_torque_sensor_broadcaster.cpp)
   target_include_directories(test_load_force_torque_sensor_broadcaster PRIVATE include)
   target_link_libraries(test_load_force_torque_sensor_broadcaster
     force_torque_sensor_broadcaster

--- a/force_torque_sensor_broadcaster/test/test_load_force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/test/test_load_force_torque_sensor_broadcaster.cpp
@@ -34,11 +34,15 @@ TEST(TestLoadForceTorqueSensorBroadcaster, load_controller)
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
 
-  ASSERT_NE(
-    cm.load_controller(
-      "test_force_torque_sensor_broadcaster",
-      "force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster"),
-    nullptr);
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/force_torque_sensor_broadcaster_params.yaml";
+
+  cm.set_parameter({"test_force_torque_sensor_broadcaster.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_force_torque_sensor_broadcaster.type",
+     "force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster"});
+
+  ASSERT_NE(cm.load_controller("test_force_torque_sensor_broadcaster"), nullptr);
 }
 
 int main(int argc, char ** argv)

--- a/imu_sensor_broadcaster/CMakeLists.txt
+++ b/imu_sensor_broadcaster/CMakeLists.txt
@@ -53,9 +53,8 @@ if(BUILD_TESTING)
   find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
-  add_rostest_with_parameters_gmock(test_load_imu_sensor_broadcaster
-    test/test_load_imu_sensor_broadcaster.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/imu_sensor_broadcaster_params.yaml)
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_imu_sensor_broadcaster test/test_load_imu_sensor_broadcaster.cpp)
   target_include_directories(test_load_imu_sensor_broadcaster PRIVATE include)
   target_link_libraries(test_load_imu_sensor_broadcaster
     imu_sensor_broadcaster

--- a/imu_sensor_broadcaster/test/test_load_imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/test/test_load_imu_sensor_broadcaster.cpp
@@ -33,11 +33,14 @@ TEST(TestLoadIMUSensorBroadcaster, load_controller)
 
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/imu_sensor_broadcaster_params.yaml";
 
-  ASSERT_NE(
-    cm.load_controller(
-      "test_imu_sensor_broadcaster", "imu_sensor_broadcaster/IMUSensorBroadcaster"),
-    nullptr);
+  cm.set_parameter({"test_imu_sensor_broadcaster.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_imu_sensor_broadcaster.type", "imu_sensor_broadcaster/IMUSensorBroadcaster"});
+
+  ASSERT_NE(cm.load_controller("test_imu_sensor_broadcaster"), nullptr);
 }
 
 int main(int argc, char ** argv)

--- a/parallel_gripper_controller/CMakeLists.txt
+++ b/parallel_gripper_controller/CMakeLists.txt
@@ -48,9 +48,8 @@ if(BUILD_TESTING)
   find_package(controller_manager REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
-  add_rostest_with_parameters_gmock(test_load_parallel_gripper_action_controllers
-  test/test_load_parallel_gripper_action_controller.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/test/gripper_action_controller_params.yaml)
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_parallel_gripper_action_controllers test/test_load_parallel_gripper_action_controller.cpp)
   target_include_directories(test_load_parallel_gripper_action_controllers PRIVATE include)
   ament_target_dependencies(test_load_parallel_gripper_action_controllers
     controller_manager

--- a/parallel_gripper_controller/test/test_load_parallel_gripper_action_controller.cpp
+++ b/parallel_gripper_controller/test/test_load_parallel_gripper_action_controller.cpp
@@ -27,12 +27,15 @@ TEST(TestLoadGripperActionControllers, load_controller)
 
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/gripper_action_controller_params.yaml";
 
-  ASSERT_NE(
-    cm.load_controller(
-      "test_gripper_action_position_controller",
-      "parallel_gripper_action_controller/GripperActionController"),
-    nullptr);
+  cm.set_parameter({"test_gripper_action_position_controller.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_gripper_action_position_controller.type",
+     "parallel_gripper_action_controller/GripperActionController"});
+
+  ASSERT_NE(cm.load_controller("test_gripper_action_position_controller"), nullptr);
 }
 
 int main(int argc, char ** argv)

--- a/range_sensor_broadcaster/CMakeLists.txt
+++ b/range_sensor_broadcaster/CMakeLists.txt
@@ -59,9 +59,8 @@ if(BUILD_TESTING)
   find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
-  add_rostest_with_parameters_gmock(test_load_range_sensor_broadcaster
-  test/test_load_range_sensor_broadcaster.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/test/range_sensor_broadcaster_params.yaml)
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_range_sensor_broadcaster test/test_load_range_sensor_broadcaster.cpp)
   target_include_directories(test_load_range_sensor_broadcaster PRIVATE include)
   target_link_libraries(test_load_range_sensor_broadcaster
     range_sensor_broadcaster

--- a/range_sensor_broadcaster/test/test_load_range_sensor_broadcaster.cpp
+++ b/range_sensor_broadcaster/test/test_load_range_sensor_broadcaster.cpp
@@ -33,11 +33,14 @@ TEST(TestLoadRangeSensorBroadcaster, load_controller)
 
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/range_sensor_broadcaster_params.yaml";
 
-  ASSERT_NE(
-    cm.load_controller(
-      "test_range_sensor_broadcaster", "range_sensor_broadcaster/RangeSensorBroadcaster"),
-    nullptr);
+  cm.set_parameter({"test_range_sensor_broadcaster.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_range_sensor_broadcaster.type", "range_sensor_broadcaster/RangeSensorBroadcaster"});
+
+  ASSERT_NE(cm.load_controller("test_range_sensor_broadcaster"), nullptr);
 }
 
 int main(int argc, char ** argv)

--- a/tricycle_controller/CMakeLists.txt
+++ b/tricycle_controller/CMakeLists.txt
@@ -76,10 +76,8 @@ if(BUILD_TESTING)
     tf2_msgs
   )
 
-  add_rostest_with_parameters_gmock(test_load_tricycle_controller
-    test/test_load_tricycle_controller.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/config/test_tricycle_controller.yaml
-  )
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_tricycle_controller test/test_load_tricycle_controller.cpp)
   target_link_libraries(test_load_tricycle_controller
     tricycle_controller
   )

--- a/tricycle_controller/test/test_load_tricycle_controller.cpp
+++ b/tricycle_controller/test/test_load_tricycle_controller.cpp
@@ -33,10 +33,13 @@ TEST(TestLoadTricycleController, load_controller)
 
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/config/test_tricycle_controller.yaml";
 
-  ASSERT_NE(
-    cm.load_controller("test_tricycle_controller", "tricycle_controller/TricycleController"),
-    nullptr);
+  cm.set_parameter({"test_tricycle_controller.params_file", test_file_path});
+  cm.set_parameter({"test_tricycle_controller.type", "tricycle_controller/TricycleController"});
+
+  ASSERT_NE(cm.load_controller("test_tricycle_controller"), nullptr);
 }
 
 int main(int argc, char ** argv)

--- a/tricycle_steering_controller/CMakeLists.txt
+++ b/tricycle_steering_controller/CMakeLists.txt
@@ -57,10 +57,8 @@ if(BUILD_TESTING)
   find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
-  add_rostest_with_parameters_gmock(test_load_tricycle_steering_controller
-    test/test_load_tricycle_steering_controller.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/tricycle_steering_controller_params.yaml
-  )
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_tricycle_steering_controller test/test_load_tricycle_steering_controller.cpp)
   ament_target_dependencies(test_load_tricycle_steering_controller
     controller_manager
     hardware_interface

--- a/tricycle_steering_controller/test/test_load_tricycle_steering_controller.cpp
+++ b/tricycle_steering_controller/test/test_load_tricycle_steering_controller.cpp
@@ -29,12 +29,15 @@ TEST(TestLoadTricycleSteeringController, load_controller)
 
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/tricycle_steering_controller_params.yaml";
 
-  ASSERT_NE(
-    cm.load_controller(
-      "test_tricycle_steering_controller",
-      "tricycle_steering_controller/TricycleSteeringController"),
-    nullptr);
+  cm.set_parameter({"test_tricycle_steering_controller.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_tricycle_steering_controller.type",
+     "tricycle_steering_controller/TricycleSteeringController"});
+
+  ASSERT_NE(cm.load_controller("test_tricycle_steering_controller"), nullptr);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Needs: https://github.com/ros-controls/ros2_control/pull/1701

Fixes: https://github.com/ros-controls/ros2_controllers/issues/1252
Fixes: https://github.com/ros-controls/ros2_controllers/issues/1253
Fixes: https://github.com/ros-controls/ros2_controllers/issues/1254
Fixes: https://github.com/ros-controls/ros2_controllers/issues/1255
