### PR TITLE
 Add compatibility build for humble+jazzy distro

### DIFF
--- a/.github/workflows/humble-semi-binary-build.yml
+++ b/.github/workflows/humble-semi-binary-build.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_REPO: [main, testing]
+        ROS_REPO: [testing]
     with:
       ros_distro: humble
       ros_repo: ${{ matrix.ROS_REPO }}

--- a/.github/workflows/iron-semi-binary-build.yml
+++ b/.github/workflows/iron-semi-binary-build.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_REPO: [main, testing]
+        ROS_REPO: [testing]
     with:
       ros_distro: iron
       ros_repo: ${{ matrix.ROS_REPO }}

--- a/.github/workflows/jazzy-semi-binary-build.yml
+++ b/.github/workflows/jazzy-semi-binary-build.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_REPO: [main, testing]
+        ROS_REPO: [testing]
     with:
       ros_distro: jazzy
       ros_repo: ${{ matrix.ROS_REPO }}

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -32,9 +32,6 @@ on:
       - '**/package.xml'
       - '**/CMakeLists.txt'
       - 'ros2_controllers.rolling.repos'
-  schedule:
-    # Run every morning to detect flakiness and broken dependencies
-    - cron: '33 1 * * *'
 
 jobs:
   build-on-humble:
@@ -43,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         ROS_DISTRO: [humble]
-        ROS_REPO: [main, testing]
+        ROS_REPO: [testing]
     with:
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: ${{ matrix.ROS_REPO }}

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -1,0 +1,51 @@
+name: Check Rolling Compatibility on Humble
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+# description: 'Build & test the rolling version on Humble distro.'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - '*feature*'
+      - '*feature/**'
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/rolling-compatibility-humble-binary-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros2_controllers.rolling.repos'
+  push:
+    branches:
+      - master
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/rolling-compatibility-humble-binary-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros2_controllers.rolling.repos'
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '33 1 * * *'
+
+jobs:
+  build-on-humble:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [humble]
+        ROS_REPO: [main, testing]
+    with:
+      ros_distro: ${{ matrix.ROS_DISTRO }}
+      ros_repo: ${{ matrix.ROS_REPO }}
+      upstream_workspace: ros2_controllers.rolling.repos
+      ref_for_scheduled_build: master

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -1,0 +1,51 @@
+name: Check Rolling Compatibility on Jazzy
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+# description: 'Build & test the rolling version on Jazzy distro.'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - '*feature*'
+      - '*feature/**'
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/rolling-compatibility-jazzy-binary-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros2_controllers.rolling.repos'
+  push:
+    branches:
+      - master
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/rolling-compatibility-jazzy-binary-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros2_controllers.rolling.repos'
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '33 1 * * *'
+
+jobs:
+  build-on-jazzy:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [jazzy]
+        ROS_REPO: [main, testing]
+    with:
+      ros_distro: ${{ matrix.ROS_DISTRO }}
+      ros_repo: ${{ matrix.ROS_REPO }}
+      upstream_workspace: ros2_controllers.rolling.repos
+      ref_for_scheduled_build: master

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -32,9 +32,6 @@ on:
       - '**/package.xml'
       - '**/CMakeLists.txt'
       - 'ros2_controllers.rolling.repos'
-  schedule:
-    # Run every morning to detect flakiness and broken dependencies
-    - cron: '33 1 * * *'
 
 jobs:
   build-on-jazzy:
@@ -43,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         ROS_DISTRO: [jazzy]
-        ROS_REPO: [main, testing]
+        ROS_REPO: [testing]
     with:
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: ${{ matrix.ROS_REPO }}

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_REPO: [main, testing]
+        ROS_REPO: [testing]
     with:
       ros_distro: rolling
       ros_repo: ${{ matrix.ROS_REPO }}


### PR DESCRIPTION
Similar to https://github.com/ros-controls/ros2_control/pull/1872 and https://github.com/ros-controls/ros2_control/pull/1876

plus

- remove main repo on semi-binary and compatibility tests
- remove scheduled nightly build on the compatibility -> we have that on ros2_control_ci repo