### PR TITLE
Fix Windows Compilation Issues in joint_trajectory_controller and pid_controller (master branch)

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -133,7 +133,7 @@ double resolve_tolerance_source(const double default_value, const double goal_va
   // * -1 - The tolerance is "erased".
   //        If there was a default, the joint will be allowed to move without restriction.
   constexpr double ERASE_VALUE = -1.0;
-  auto is_erase_value = [](double value)
+  auto is_erase_value = [=](double value)
   { return fabs(value - ERASE_VALUE) < std::numeric_limits<float>::epsilon(); };
 
   if (goal_value > 0.0)

--- a/pid_controller/CMakeLists.txt
+++ b/pid_controller/CMakeLists.txt
@@ -5,6 +5,16 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   add_compile_options(-Wall -Wextra -Werror=conversion -Werror=unused-but-set-variable -Werror=return-type -Werror=shadow -Werror=format)
 endif()
 
+if(WIN32)
+  add_compile_definitions(
+    # For math constants
+    _USE_MATH_DEFINES
+    # Minimize Windows namespace collision
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+  )
+endif()
+
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   angles
   control_msgs


### PR DESCRIPTION
### Description:
This pull request addresses compilation issues encountered in the `joint_trajectory_controller` and `pid_controller` when building on Windows. The changes ensure compatibility with the Windows environment and improve overall stability.

### Changes Made:
- **joint_trajectory_controller**: 
  - Modifies the lambda capture in is_erase_value from [ ] to [=], which captures all outer scope variables by value.

- **pid_controller**:
  - Added compile definitions for Windows to minimize namespace collisions and define math constants:
    ```cmake
    if(WIN32)
      add_compile_definitions(
        # For math constants
        _USE_MATH_DEFINES
        # Minimize Windows namespace collision
        NOMINMAX
        WIN32_LEAN_AND_MEAN
      )
    endif()
    ```

### Testing:
- Local tests have been run successfully, confirming that all modifications do not break existing functionality.

Please let me know if you have any questions or need further modifications. I appreciate your feedback!