### PR TITLE
Update maintainers and add url tags

### DIFF
--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -4,10 +4,17 @@
   <name>ackermann_steering_controller</name>
   <version>4.16.0</version>
   <description>Steering controller for Ackermann kinematics. Rear fixed wheels are powering the vehicle and front wheels are steering it.</description>
-  <license>Apache License 2.0</license>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</maintainer>
-  <maintainer email="tomislav.petkovic.fer@gmail.com">dr. sc. Tomislav Petkovic</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
   <author email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</author>
   <author email="tomislav.petkovic.fer@gmail.com">dr. sc. Tomislav Petkovic</author>

--- a/admittance_controller/package.xml
+++ b/admittance_controller/package.xml
@@ -4,10 +4,21 @@
   <name>admittance_controller</name>
   <version>4.16.0</version>
   <description>Implementation of admittance controllers for different input and output interface.</description>
-  <maintainer email="denis@stogl.de">Denis Štogl</maintainer>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="zelenak@picknik.ai">Andy Zelenak</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="denis@stogl.de">Denis Štogl</author>
+  <author email="zelenak@picknik.ai">Andy Zelenak</author>
+  <author email="paulgesel@gmail.com">Paul Gesel</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/bicycle_steering_controller/package.xml
+++ b/bicycle_steering_controller/package.xml
@@ -4,10 +4,17 @@
   <name>bicycle_steering_controller</name>
   <version>4.16.0</version>
   <description>Steering controller with bicycle kinematics. Rear fixed wheel is powering the vehicle and front wheel is steering.</description>
-  <license>Apache License 2.0</license>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</maintainer>
-  <maintainer email="tomislav.petkovic.fer@gmail.com">dr. sc. Tomislav Petkovic</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
   <author email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</author>
   <author email="tomislav.petkovic.fer@gmail.com">dr. sc. Tomislav Petkovic</author>

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -15,9 +15,10 @@
   <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
   <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
-  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <author email="bence.magyar.robotics@gmail.com">Bence Magyar</author>
   <author>Enrique Fernández</author>
   <author>Manuel Meraz</author>
+  <author email="jordan.palacios@pal-robotics.com">Jordan Palacios</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>generate_parameter_library</build_depend>

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -2,11 +2,22 @@
 <package format="3">
   <name>diff_drive_controller</name>
   <version>4.16.0</version>
-  <description>Controller for a differential drive mobile base.</description>
+  <description>Controller for a differential-drive mobile base.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="jordan.palacios@pal-robotics.com">Jordan Palacios</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <author>Enrique Fernández</author>
+  <author>Manuel Meraz</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>generate_parameter_library</build_depend>

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -3,10 +3,19 @@
   <name>effort_controllers</name>
   <version>4.16.0</version>
   <description>Generic controller for forwarding commands.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="jordan.palacios@pal-robotics.com">Jordan Palacios</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="jordan.palacios@pal-robotics.com">Jordan Palacios</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/force_torque_sensor_broadcaster/package.xml
+++ b/force_torque_sensor_broadcaster/package.xml
@@ -4,10 +4,20 @@
   <name>force_torque_sensor_broadcaster</name>
   <version>4.16.0</version>
   <description>Controller to publish state of force-torque sensors.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="denis@stogl.de">Denis Štogl</maintainer>
-  <maintainer email="subhas.robotics@gmail.com">Subhas Das</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="denis@stogl.de">Denis Štogl</author>
+  <author email="subhas.robotics@gmail.com">Subhas Das</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/forward_command_controller/package.xml
+++ b/forward_command_controller/package.xml
@@ -3,10 +3,19 @@
   <name>forward_command_controller</name>
   <version>4.16.0</version>
   <description>Generic controller for forwarding commands.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="jordan.palacios@pal-robotics.com">Jordan Palacios</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="jordan.palacios@pal-robotics.com">Jordan Palacios</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/gripper_controllers/package.xml
+++ b/gripper_controllers/package.xml
@@ -6,11 +6,20 @@
   <name>gripper_controllers</name>
   <version>4.16.0</version>
   <description>The gripper_controllers package</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
 
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>
+  <author email="cafer.abdi@gmail.com">Jafar Abdi</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/imu_sensor_broadcaster/package.xml
+++ b/imu_sensor_broadcaster/package.xml
@@ -4,10 +4,19 @@
   <name>imu_sensor_broadcaster</name>
   <version>4.16.0</version>
   <description>Controller to publish readings of IMU sensors.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="denis@stogl.de">Denis Štogl</maintainer>
-  <maintainer email="victor.lopez@pal-robotics.com">Victor Lopez</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="victor.lopez@pal-robotics.com">Victor Lopez</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/joint_state_broadcaster/package.xml
+++ b/joint_state_broadcaster/package.xml
@@ -3,12 +3,20 @@
   <name>joint_state_broadcaster</name>
   <version>4.16.0</version>
   <description>Broadcaster to publish joint state</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="denis@stogl.de">Denis Stogl</maintainer>
-  <maintainer email="jordan.palacios@pal-robotics.com">Jordan Palacios</maintainer>
-  <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="jordan.palacios@pal-robotics.com">Jordan Palacios</author>
+  <author email="karsten@openrobotics.org">Karsten Knese</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -3,11 +3,17 @@
   <name>joint_trajectory_controller</name>
   <version>4.16.0</version>
   <description>Controller for executing joint-space trajectories on a group of joints</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="denis.stogl@stoglrobotics.de">Dr. Denis Štogl</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
   <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/parallel_gripper_controller/package.xml
+++ b/parallel_gripper_controller/package.xml
@@ -6,11 +6,20 @@
   <name>parallel_gripper_controller</name>
   <version>4.16.0</version>
   <description>The parallel_gripper_controller package</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
 
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>
+  <author email="paulgesel@gmail.com">Paul Gesel</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/pid_controller/package.xml
+++ b/pid_controller/package.xml
@@ -4,10 +4,19 @@
   <name>pid_controller</name>
   <version>4.16.0</version>
   <description>Controller based on PID implememenation from control_toolbox package.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="denis.stogl@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
   <author email="denis.stogl@stoglrobotics.de">Denis Štogl</author>
-  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/pose_broadcaster/package.xml
+++ b/pose_broadcaster/package.xml
@@ -4,9 +4,19 @@
   <name>pose_broadcaster</name>
   <version>4.16.0</version>
   <description>Broadcaster to publish cartesian states.</description>
-  <maintainer email="wilbrandt@fzi.de">Robert Wilbrandt</maintainer>
+
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="wilbrandt@fzi.de">Robert Wilbrandt</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/position_controllers/package.xml
+++ b/position_controllers/package.xml
@@ -3,10 +3,19 @@
   <name>position_controllers</name>
   <version>4.16.0</version>
   <description>Generic controller for forwarding commands.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="jordan.palacios@pal-robotics.com">Jordan Palacios</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="jordan.palacios@pal-robotics.com">Jordan Palacios</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/range_sensor_broadcaster/package.xml
+++ b/range_sensor_broadcaster/package.xml
@@ -3,10 +3,20 @@
 <package format="3">
   <name>range_sensor_broadcaster</name>
   <version>4.16.0</version>
-  <description>Controller to publish readings of Range sensors.</description>
+  <description>Controller to publish readings of range sensors.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <author email="flopubs@gmail.com">Florent Chretien</author>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="flopubs@gmail.com">Florent Chretien</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/ros2_controllers/package.xml
+++ b/ros2_controllers/package.xml
@@ -2,13 +2,18 @@
 <package format="3">
   <name>ros2_controllers</name>
   <version>4.16.0</version>
-  <description>Metapackage for ROS2 controllers related packages</description>
+  <description>Metapackage for ros2_controllers related packages</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="jordan.palacios@pal-robotics.com">Jordan Palacios</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
 
   <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/ros2_controllers_test_nodes/package.xml
+++ b/ros2_controllers_test_nodes/package.xml
@@ -5,10 +5,16 @@
   <version>4.16.0</version>
   <description>Demo nodes for showing and testing functionalities of the ros2_control framework.</description>
 
-  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
-  <license>Apache-2.0</license>
+  <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
   <depend>rclpy</depend>
   <depend>std_msgs</depend>

--- a/rqt_joint_trajectory_controller/package.xml
+++ b/rqt_joint_trajectory_controller/package.xml
@@ -8,8 +8,15 @@
   <description>Graphical frontend for interacting with joint_trajectory_controller instances.</description>
 
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
-  <license>Apache-2.0</license>
+  <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
   <author email="adolfo.rodriguez@pal-robotics.com">Adolfo Rodriguez Tsouroukdissian</author>
   <author email="noel.jimenez@pal-robotics.com">Noel Jimenez Garcia</author>

--- a/steering_controllers_library/package.xml
+++ b/steering_controllers_library/package.xml
@@ -4,11 +4,17 @@
   <name>steering_controllers_library</name>
   <version>4.16.0</version>
   <description>Package for steering robot configurations including odometry and interfaces.</description>
-  <license>Apache License 2.0</license>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</maintainer>
-  <maintainer email="tomislav.petkovic.fer@gmail.com">dr. sc. Tomislav Petkovic</maintainer>
-  <maintainer email="tony.najjar@logivations.com">Tony Najjar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
   <author email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</author>
   <author email="tomislav.petkovic.fer@gmail.com">dr. sc. Tomislav Petkovic</author>

--- a/tricycle_controller/package.xml
+++ b/tricycle_controller/package.xml
@@ -4,9 +4,18 @@
   <name>tricycle_controller</name>
   <version>4.16.0</version>
   <description>Controller for a tricycle drive mobile base</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="tony.najjar@logivations.com">Tony Najjar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
   <author email="tony.najjar@logivations.com">Tony Najjar</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/tricycle_steering_controller/package.xml
+++ b/tricycle_steering_controller/package.xml
@@ -4,11 +4,17 @@
   <name>tricycle_steering_controller</name>
   <version>4.16.0</version>
   <description>Steering controller with tricycle kinematics. Rear fixed wheels are powering the vehicle and front wheel is steering.</description>
-  <license>Apache License 2.0</license>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</maintainer>
-  <maintainer email="tomislav.petkovic.fer@gmail.com">dr. sc. Tomislav Petkovic</maintainer>
-  <maintainer email="tony.najjar@logivations.com">Tony Najjar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
   <author email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</author>
   <author email="tomislav.petkovic.fer@gmail.com">dr. sc. Tomislav Petkovic</author>

--- a/velocity_controllers/package.xml
+++ b/velocity_controllers/package.xml
@@ -3,10 +3,19 @@
   <name>velocity_controllers</name>
   <version>4.16.0</version>
   <description>Generic controller for forwarding commands.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
-  <maintainer email="jordan.palacios@pal-robotics.com">Jordan Palacios</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="jordan.palacios@pal-robotics.com">Jordan Palacios</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
The contents of the package.xml get parsed for index.ros.org, so I thought it might be worth updating them.

- Update the current maintainers
- Where possible, I added the original authors as `<author>`
- add url tags, but only to github and control.ros.org homepage. The direct links to the controllers have the ROS distro in the URL, that would soon become outdated.