### PR TITLE
test_nodes: catch keyboard interrupt and add simple launch tests

### DIFF
--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_forward_position_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_forward_position_controller.py
@@ -68,9 +68,16 @@ def main(args=None):
 
     publisher_forward_position = PublisherForwardPosition()
 
-    rclpy.spin(publisher_forward_position)
-    publisher_forward_position.destroy_node()
-    rclpy.shutdown()
+    try:
+        rclpy.spin(publisher_forward_position)
+    except KeyboardInterrupt:
+        print("Keyboard interrupt received. Shutting down node.")
+    except Exception as e:
+        print(f"Unhandled exception: {e}")
+    finally:
+        if rclpy.ok():
+            publisher_forward_position.destroy_node()
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
@@ -184,9 +184,16 @@ def main(args=None):
 
     publisher_joint_trajectory = PublisherJointTrajectory()
 
-    rclpy.spin(publisher_joint_trajectory)
-    publisher_joint_trajectory.destroy_node()
-    rclpy.shutdown()
+    try:
+        rclpy.spin(publisher_joint_trajectory)
+    except KeyboardInterrupt:
+        print("Keyboard interrupt received. Shutting down node.")
+    except Exception as e:
+        print(f"Unhandled exception: {e}")
+    finally:
+        if rclpy.ok():
+            publisher_joint_trajectory.destroy_node()
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/ros2_controllers_test_nodes/setup.py
+++ b/ros2_controllers_test_nodes/setup.py
@@ -25,8 +25,7 @@ setup(
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),
-        ("share/" + package_name, glob("launch/*.launch.py")),
-        ("share/" + package_name + "/configs", glob("configs/*.*")),
+        ("share/" + package_name + "/test", glob("test/*.yaml")),
     ],
     install_requires=["setuptools"],
     zip_safe=True,

--- a/ros2_controllers_test_nodes/test/rrbot_forward_position_publisher.yaml
+++ b/ros2_controllers_test_nodes/test/rrbot_forward_position_publisher.yaml
@@ -1,0 +1,11 @@
+publisher_forward_position_controller:
+  ros__parameters:
+
+    wait_sec_between_publish: 5
+    publish_topic: "/forward_position_controller/commands"
+
+    goal_names: ["pos1", "pos2", "pos3", "pos4"]
+    pos1: [0.785, 0.785]
+    pos2: [0.0, 0.0]
+    pos3: [-0.785, -0.785]
+    pos4: [0.0, 0.0]

--- a/ros2_controllers_test_nodes/test/rrbot_joint_trajectory_publisher.yaml
+++ b/ros2_controllers_test_nodes/test/rrbot_joint_trajectory_publisher.yaml
@@ -1,0 +1,24 @@
+publisher_joint_trajectory_controller:
+  ros__parameters:
+
+    controller_name: "joint_trajectory_position_controller"
+    wait_sec_between_publish: 6
+
+    goal_names: ["pos1", "pos2", "pos3", "pos4"]
+    pos1:
+      positions: [0.785, 0.785]
+    pos2:
+      positions: [0.0, 0.0]
+    pos3:
+      positions: [-0.785, -0.785]
+    pos4:
+      positions: [0.0, 0.0]
+
+    joints:
+      - joint1
+      - joint2
+
+    check_starting_point: false
+    starting_point_limits:
+      joint1: [-0.1,0.1]
+      joint2: [-0.1,0.1]

--- a/ros2_controllers_test_nodes/test/rrbot_joint_trajectory_publisher.yaml
+++ b/ros2_controllers_test_nodes/test/rrbot_joint_trajectory_publisher.yaml
@@ -1,4 +1,4 @@
-publisher_joint_trajectory_controller:
+publisher_position_trajectory_controller:
   ros__parameters:
 
     controller_name: "joint_trajectory_position_controller"

--- a/ros2_controllers_test_nodes/test/test_publisher_forward_position_controller_launch.py
+++ b/ros2_controllers_test_nodes/test/test_publisher_forward_position_controller_launch.py
@@ -36,11 +36,14 @@ from launch import LaunchDescription
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 from launch_testing.actions import ReadyToTest
+from launch_testing_ros import WaitForTopics
 
 import launch_testing.markers
 import rclpy
 import launch_ros.actions
 from rclpy.node import Node
+
+from std_msgs.msg import Float64MultiArray
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -85,10 +88,19 @@ class TestFixture(unittest.TestCase):
             time.sleep(0.1)
         assert found, "publisher_forward_position_controller not found!"
 
+    def test_check_if_topic_published(self):
+        topic = "/forward_position_controller/commands"
+        wait_for_topics = WaitForTopics([(topic, Float64MultiArray)], timeout=20.0)
+        assert wait_for_topics.wait(), f"Topic '{topic}' not found!"
+        msgs = wait_for_topics.received_messages(topic)
+        msg = msgs[0]
+        assert len(msg.data) == 2, "Wrong number of joints in message"
+        wait_for_topics.shutdown()
+
 
 @launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# These tests are run after the processes in generate_test_description() have shut down.
+class TestPublisherShutdown(unittest.TestCase):
 
     def test_exit_codes(self, proc_info):
         """Check if the processes exited normally."""

--- a/ros2_controllers_test_nodes/test/test_publisher_forward_position_controller_launch.py
+++ b/ros2_controllers_test_nodes/test/test_publisher_forward_position_controller_launch.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import pytest
+import unittest
+import time
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+from launch_testing.actions import ReadyToTest
+
+import launch_testing.markers
+import rclpy
+import launch_ros.actions
+from rclpy.node import Node
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.launch_test
+def generate_test_description():
+
+    params = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_controllers_test_nodes"),
+            "test",
+            "rrbot_forward_position_publisher.yaml",
+        ]
+    )
+
+    pub_node = launch_ros.actions.Node(
+        package="ros2_controllers_test_nodes",
+        executable="publisher_forward_position_controller",
+        parameters=[params],
+        output="both",
+    )
+
+    return LaunchDescription([pub_node, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "publisher_forward_position_controller" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "publisher_forward_position_controller not found!"
+
+
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
+++ b/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
@@ -81,9 +81,9 @@ class TestFixture(unittest.TestCase):
         start = time.time()
         found = False
         while time.time() - start < 2.0 and not found:
-            found = "/publisher_position_trajectory_controller" in self.node.get_node_names()
+            found = "publisher_position_trajectory_controller" in self.node.get_node_names()
             time.sleep(0.1)
-        assert found, "/publisher_position_trajectory_controller not found!"
+        assert found, "publisher_position_trajectory_controller not found!"
 
 
 @launch_testing.post_shutdown_test()

--- a/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
+++ b/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import pytest
+import unittest
+import time
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+from launch_testing.actions import ReadyToTest
+
+import launch_testing.markers
+import rclpy
+import launch_ros.actions
+from rclpy.node import Node
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.launch_test
+def generate_test_description():
+
+    params = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_controllers_test_nodes"),
+            "test",
+            "rrbot_joint_trajectory_publisher.yaml",
+        ]
+    )
+
+    pub_node = launch_ros.actions.Node(
+        package="ros2_controllers_test_nodes",
+        executable="publisher_joint_trajectory_controller",
+        parameters=[params],
+        output="both",
+    )
+
+    return LaunchDescription([pub_node, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "/publisher_position_trajectory_controller" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "/publisher_position_trajectory_controller not found!"
+
+
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
+++ b/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
@@ -88,7 +88,7 @@ class TestFixture(unittest.TestCase):
         assert found, "publisher_position_trajectory_controller not found!"
 
     def test_check_if_topic_published(self):
-        topic = "/position_trajectory_controller/joint_trajectory"
+        topic = "/joint_trajectory_position_controller/joint_trajectory"
         wait_for_topics = WaitForTopics([(topic, JointTrajectory)], timeout=20.0)
         assert wait_for_topics.wait(), f"Topic '{topic}' not found!"
         msgs = wait_for_topics.received_messages(topic)


### PR DESCRIPTION
When the test nodes are shut down by ctrl-c keyboard interrupt we see this verbose console output

```
    [publisher_forward_position_controller-15] Traceback (most recent call last):
    [publisher_forward_position_controller-15]   File "/home/runner/work/ros2_control_demos/ros2_control_demos/.work/upstream_ws/install/ros2_controllers_test_nodes/lib/ros2_controllers_test_nodes/publisher_forward_position_controller", line 33, in <module>
    [publisher_forward_position_controller-15]     sys.exit(load_entry_point('ros2-controllers-test-nodes==3.28.0', 'console_scripts', 'publisher_forward_position_controller')())
    [publisher_forward_position_controller-15]   File "/home/runner/work/ros2_control_demos/ros2_control_demos/.work/upstream_ws/install/ros2_controllers_test_nodes/lib/python3.10/site-packages/ros2_controllers_test_nodes/publisher_forward_position_controller.py", line 71, in main
    [publisher_forward_position_controller-15]     rclpy.spin(publisher_forward_position)
    [publisher_forward_position_controller-15]   File "/opt/ros/iron/lib/python3.10/site-packages/rclpy/__init__.py", line 228, in spin
    [publisher_forward_position_controller-15]     executor.spin_once()
    [publisher_forward_position_controller-15]   File "/opt/ros/iron/lib/python3.10/site-packages/rclpy/executors.py", line 787, in spin_once
    [publisher_forward_position_controller-15]     self._spin_once_impl(timeout_sec)
    [publisher_forward_position_controller-15]   File "/opt/ros/iron/lib/python3.10/site-packages/rclpy/executors.py", line 776, in _spin_once_impl
    [publisher_forward_position_controller-15]     handler, entity, node = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
    [publisher_forward_position_controller-15]   File "/opt/ros/iron/lib/python3.10/site-packages/rclpy/executors.py", line 762, in wait_for_ready_callbacks
    [publisher_forward_position_controller-15]     return next(self._cb_iter)
    [publisher_forward_position_controller-15]   File "/opt/ros/iron/lib/python3.10/site-packages/rclpy/executors.py", line 666, in _wait_for_ready_callbacks
    [publisher_forward_position_controller-15]     wait_set.wait(timeout_nsec)
    [publisher_forward_position_controller-15] KeyboardInterrupt
```

With the proposed changes, we get a nice 
```
 $ ros2 run ros2_controllers_test_nodes publisher_forward_position_controller --ros-args --params-file src/ros2_control_demos/example_1/bringup/config/rrbot_forward_position_publisher.yaml 
[INFO] [1731859611.015984561] [publisher_forward_position_controller]: Publishing 4 goals on topic '/forward_position_controller/commands' every 5 s'
[INFO] [1731859616.018749700] [publisher_forward_position_controller]: Publishing: "array('d', [0.785, 0.785])"
^CKeyboard interrupt received. Shutting down node.
```