### PR TITLE
Add hardware_interface_testing dependency

### DIFF
--- a/pose_broadcaster/package.xml
+++ b/pose_broadcaster/package.xml
@@ -22,6 +22,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>


### PR DESCRIPTION
Was necessary and already included in #1326 and #1327, don't know why this succeeded on jazzy/rolling without.