### PR TITLE
Implement new PoseBroadcaster controller

### DIFF
--- a/doc/controllers_index.rst
+++ b/doc/controllers_index.rst
@@ -71,6 +71,7 @@ In the sense of ros2_control, broadcasters are still controllers using the same 
    IMU Sensor Broadcaster <../imu_sensor_broadcaster/doc/userdoc.rst>
    Joint State Broadcaster <../joint_state_broadcaster/doc/userdoc.rst>
    Range Sensor Broadcaster <../range_sensor_broadcaster/doc/userdoc.rst>
+   Pose Broadcaster <../pose_broadcaster/doc/userdoc.rst>
 
 
 Common Controller Parameters

--- a/pose_broadcaster/CMakeLists.txt
+++ b/pose_broadcaster/CMakeLists.txt
@@ -18,6 +18,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   rclcpp_lifecycle
   realtime_tools
+  tf2_msgs
 )
 
 find_package(ament_cmake REQUIRED)

--- a/pose_broadcaster/CMakeLists.txt
+++ b/pose_broadcaster/CMakeLists.txt
@@ -26,6 +26,10 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
 
+generate_parameter_library(pose_broadcaster_parameters
+  src/pose_broadcaster_parameters.yaml
+)
+
 add_library(pose_broadcaster SHARED
   src/pose_broadcaster.cpp
 )
@@ -35,6 +39,9 @@ target_compile_features(pose_broadcaster PUBLIC
 target_include_directories(pose_broadcaster PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+target_link_libraries(pose_broadcaster PUBLIC
+  pose_broadcaster_parameters
 )
 ament_target_dependencies(pose_broadcaster PUBLIC
     ${THIS_PACKAGE_INCLUDE_DEPENDS}
@@ -61,6 +68,7 @@ install(
 install(
   TARGETS
     pose_broadcaster
+    pose_broadcaster_parameters
   EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib

--- a/pose_broadcaster/CMakeLists.txt
+++ b/pose_broadcaster/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.16)
+project(pose_broadcaster
+  LANGUAGES
+    CXX
+)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror=conversion -Werror=unused-but-set-variable
+                      -Werror=return-type -Werror=shadow -Werror=format)
+endif()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  controller_interface
+  generate_parameter_library
+  geometry_msgs
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+  realtime_tools
+)
+
+find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
+
+add_library(pose_broadcaster SHARED
+  src/pose_broadcaster.cpp
+)
+target_compile_features(pose_broadcaster PUBLIC
+    cxx_std_17
+)
+target_include_directories(pose_broadcaster PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+ament_target_dependencies(pose_broadcaster PUBLIC
+    ${THIS_PACKAGE_INCLUDE_DEPENDS}
+)
+
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(pose_broadcaster PRIVATE "POSE_BROADCASTER_BUILDING_DLL")
+
+pluginlib_export_plugin_description_file(
+  controller_interface pose_broadcaster.xml
+)
+
+if(BUILD_TESTING)
+  #  find_package(ament_lint_auto REQUIRED)
+  #  ament_lint_auto_find_test_dependencies()
+endif()
+
+install(
+  DIRECTORY
+    include/
+  DESTINATION include/${PROJECT_NAME}
+)
+install(
+  TARGETS
+    pose_broadcaster
+  EXPORT export_${PROJECT_NAME}
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/pose_broadcaster/CMakeLists.txt
+++ b/pose_broadcaster/CMakeLists.txt
@@ -58,6 +58,7 @@ pluginlib_export_plugin_description_file(
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(controller_manager REQUIRED)
+  find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
   add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
@@ -70,6 +71,17 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_load_pose_broadcaster
     controller_manager
     ros2_control_test_assets
+  )
+
+  add_rostest_with_parameters_gmock(test_pose_broadcaster
+    test/test_pose_broadcaster.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/pose_broadcaster_params.yaml
+  )
+  target_link_libraries(test_pose_broadcaster
+    pose_broadcaster
+  )
+  ament_target_dependencies(test_pose_broadcaster
+    hardware_interface
   )
 endif()
 

--- a/pose_broadcaster/CMakeLists.txt
+++ b/pose_broadcaster/CMakeLists.txt
@@ -56,8 +56,21 @@ pluginlib_export_plugin_description_file(
 )
 
 if(BUILD_TESTING)
-  #  find_package(ament_lint_auto REQUIRED)
-  #  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gmock REQUIRED)
+  find_package(controller_manager REQUIRED)
+  find_package(ros2_control_test_assets REQUIRED)
+
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_pose_broadcaster
+    test/test_load_pose_broadcaster.cpp
+  )
+  target_link_libraries(test_load_pose_broadcaster
+    pose_broadcaster
+  )
+  ament_target_dependencies(test_load_pose_broadcaster
+    controller_manager
+    ros2_control_test_assets
+  )
 endif()
 
 install(

--- a/pose_broadcaster/README.md
+++ b/pose_broadcaster/README.md
@@ -1,0 +1,8 @@
+pose_broadcaster
+==========================================
+
+Controller to publish poses provided by pose sensors.
+
+Pluginlib-Library: pose_broadcaster
+
+Plugin: pose_broadcaster/PoseBroadcaster (controller_interface::ControllerInterface)

--- a/pose_broadcaster/doc/userdoc.rst
+++ b/pose_broadcaster/doc/userdoc.rst
@@ -1,0 +1,27 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/pose_broadcaster/doc/userdoc.rst
+
+.. _pose_broadcaster_userdoc:
+
+Pose Broadcaster
+--------------------------------
+Broadcaster for poses measured by a robot or a sensor.
+The published message type is ``geometry_msgs/msg/PoseStamped``.
+
+The controller is a wrapper around the ``PoseSensor`` semantic component (see ``controller_interface`` package).
+
+Parameters
+^^^^^^^^^^^
+This controller uses the `generate_parameter_library <https://github.com/PickNikRobotics/generate_parameter_library>`_ to handle its parameters. The parameter `definition file located in the src folder <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/pose_broadcaster/src/pose_broadcaster_parameters.yaml>`_ contains descriptions for all the parameters used by the controller.
+
+List of parameters
+=========================
+.. generate_parameter_library_details:: ../src/pose_broadcaster_parameters.yaml
+
+
+An example parameter file
+=========================
+
+An example parameter file for this controller can be found in `the test directory <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/pose_broadcaster/test/pose_broadcaster_params.yaml>`_:
+
+.. literalinclude:: ../test/pose_broadcaster_params.yaml
+   :language: yaml

--- a/pose_broadcaster/doc/userdoc.rst
+++ b/pose_broadcaster/doc/userdoc.rst
@@ -5,7 +5,7 @@
 Pose Broadcaster
 --------------------------------
 Broadcaster for poses measured by a robot or a sensor.
-The published message type is ``geometry_msgs/msg/PoseStamped``.
+Poses are published as ``geometry_msgs/msg/PoseStamped`` messages and optionally as tf transforms.
 
 The controller is a wrapper around the ``PoseSensor`` semantic component (see ``controller_interface`` package).
 

--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -14,8 +14,13 @@
 #ifndef POSE_BROADCASTER__POSE_BROADCASTER_HPP_
 #define POSE_BROADCASTER__POSE_BROADCASTER_HPP_
 
+#include <array>
+#include <memory>
+#include <string>
+
 #include "controller_interface/controller_interface.hpp"
 #include "pose_broadcaster/visibility_control.h"
+#include "pose_broadcaster_parameters.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 
 namespace pose_broadcaster
@@ -45,6 +50,10 @@ public:
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
 private:
+  std::shared_ptr<ParamListener> param_listener_;
+  Params params_;
+
+  std::array<std::string, 6> interface_names_;
 };
 
 }  // namespace pose_broadcaster

--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -20,12 +20,12 @@
 
 #include "controller_interface/controller_interface.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "geometry_msgs/msg/quaternion.hpp"
 #include "pose_broadcaster/visibility_control.h"
 #include "pose_broadcaster_parameters.hpp"
 #include "rclcpp/publisher.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 #include "realtime_tools/realtime_publisher.h"
+#include "semantic_components/pose_sensor.hpp"
 
 namespace pose_broadcaster
 {
@@ -57,7 +57,7 @@ private:
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;
 
-  std::array<std::string, 7> interface_names_;
+  std::unique_ptr<semantic_components::PoseSensor> pose_sensor_;
 
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
   std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>

--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -26,6 +26,7 @@
 #include "rclcpp_lifecycle/state.hpp"
 #include "realtime_tools/realtime_publisher.h"
 #include "semantic_components/pose_sensor.hpp"
+#include "tf2_msgs/msg/tf_message.hpp"
 
 namespace pose_broadcaster
 {
@@ -62,6 +63,10 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
   std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>
     realtime_publisher_;
+
+  rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr tf_publisher_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>>
+    realtime_tf_publisher_;
 };
 
 }  // namespace pose_broadcaster

--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -1,0 +1,52 @@
+// Copyright 2024 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef POSE_BROADCASTER__POSE_BROADCASTER_HPP_
+#define POSE_BROADCASTER__POSE_BROADCASTER_HPP_
+
+#include "controller_interface/controller_interface.hpp"
+#include "pose_broadcaster/visibility_control.h"
+#include "rclcpp_lifecycle/state.hpp"
+
+namespace pose_broadcaster
+{
+
+class PoseBroadcaster : public controller_interface::ControllerInterface
+{
+public:
+  POSE_BROADCASTER_PUBLIC controller_interface::InterfaceConfiguration
+  command_interface_configuration() const override;
+
+  POSE_BROADCASTER_PUBLIC controller_interface::InterfaceConfiguration
+  state_interface_configuration() const override;
+
+  POSE_BROADCASTER_PUBLIC controller_interface::CallbackReturn on_init() override;
+
+  POSE_BROADCASTER_PUBLIC controller_interface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  POSE_BROADCASTER_PUBLIC controller_interface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  POSE_BROADCASTER_PUBLIC controller_interface::CallbackReturn on_deactivate(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  POSE_BROADCASTER_PUBLIC controller_interface::return_type update(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+private:
+};
+
+}  // namespace pose_broadcaster
+
+#endif  // POSE_BROADCASTER__POSE_BROADCASTER_HPP_

--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -19,9 +19,13 @@
 #include <string>
 
 #include "controller_interface/controller_interface.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/quaternion.hpp"
 #include "pose_broadcaster/visibility_control.h"
 #include "pose_broadcaster_parameters.hpp"
+#include "rclcpp/publisher.hpp"
 #include "rclcpp_lifecycle/state.hpp"
+#include "realtime_tools/realtime_publisher.h"
 
 namespace pose_broadcaster
 {
@@ -50,10 +54,16 @@ public:
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
 private:
+  void setRPY(double r, double p, double y, geometry_msgs::msg::Quaternion & q) const;
+
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;
 
   std::array<std::string, 6> interface_names_;
+
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>
+    realtime_publisher_;
 };
 
 }  // namespace pose_broadcaster

--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -54,12 +54,10 @@ public:
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
 private:
-  void setRPY(double r, double p, double y, geometry_msgs::msg::Quaternion & q) const;
-
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;
 
-  std::array<std::string, 6> interface_names_;
+  std::array<std::string, 7> interface_names_;
 
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
   std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>

--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "controller_interface/controller_interface.hpp"
@@ -64,6 +65,8 @@ private:
   std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>
     realtime_publisher_;
 
+  std::optional<rclcpp::Duration> tf_publish_period_;
+  rclcpp::Time tf_last_publish_time_{0, 0, RCL_CLOCK_UNINITIALIZED};
   rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr tf_publisher_;
   std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>>
     realtime_tf_publisher_;

--- a/pose_broadcaster/include/pose_broadcaster/visibility_control.h
+++ b/pose_broadcaster/include/pose_broadcaster/visibility_control.h
@@ -1,0 +1,49 @@
+// Copyright 2024 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POSE_BROADCASTER__VISIBILITY_CONTROL_H_
+#define POSE_BROADCASTER__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define POSE_BROADCASTER_EXPORT __attribute__((dllexport))
+#define POSE_BROADCASTER_IMPORT __attribute__((dllimport))
+#else
+#define POSE_BROADCASTER_EXPORT __declspec(dllexport)
+#define POSE_BROADCASTER_IMPORT __declspec(dllimport)
+#endif
+#ifdef POSE_BROADCASTER_BUILDING_DLL
+#define POSE_BROADCASTER_PUBLIC POSE_BROADCASTER_EXPORT
+#else
+#define POSE_BROADCASTER_PUBLIC POSE_BROADCASTER_IMPORT
+#endif
+#define POSE_BROADCASTER_PUBLIC_TYPE POSE_BROADCASTER_PUBLIC
+#define POSE_BROADCASTER_LOCAL
+#else
+#define POSE_BROADCASTER_EXPORT __attribute__((visibility("default")))
+#define POSE_BROADCASTER_IMPORT
+#if __GNUC__ >= 4
+#define POSE_BROADCASTER_PUBLIC __attribute__((visibility("default")))
+#define POSE_BROADCASTER_LOCAL __attribute__((visibility("hidden")))
+#else
+#define POSE_BROADCASTER_PUBLIC
+#define POSE_BROADCASTER_LOCAL
+#endif
+#define POSE_BROADCASTER_PUBLIC_TYPE
+#endif
+
+#endif  // POSE_BROADCASTER__VISIBILITY_CONTROL_H_

--- a/pose_broadcaster/package.xml
+++ b/pose_broadcaster/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>realtime_tools</depend>
+  <depend>tf2_msgs</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>

--- a/pose_broadcaster/package.xml
+++ b/pose_broadcaster/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>pose_broadcaster</name>
+  <version>0.0.0</version>
+  <description>Broadcaster to publish cartesian states.</description>
+  <maintainer email="wilbrandt@fzi.de">Robert Wilbrandt</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>backward_ros</depend>
+  <depend>controller_interface</depend>
+  <depend>generate_parameter_library</depend>
+  <depend>geometry_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>realtime_tools</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/pose_broadcaster/package.xml
+++ b/pose_broadcaster/package.xml
@@ -19,6 +19,10 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>realtime_tools</depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>controller_manager</test_depend>
+  <test_depend>ros2_control_test_assets</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/pose_broadcaster/pose_broadcaster.xml
+++ b/pose_broadcaster/pose_broadcaster.xml
@@ -3,7 +3,7 @@
          type="pose_broadcaster::PoseBroadcaster"
          base_class_type="controller_interface::ControllerInterface">
     <description>
-      This controller publishes a Cartesian state as a geometry_msgs/PoseStamped message.
+      This controller publishes a Cartesian state as a geometry_msgs/PoseStamped message and optionally as a tf transform.
     </description>
   </class>
 </library>

--- a/pose_broadcaster/pose_broadcaster.xml
+++ b/pose_broadcaster/pose_broadcaster.xml
@@ -3,7 +3,7 @@
          type="pose_broadcaster::PoseBroadcaster"
          base_class_type="controller_interface::ControllerInterface">
     <description>
-      This controller publishes a cartesian state as a geometry_msgs/PoseStamped message.
+      This controller publishes a Cartesian state as a geometry_msgs/PoseStamped message.
     </description>
   </class>
 </library>

--- a/pose_broadcaster/pose_broadcaster.xml
+++ b/pose_broadcaster/pose_broadcaster.xml
@@ -1,0 +1,9 @@
+<library path="pose_broadcaster">
+  <class name="pose_broadcaster/PoseBroadcaster"
+         type="pose_broadcaster::PoseBroadcaster"
+         base_class_type="controller_interface::ControllerInterface">
+    <description>
+      This controller publishes a cartesian state as a geometry_msgs/PoseStamped message.
+    </description>
+  </class>
+</library>

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -1,0 +1,63 @@
+// Copyright 2024 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "pose_broadcaster/pose_broadcaster.hpp"
+
+namespace pose_broadcaster
+{
+
+controller_interface::InterfaceConfiguration PoseBroadcaster::command_interface_configuration()
+  const
+{
+  return controller_interface::InterfaceConfiguration{};
+}
+
+controller_interface::InterfaceConfiguration PoseBroadcaster::state_interface_configuration() const
+{
+  return controller_interface::InterfaceConfiguration{};
+}
+
+controller_interface::CallbackReturn PoseBroadcaster::on_init()
+{
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn PoseBroadcaster::on_configure(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn PoseBroadcaster::on_activate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn PoseBroadcaster::on_deactivate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::return_type PoseBroadcaster::update(
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  return controller_interface::return_type::OK;
+}
+
+}  // namespace pose_broadcaster
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(pose_broadcaster::PoseBroadcaster, controller_interface::ControllerInterface)

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -28,9 +28,7 @@ controller_interface::InterfaceConfiguration PoseBroadcaster::state_interface_co
 {
   controller_interface::InterfaceConfiguration state_interfaces_config;
   state_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
-  std::copy(
-    interface_names_.cbegin(), interface_names_.cend(),
-    std::back_inserter(state_interfaces_config.names));
+  state_interfaces_config.names = pose_sensor_->get_state_interface_names();
 
   return state_interfaces_config;
 }
@@ -56,47 +54,7 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
 {
   params_ = param_listener_->get_params();
 
-  const bool no_interface_names_defined =
-    params_.interface_names.position.x.empty() && params_.interface_names.position.y.empty() &&
-    params_.interface_names.position.z.empty() && params_.interface_names.orientation.x.empty() &&
-    params_.interface_names.orientation.y.empty() &&
-    params_.interface_names.orientation.z.empty() && params_.interface_names.orientation.w.empty();
-
-  if (params_.pose_name.empty() && no_interface_names_defined)
-  {
-    RCLCPP_ERROR(
-      get_node()->get_logger(),
-      "'pose_name' or 'interface_names.[position.[x|y|z]|orientation.[x|y|z|w]]' parameter has to "
-      "be "
-      "specified.");
-    return controller_interface::CallbackReturn::ERROR;
-  }
-
-  if (!params_.pose_name.empty() && !no_interface_names_defined)
-  {
-    RCLCPP_ERROR(
-      get_node()->get_logger(),
-      "'pose_name' and 'interface_names.[position.[x|y|z]|orientation.[x|y|z|w]]' parameters can "
-      "not "
-      "be specified together.");
-    return controller_interface::CallbackReturn::ERROR;
-  }
-
-  if (params_.pose_name.empty())
-  {
-    interface_names_ = {
-      params_.interface_names.position.x,    params_.interface_names.position.y,
-      params_.interface_names.position.z,    params_.interface_names.orientation.x,
-      params_.interface_names.orientation.y, params_.interface_names.orientation.z,
-      params_.interface_names.orientation.w};
-  }
-  else
-  {
-    interface_names_ = {params_.pose_name + "/position.x",    params_.pose_name + "/position.y",
-                        params_.pose_name + "/position.z",    params_.pose_name + "/orientation.x",
-                        params_.pose_name + "/orientation.y", params_.pose_name + "/orientation.z",
-                        params_.pose_name + "/orientation.w"};
-  }
+  pose_sensor_ = std::make_unique<semantic_components::PoseSensor>(params_.pose_name);
 
   try
   {
@@ -124,12 +82,14 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
 controller_interface::CallbackReturn PoseBroadcaster::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  pose_sensor_->assign_loaned_state_interfaces(state_interfaces_);
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn PoseBroadcaster::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  pose_sensor_->release_interfaces();
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
@@ -139,16 +99,7 @@ controller_interface::return_type PoseBroadcaster::update(
   if (realtime_publisher_ && realtime_publisher_->trylock())
   {
     realtime_publisher_->msg_.header.stamp = time;
-
-    realtime_publisher_->msg_.pose.position.x = state_interfaces_[0].get_value();
-    realtime_publisher_->msg_.pose.position.y = state_interfaces_[1].get_value();
-    realtime_publisher_->msg_.pose.position.z = state_interfaces_[2].get_value();
-
-    realtime_publisher_->msg_.pose.orientation.x = state_interfaces_[3].get_value();
-    realtime_publisher_->msg_.pose.orientation.y = state_interfaces_[4].get_value();
-    realtime_publisher_->msg_.pose.orientation.z = state_interfaces_[5].get_value();
-    realtime_publisher_->msg_.pose.orientation.w = state_interfaces_[6].get_value();
-
+    pose_sensor_->get_values_as_message(realtime_publisher_->msg_.pose);
     realtime_publisher_->unlockAndPublish();
   }
 

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -156,7 +156,7 @@ controller_interface::return_type PoseBroadcaster::update(
     {
       do_publish = true;
     }
-    else if (!tf_publish_period_ || (tf_last_publish_time_ + *tf_publish_period_ < time))
+    else if (!tf_publish_period_ || (tf_last_publish_time_ + *tf_publish_period_ <= time))
     {
       do_publish = true;
     }

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -74,15 +74,6 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
 
     if (params_.tf.enable)
     {
-      if (params_.tf.child_frame_id.empty())
-      {
-        fprintf(
-          stderr,
-          "Parameter tf.child_frame_id needs to be set to a non-empty value if tf publishing is "
-          "enabled");
-        return controller_interface::CallbackReturn::ERROR;
-      }
-
       tf_publisher_ = get_node()->create_publisher<tf2_msgs::msg::TFMessage>(
         DEFAULT_TF_TOPIC, rclcpp::SystemDefaultsQoS());
       realtime_tf_publisher_ =
@@ -111,7 +102,14 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
     realtime_tf_publisher_->msg_.transforms.resize(1);
     auto & tf_transform = realtime_tf_publisher_->msg_.transforms.front();
     tf_transform.header.frame_id = params_.frame_id;
-    tf_transform.child_frame_id = params_.tf.child_frame_id;
+    if (params_.tf.child_frame_id.empty())
+    {
+      tf_transform.child_frame_id = params_.pose_name;
+    }
+    else
+    {
+      tf_transform.child_frame_id = params_.tf.child_frame_id;
+    }
 
     realtime_tf_publisher_->unlock();
   }

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -13,6 +13,14 @@
 // limitations under the License.
 #include "pose_broadcaster/pose_broadcaster.hpp"
 
+namespace
+{
+
+constexpr auto DEFAULT_POSE_TOPIC = "~/pose";
+constexpr auto DEFAULT_TF_TOPIC = "/tf";
+
+}  // namespace
+
 namespace pose_broadcaster
 {
 
@@ -59,10 +67,28 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
   try
   {
     pose_publisher_ = get_node()->create_publisher<geometry_msgs::msg::PoseStamped>(
-      "~/pose", rclcpp::SystemDefaultsQoS());
+      DEFAULT_POSE_TOPIC, rclcpp::SystemDefaultsQoS());
     realtime_publisher_ =
       std::make_unique<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>(
         pose_publisher_);
+
+    if (params_.tf.enable)
+    {
+      if (params_.tf.child_frame_id.empty())
+      {
+        fprintf(
+          stderr,
+          "Parameter tf.child_frame_id needs to be set to a non-empty value if tf publishing is "
+          "enabled");
+        return controller_interface::CallbackReturn::ERROR;
+      }
+
+      tf_publisher_ = get_node()->create_publisher<tf2_msgs::msg::TFMessage>(
+        DEFAULT_TF_TOPIC, rclcpp::SystemDefaultsQoS());
+      realtime_tf_publisher_ =
+        std::make_unique<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>>(
+          tf_publisher_);
+    }
   }
   catch (const std::exception & ex)
   {
@@ -72,9 +98,23 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
     return controller_interface::CallbackReturn::ERROR;
   }
 
+  // Initialize pose message
   realtime_publisher_->lock();
   realtime_publisher_->msg_.header.frame_id = params_.frame_id;
   realtime_publisher_->unlock();
+
+  // Initialize tf message if tf publishing is enabled
+  if (realtime_tf_publisher_)
+  {
+    realtime_tf_publisher_->lock();
+
+    realtime_tf_publisher_->msg_.transforms.resize(1);
+    auto & tf_transform = realtime_tf_publisher_->msg_.transforms.front();
+    tf_transform.header.frame_id = params_.frame_id;
+    tf_transform.child_frame_id = params_.tf.child_frame_id;
+
+    realtime_tf_publisher_->unlock();
+  }
 
   return controller_interface::CallbackReturn::SUCCESS;
 }
@@ -96,11 +136,31 @@ controller_interface::CallbackReturn PoseBroadcaster::on_deactivate(
 controller_interface::return_type PoseBroadcaster::update(
   const rclcpp::Time & time, const rclcpp::Duration & /*period*/)
 {
+  geometry_msgs::msg::Pose pose;
+  pose_sensor_->get_values_as_message(pose);
+
   if (realtime_publisher_ && realtime_publisher_->trylock())
   {
     realtime_publisher_->msg_.header.stamp = time;
-    pose_sensor_->get_values_as_message(realtime_publisher_->msg_.pose);
+    realtime_publisher_->msg_.pose = pose;
     realtime_publisher_->unlockAndPublish();
+  }
+
+  if (realtime_tf_publisher_ && realtime_tf_publisher_->trylock())
+  {
+    auto & tf_transform = realtime_tf_publisher_->msg_.transforms[0];
+    tf_transform.header.stamp = time;
+
+    tf_transform.transform.translation.x = pose.position.x;
+    tf_transform.transform.translation.y = pose.position.y;
+    tf_transform.transform.translation.z = pose.position.z;
+
+    tf_transform.transform.rotation.x = pose.orientation.x;
+    tf_transform.transform.rotation.y = pose.orientation.y;
+    tf_transform.transform.rotation.z = pose.orientation.z;
+    tf_transform.transform.rotation.w = pose.orientation.w;
+
+    realtime_tf_publisher_->unlockAndPublish();
   }
 
   return controller_interface::return_type::OK;

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -19,7 +19,9 @@ namespace pose_broadcaster
 controller_interface::InterfaceConfiguration PoseBroadcaster::command_interface_configuration()
   const
 {
-  return controller_interface::InterfaceConfiguration{};
+  controller_interface::InterfaceConfiguration command_interfaces_config;
+  command_interfaces_config.type = controller_interface::interface_configuration_type::NONE;
+  return command_interfaces_config;
 }
 
 controller_interface::InterfaceConfiguration PoseBroadcaster::state_interface_configuration() const

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -63,6 +63,10 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
   params_ = param_listener_->get_params();
 
   pose_sensor_ = std::make_unique<semantic_components::PoseSensor>(params_.pose_name);
+  tf_publish_period_ =
+    params_.tf.publish_rate == 0.0
+      ? std::nullopt
+      : std::optional{rclcpp::Duration::from_seconds(1.0 / params_.tf.publish_rate)};
 
   try
   {
@@ -146,19 +150,39 @@ controller_interface::return_type PoseBroadcaster::update(
 
   if (realtime_tf_publisher_ && realtime_tf_publisher_->trylock())
   {
-    auto & tf_transform = realtime_tf_publisher_->msg_.transforms[0];
-    tf_transform.header.stamp = time;
+    bool do_publish = false;
+    // rlcpp::Time comparisons throw if clock types are not the same
+    if (tf_last_publish_time_.get_clock_type() != time.get_clock_type())
+    {
+      do_publish = true;
+    }
+    else if (!tf_publish_period_ || (tf_last_publish_time_ + *tf_publish_period_ < time))
+    {
+      do_publish = true;
+    }
 
-    tf_transform.transform.translation.x = pose.position.x;
-    tf_transform.transform.translation.y = pose.position.y;
-    tf_transform.transform.translation.z = pose.position.z;
+    if (do_publish)
+    {
+      auto & tf_transform = realtime_tf_publisher_->msg_.transforms[0];
+      tf_transform.header.stamp = time;
 
-    tf_transform.transform.rotation.x = pose.orientation.x;
-    tf_transform.transform.rotation.y = pose.orientation.y;
-    tf_transform.transform.rotation.z = pose.orientation.z;
-    tf_transform.transform.rotation.w = pose.orientation.w;
+      tf_transform.transform.translation.x = pose.position.x;
+      tf_transform.transform.translation.y = pose.position.y;
+      tf_transform.transform.translation.z = pose.position.z;
 
-    realtime_tf_publisher_->unlockAndPublish();
+      tf_transform.transform.rotation.x = pose.orientation.x;
+      tf_transform.transform.rotation.y = pose.orientation.y;
+      tf_transform.transform.rotation.z = pose.orientation.z;
+      tf_transform.transform.rotation.w = pose.orientation.w;
+
+      realtime_tf_publisher_->unlockAndPublish();
+
+      tf_last_publish_time_ = time;
+    }
+    else
+    {
+      realtime_tf_publisher_->unlock();
+    }
   }
 
   return controller_interface::return_type::OK;

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -9,7 +9,7 @@ pose_broadcaster:
     type: string
     default_value: ""
     description: "Name of the published pose used as prefix for interfaces if there are no individual interface names defined.
-      If used, standard interface names will be used: ``<pose_name>/position.x, ..., <pose_name>/orientation.y``"
+      If used, standard interface names will be used: ``<pose_name>/position.x, ..., <pose_name>/orientation.w``"
   interface_names:
     position:
       x:
@@ -25,15 +25,19 @@ pose_broadcaster:
         default_value: ""
         description: "Name of the state interface with position values along the 'z' axis"
     orientation:
-      r:
+      x:
         type: string
         default_value: ""
-        description: "Name of the state interface with roll values around 'x' axis"
-      p:
-        type: string
-        default_value: ""
-        description: "Name of the state interface with pitch values around 'y' axis"
+        description: "Name of the state interface with the quaternion orientation x component"
       y:
         type: string
         default_value: ""
-        description: "Name of the state interface with yaw values around 'z' axis"
+        description: "Name of the state interface with the quaternion orientation y component"
+      z:
+        type: string
+        default_value: ""
+        description: "Name of the state interface with the quaternion orientation z component"
+      w:
+        type: string
+        default_value: ""
+        description: "Name of the state interface with the quaternion orientation w component"

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -1,0 +1,39 @@
+pose_broadcaster:
+  frame_id:
+    type: string
+    default_value: ""
+    description: "frame_id in which values are published"
+    validation:
+      not_empty<>: null
+  pose_name:
+    type: string
+    default_value: ""
+    description: "Name of the published pose used as prefix for interfaces if there are no individual interface names defined.
+      If used, standard interface names will be used: ``<pose_name>/position.x, ..., <pose_name>/orientation.y``"
+  interface_names:
+    position:
+      x:
+        type: string
+        default_value: ""
+        description: "Name of the state interface with position values along the 'x' axis"
+      y:
+        type: string
+        default_value: ""
+        description: "Name of the state interface with position values along the 'y' axis"
+      z:
+        type: string
+        default_value: ""
+        description: "Name of the state interface with position values along the 'z' axis"
+    orientation:
+      r:
+        type: string
+        default_value: ""
+        description: "Name of the state interface with roll values around 'x' axis"
+      p:
+        type: string
+        default_value: ""
+        description: "Name of the state interface with pitch values around 'y' axis"
+      y:
+        type: string
+        default_value: ""
+        description: "Name of the state interface with yaw values around 'z' axis"

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -8,36 +8,8 @@ pose_broadcaster:
   pose_name:
     type: string
     default_value: ""
-    description: "Name of the published pose used as prefix for interfaces if there are no individual interface names defined.
-      If used, standard interface names will be used: ``<pose_name>/position.x, ..., <pose_name>/orientation.w``"
-  interface_names:
-    position:
-      x:
-        type: string
-        default_value: ""
-        description: "Name of the state interface with position values along the 'x' axis"
-      y:
-        type: string
-        default_value: ""
-        description: "Name of the state interface with position values along the 'y' axis"
-      z:
-        type: string
-        default_value: ""
-        description: "Name of the state interface with position values along the 'z' axis"
-    orientation:
-      x:
-        type: string
-        default_value: ""
-        description: "Name of the state interface with the quaternion orientation x component"
-      y:
-        type: string
-        default_value: ""
-        description: "Name of the state interface with the quaternion orientation y component"
-      z:
-        type: string
-        default_value: ""
-        description: "Name of the state interface with the quaternion orientation z component"
-      w:
-        type: string
-        default_value: ""
-        description: "Name of the state interface with the quaternion orientation w component"
+    description: "Base name used as prefix for controller interfaces.
+    The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z,
+    <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
+    validation:
+      not_empty<>: null

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -13,3 +13,13 @@ pose_broadcaster:
     <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
     validation:
       not_empty<>: null
+  tf:
+    enable:
+      type: bool
+      default_value: false
+      description: "Whether to publish the pose as a tf transform"
+    child_frame_id:
+      type: string
+      default_value: ""
+      description: "Child frame id of published tf transforms. This needs to be set if tf publishing is
+      enabled."

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -16,10 +16,10 @@ pose_broadcaster:
   tf:
     enable:
       type: bool
-      default_value: false
+      default_value: true
       description: "Whether to publish the pose as a tf transform"
     child_frame_id:
       type: string
       default_value: ""
-      description: "Child frame id of published tf transforms. This needs to be set if tf publishing is
-      enabled."
+      description: "Child frame id of published tf transforms. Defaults to ``pose_name`` if left
+      empty."

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -23,3 +23,10 @@ pose_broadcaster:
       default_value: ""
       description: "Child frame id of published tf transforms. Defaults to ``pose_name`` if left
       empty."
+    publish_rate:
+      type: double
+      default_value: 0.0
+      description: "Rate to limit publishing of tf transforms to (Hz). If set to 0, no limiting is
+      performed."
+      validation:
+        gt_eq<>: 0.0

--- a/pose_broadcaster/test/pose_broadcaster_params.yaml
+++ b/pose_broadcaster/test/pose_broadcaster_params.yaml
@@ -1,3 +1,4 @@
 test_pose_broadcaster:
   ros__parameters:
+    pose_name: "test_pose"
     frame_id: "pose_frame"

--- a/pose_broadcaster/test/pose_broadcaster_params.yaml
+++ b/pose_broadcaster/test/pose_broadcaster_params.yaml
@@ -1,0 +1,3 @@
+test_pose_broadcaster:
+  ros__parameters:
+    frame_id: "pose_frame"

--- a/pose_broadcaster/test/test_load_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_load_pose_broadcaster.cpp
@@ -1,0 +1,50 @@
+// Copyright 2024 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gmock/gmock.h>
+#include <memory>
+
+#include "controller_manager/controller_manager.hpp"
+#include "hardware_interface/resource_manager.hpp"
+#include "rclcpp/executor.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
+#include "ros2_control_test_assets/descriptions.hpp"
+
+TEST(TestLoadPoseBroadcaster, load_controller)
+{
+  std::shared_ptr<rclcpp::Executor> executor =
+    std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+  controller_manager::ControllerManager cm{
+    executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager"};
+
+  const std::string test_file_path =
+    std::string{TEST_FILES_DIRECTORY} + "/pose_broadcaster_params.yaml";
+  cm.set_parameter({"test_pose_broadcaster.params_file", test_file_path});
+
+  cm.set_parameter({"test_pose_broadcaster.type", "pose_broadcaster/PoseBroadcaster"});
+
+  ASSERT_NE(cm.load_controller("test_pose_broadcaster"), nullptr);
+}
+
+int main(int argc, char * argv[])
+{
+  ::testing::InitGoogleMock(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/pose_broadcaster/test/test_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.cpp
@@ -1,0 +1,215 @@
+// Copyright 2024 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "test_pose_broadcaster.hpp"
+
+#include <utility>
+#include <vector>
+
+#include "rclcpp/executors.hpp"
+
+using hardware_interface::LoanedStateInterface;
+
+void PoseBroadcasterTest::SetUp() { pose_broadcaster_ = std::make_unique<PoseBroadcaster>(); }
+
+void PoseBroadcasterTest::TearDown() { pose_broadcaster_.reset(nullptr); }
+
+void PoseBroadcasterTest::SetUpPoseBroadcaster()
+{
+  ASSERT_EQ(
+    pose_broadcaster_->init(
+      "test_pose_broadcaster", "", 0, "", pose_broadcaster_->define_custom_node_options()),
+    controller_interface::return_type::OK);
+
+  std::vector<LoanedStateInterface> state_interfaces;
+  state_interfaces.emplace_back(pose_position_x_);
+  state_interfaces.emplace_back(pose_position_y_);
+  state_interfaces.emplace_back(pose_position_z_);
+  state_interfaces.emplace_back(pose_orientation_x_);
+  state_interfaces.emplace_back(pose_orientation_y_);
+  state_interfaces.emplace_back(pose_orientation_z_);
+  state_interfaces.emplace_back(pose_orientation_w_);
+
+  pose_broadcaster_->assign_interfaces({}, std::move(state_interfaces));
+}
+
+void PoseBroadcasterTest::subscribe_and_get_message(geometry_msgs::msg::PoseStamped & pose_msg)
+{
+  // Create node for subscribing
+  rclcpp::Node node{"test_subscription_node"};
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node.get_node_base_interface());
+
+  // Create subscription
+  geometry_msgs::msg::PoseStamped::SharedPtr received_msg;
+  const auto msg_callback = [&](const geometry_msgs::msg::PoseStamped::SharedPtr msg)
+  { received_msg = msg; };
+  const auto subscription = node.create_subscription<geometry_msgs::msg::PoseStamped>(
+    "/test_pose_broadcaster/pose", 10, msg_callback);
+
+  // Update controller and spin until a message is received
+  // Since update doesn't guarantee a published message, republish until received
+  constexpr size_t max_sub_check_loop_count = 5;
+  for (size_t i = 0; !received_msg; ++i)
+  {
+    ASSERT_LT(i, max_sub_check_loop_count);
+
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01));
+
+    const auto timeout = std::chrono::milliseconds{5};
+    const auto until = node.get_clock()->now() + timeout;
+    while (!received_msg && node.get_clock()->now() < until)
+    {
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::microseconds{10});
+    }
+  }
+
+  pose_msg = *received_msg;
+}
+
+TEST_F(PoseBroadcasterTest, Configure_Success)
+{
+  SetUpPoseBroadcaster();
+
+  // Set 'pose_name' and 'frame_id' parameters
+  pose_broadcaster_->get_node()->set_parameter({"pose_name", pose_name_});
+  pose_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
+
+  // Configure controller
+  ASSERT_EQ(
+    pose_broadcaster_->on_configure(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+
+  // Verify command interface configuration
+  const auto command_interface_conf = pose_broadcaster_->command_interface_configuration();
+  EXPECT_EQ(command_interface_conf.type, controller_interface::interface_configuration_type::NONE);
+  EXPECT_TRUE(command_interface_conf.names.empty());
+
+  // Verify state interface configuration
+  const auto state_interface_conf = pose_broadcaster_->state_interface_configuration();
+  EXPECT_EQ(
+    state_interface_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
+  ASSERT_EQ(state_interface_conf.names.size(), 7lu);
+}
+
+TEST_F(PoseBroadcasterTest, Activate_Success)
+{
+  SetUpPoseBroadcaster();
+
+  // Set 'pose_name' and 'frame_id' parameters
+  pose_broadcaster_->get_node()->set_parameter({"pose_name", pose_name_});
+  pose_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
+
+  // Configure and activate controller
+  ASSERT_EQ(
+    pose_broadcaster_->on_configure(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    pose_broadcaster_->on_activate(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+
+  // Verify command and state interface configuration
+  {
+    const auto command_interface_conf = pose_broadcaster_->command_interface_configuration();
+    EXPECT_EQ(
+      command_interface_conf.type, controller_interface::interface_configuration_type::NONE);
+    EXPECT_TRUE(command_interface_conf.names.empty());
+
+    const auto state_interface_conf = pose_broadcaster_->state_interface_configuration();
+    EXPECT_EQ(
+      state_interface_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
+    ASSERT_EQ(state_interface_conf.names.size(), 7lu);
+  }
+
+  // Deactivate controller
+  ASSERT_EQ(
+    pose_broadcaster_->on_deactivate(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+
+  // Verify command and state interface configuration
+  {
+    const auto command_interface_conf = pose_broadcaster_->command_interface_configuration();
+    EXPECT_EQ(
+      command_interface_conf.type, controller_interface::interface_configuration_type::NONE);
+    EXPECT_TRUE(command_interface_conf.names.empty());
+
+    const auto state_interface_conf = pose_broadcaster_->state_interface_configuration();
+    EXPECT_EQ(
+      state_interface_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
+    ASSERT_EQ(state_interface_conf.names.size(), 7lu);  // Should not change when deactivating
+  }
+}
+
+TEST_F(PoseBroadcasterTest, Update_Success)
+{
+  SetUpPoseBroadcaster();
+
+  // Set 'pose_name' and 'frame_id' parameters
+  pose_broadcaster_->get_node()->set_parameter({"pose_name", pose_name_});
+  pose_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
+
+  // Configure and activate controller
+  ASSERT_EQ(
+    pose_broadcaster_->on_configure(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    pose_broadcaster_->on_activate(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+
+  ASSERT_EQ(
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+}
+
+TEST_F(PoseBroadcasterTest, PublishSuccess)
+{
+  SetUpPoseBroadcaster();
+
+  // Set 'pose_name' and 'frame_id' parameters
+  pose_broadcaster_->get_node()->set_parameter({"pose_name", pose_name_});
+  pose_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
+
+  // Configure and activate controller
+  ASSERT_EQ(
+    pose_broadcaster_->on_configure(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    pose_broadcaster_->on_activate(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+
+  // Subscribe to pose topic
+  geometry_msgs::msg::PoseStamped pose_msg;
+  subscribe_and_get_message(pose_msg);
+
+  // Verify content of pose message
+  EXPECT_EQ(pose_msg.header.frame_id, frame_id_);
+  EXPECT_EQ(pose_msg.pose.position.x, pose_values_[0]);
+  EXPECT_EQ(pose_msg.pose.position.y, pose_values_[1]);
+  EXPECT_EQ(pose_msg.pose.position.z, pose_values_[2]);
+  EXPECT_EQ(pose_msg.pose.orientation.x, pose_values_[3]);
+  EXPECT_EQ(pose_msg.pose.orientation.y, pose_values_[4]);
+  EXPECT_EQ(pose_msg.pose.orientation.z, pose_values_[5]);
+  EXPECT_EQ(pose_msg.pose.orientation.w, pose_values_[6]);
+}
+
+int main(int argc, char * argv[])
+{
+  ::testing::InitGoogleMock(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/pose_broadcaster/test/test_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.cpp
@@ -66,23 +66,6 @@ TEST_F(PoseBroadcasterTest, Configure_Success)
   ASSERT_EQ(state_interface_conf.names.size(), 7lu);
 }
 
-TEST_F(PoseBroadcasterTest, Configure_TF_ChildFrameId_NotSet)
-{
-  SetUpPoseBroadcaster();
-
-  // Set 'pose_name' and 'frame_id' parameters
-  pose_broadcaster_->get_node()->set_parameter({"pose_name", pose_name_});
-  pose_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
-
-  // Set 'tf.enable' parameter, but don't set 'tf.child_frame_id'
-  pose_broadcaster_->get_node()->set_parameter({"tf.enable", true});
-
-  // Verify that controller cannot be configured
-  ASSERT_EQ(
-    pose_broadcaster_->on_configure(rclcpp_lifecycle::State{}),
-    controller_interface::CallbackReturn::ERROR);
-}
-
 TEST_F(PoseBroadcasterTest, Activate_Success)
 {
   SetUpPoseBroadcaster();

--- a/pose_broadcaster/test/test_pose_broadcaster.hpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.hpp
@@ -1,0 +1,58 @@
+// Copyright 2024 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef TEST_POSE_BROADCASTER_HPP_
+#define TEST_POSE_BROADCASTER_HPP_
+
+#include <gmock/gmock.h>
+
+#include <array>
+#include <memory>
+#include <string>
+
+#include "pose_broadcaster/pose_broadcaster.hpp"
+
+using pose_broadcaster::PoseBroadcaster;
+
+class PoseBroadcasterTest : public ::testing::Test
+{
+public:
+  void SetUp();
+  void TearDown();
+
+  void SetUpPoseBroadcaster();
+
+protected:
+  const std::string pose_name_ = "test_pose";
+  const std::string frame_id_ = "pose_frame";
+
+  std::array<double, 7> pose_values_ = {1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7};
+
+  hardware_interface::StateInterface pose_position_x_{pose_name_, "position.x", &pose_values_[0]};
+  hardware_interface::StateInterface pose_position_y_{pose_name_, "position.x", &pose_values_[1]};
+  hardware_interface::StateInterface pose_position_z_{pose_name_, "position.x", &pose_values_[2]};
+  hardware_interface::StateInterface pose_orientation_x_{
+    pose_name_, "orientation.x", &pose_values_[3]};
+  hardware_interface::StateInterface pose_orientation_y_{
+    pose_name_, "orientation.y", &pose_values_[4]};
+  hardware_interface::StateInterface pose_orientation_z_{
+    pose_name_, "orientation.z", &pose_values_[5]};
+  hardware_interface::StateInterface pose_orientation_w_{
+    pose_name_, "orientation.w", &pose_values_[6]};
+
+  std::unique_ptr<PoseBroadcaster> pose_broadcaster_;
+
+  void subscribe_and_get_message(geometry_msgs::msg::PoseStamped & pose_msg);
+};
+
+#endif  // TEST_POSE_BROADCASTER_HPP_


### PR DESCRIPTION
This PR implements a new broadcasting controller based on the `PoseSensor` semantic component introduced in https://github.com/ros-controls/ros2_control/pull/1775.

As described in the `PoseSensor` PR, my primary use-case for this is the publishing of tcp poses from robot arms. This can be more accurate than calculating forward kinematics, as robot calibrations etc. can be considered by the robot. Settings on the robot side concerning tool offsets etc. can also be included by this (at least for UR and kuka RSI). The ROS 1 `ur_robot_driver` used to publish this transform directly from within the hardware interface, but in ROS 2 there is not yet a standard way for providing this information. A PR for the UR ROS 2 driver already exists at https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1108.

This controller publishes poses directly as `geometry_msgs::msg::PoseStamped`s and as tf transforms (can be disabled).