### PR TITLE
fix(steering-odometry): convert twist to steering angle

### DIFF
--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -208,12 +208,9 @@ void SteeringOdometry::set_odometry_type(const unsigned int type) { config_type_
 
 double SteeringOdometry::convert_twist_to_steering_angle(double v_bx, double omega_bz)
 {
-  if (fabs(v_bx) < std::numeric_limits<float>::epsilon())
-  {
-    // avoid division by zero
-    return 0.;
-  }
-  return std::atan(omega_bz * wheelbase_ / v_bx);
+  // phi can be nan if both v_bx and omega_bz are zero
+  const auto phi = std::atan(omega_bz * wheelbase_ / v_bx);
+  return std::isfinite(phi) ? phi : 0.0;
 }
 
 std::tuple<std::vector<double>, std::vector<double>> SteeringOdometry::get_commands(


### PR DESCRIPTION
The logic in this function was incorrect, if we divide by `0.`, the input of the `atan` goes to `inf` which should result in `PI/2` instead of `0.`. What should be handled instead are `nan` values as an input of the `atan` function that can happen if we input `0./0.`.