### PR TITLE
[Joint State Broadcaster] Move urdf::Model initialization from on_activate to on_configure to enhance real-time performance

### DIFF
--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -27,6 +27,7 @@
 #include "joint_state_broadcaster_parameters.hpp"
 #include "realtime_tools/realtime_publisher.h"
 #include "sensor_msgs/msg/joint_state.hpp"
+#include "urdf/model.h"
 
 namespace joint_state_broadcaster
 {
@@ -111,6 +112,9 @@ protected:
     dynamic_joint_state_publisher_;
   std::shared_ptr<realtime_tools::RealtimePublisher<control_msgs::msg::DynamicJointState>>
     realtime_dynamic_joint_state_publisher_;
+
+  urdf::Model model_;
+  bool is_model_loaded_ = false;
 };
 
 }  // namespace joint_state_broadcaster


### PR DESCRIPTION
This PR aims to enhance real-time performance during the activation of the Joint State Broadcaster, which was introduced in #1233.

The `urdf::Model` initialization ([here](https://github.com/ros-controls/ros2_controllers/blob/20f6f0bba9a73cb49b4547cc5316ee058a2298aa/joint_state_broadcaster/src/joint_state_broadcaster.cpp#L248-L249)), previously executed within the on_activate function, incurred a substantial amount of time, leading to significant jitter in the Controller Manager's real-time loop.

To address this, the initialization of the `urdf::Model` has been relocated from on_activate to on_configure, as it can be effectively performed beforehand. In my testing environment, this modification has resulted in a remarkable improvement, accelerating the on_activate process by approximately 40 times (reducing the time from 5ms to 0.12ms).