### PR TITLE
[JTC] Fix the JTC length_error exceptions in the tests

### DIFF
--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -26,6 +26,7 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "joint_trajectory_controller/joint_trajectory_controller.hpp"
 #include "joint_trajectory_controller/tolerances.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
 namespace

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -392,7 +392,7 @@ public:
     return traj_controller_->get_node()->activate();
   }
 
-  rclcpp_lifecycle::State DeactivateTrajectoryController()
+  void DeactivateTrajectoryController()
   {
     if (traj_controller_)
     {
@@ -400,12 +400,9 @@ public:
         traj_controller_->get_lifecycle_state().id() ==
         lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
       {
-        const auto new_state = traj_controller_->get_node()->deactivate();
-        EXPECT_EQ(new_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
-        return new_state;
+        traj_controller_->get_node()->deactivate();
       }
     }
-    return traj_controller_->get_lifecycle_state();
   }
 
   static void TearDownTestCase() { rclcpp::shutdown(); }

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -400,7 +400,9 @@ public:
         traj_controller_->get_lifecycle_state().id() ==
         lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
       {
-        traj_controller_->get_node()->deactivate();
+        EXPECT_EQ(
+          traj_controller_->get_node()->deactivate().id(),
+          lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
       }
     }
   }

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -391,6 +391,22 @@ public:
     return traj_controller_->get_node()->activate();
   }
 
+  rclcpp_lifecycle::State DeactivateTrajectoryController()
+  {
+    if (traj_controller_)
+    {
+      if (
+        traj_controller_->get_lifecycle_state().id() ==
+        lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+      {
+        const auto new_state = traj_controller_->get_node()->deactivate();
+        EXPECT_EQ(new_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+        return new_state;
+      }
+    }
+    return traj_controller_->get_lifecycle_state();
+  }
+
   static void TearDownTestCase() { rclcpp::shutdown(); }
 
   void subscribeToState(rclcpp::Executor & executor)
@@ -775,6 +791,8 @@ public:
     command_interface_types_ = std::get<0>(GetParam());
     state_interface_types_ = std::get<1>(GetParam());
   }
+
+  virtual void TearDown() { TrajectoryControllerTest::DeactivateTrajectoryController(); }
 
   static void TearDownTestCase() { TrajectoryControllerTest::TearDownTestCase(); }
 };


### PR DESCRIPTION
Fix the exception in JTC tests from time to time 

````
     [INFO] [1730930292.973865185] [test_joint_trajectory_controller]: Using 'splines' interpolation method.
    [INFO] [1730930292.974352669] [test_joint_trajectory_controller]: Action status changes will be monitored at 20.00 Hz.
    terminate called after throwing an instance of 'std::length_error'
      what():  basic_string::_M_create
````

https://github.com/ros-controls/ros2_controllers/actions/runs/11712509515/job/32623343057?pr=1297