### PR TITLE
Fix deprecation warning in paramater declaration

### DIFF
--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_forward_position_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_forward_position_controller.py
@@ -17,6 +17,7 @@
 
 import rclpy
 from rclpy.node import Node
+from rcl_interfaces.msg import ParameterDescriptor
 
 from std_msgs.msg import Float64MultiArray
 
@@ -37,7 +38,7 @@ class PublisherForwardPosition(Node):
         # Read all positions from parameters
         self.goals = []
         for name in goal_names:
-            self.declare_parameter(name)
+            self.declare_parameter(name, descriptor=ParameterDescriptor(dynamic_typing=True))
             goal = self.get_parameter(name).value
             if goal is None or len(goal) == 0:
                 raise Exception(f'Values for goal "{name}" not set!')

--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_forward_position_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_forward_position_controller.py
@@ -17,7 +17,6 @@
 
 import rclpy
 from rclpy.node import Node
-from rcl_interfaces.msg import ParameterDescriptor
 
 from std_msgs.msg import Float64MultiArray
 
@@ -38,7 +37,7 @@ class PublisherForwardPosition(Node):
         # Read all positions from parameters
         self.goals = []
         for name in goal_names:
-            self.declare_parameter(name, descriptor=ParameterDescriptor(dynamic_typing=True))
+            self.declare_parameter(name, rclpy.Parameter.Type.DOUBLE_ARRAY)
             goal = self.get_parameter(name).value
             if goal is None or len(goal) == 0:
                 raise Exception(f'Values for goal "{name}" not set!')

--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
@@ -18,7 +18,6 @@
 import rclpy
 from rclpy.node import Node
 from builtin_interfaces.msg import Duration
-from rcl_interfaces.msg import ParameterDescriptor
 
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 from sensor_msgs.msg import JointState
@@ -67,8 +66,7 @@ class PublisherJointTrajectory(Node):
         # Read all positions from parameters
         self.goals = []  # List of JointTrajectoryPoint
         for name in goal_names:
-            self.declare_parameter(name, descriptor=ParameterDescriptor(dynamic_typing=True))
-
+            self.declare_parameter(name, rclpy.Parameter.Type.DOUBLE_ARRAY)
             point = JointTrajectoryPoint()
 
             def get_sub_param(sub_param):


### PR DESCRIPTION
Updated the paramater declaration in `publisher_forward_position_controller` to resolve a deprecation warning when running the demo using  `ros2 launch ros2_control_demo_example_1 test_forward_position_controller.launch.py`.

Changes Made:
- Replaced `self.declare_parameter(name)` with `self.declare_parameter(name, descriptor=ParameterDescriptor(dynamic_typing=True))`

Fixes: #1239