### PR TITLE
Add missing deps for test_nodes

### DIFF
--- a/ros2_controllers_test_nodes/package.xml
+++ b/ros2_controllers_test_nodes/package.xml
@@ -21,6 +21,8 @@
   <depend>trajectory_msgs</depend>
 
   <test_depend>python3-pytest</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>launch_ros</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2_controllers_test_nodes/test/test_publisher_forward_position_controller_launch.py
+++ b/ros2_controllers_test_nodes/test/test_publisher_forward_position_controller_launch.py
@@ -34,11 +34,11 @@ import time
 
 from launch import LaunchDescription
 from launch.substitutions import PathJoinSubstitution
-from launch_ros.substitutions import FindPackageShare
 import launch_ros.actions
+from launch_ros.substitutions import FindPackageShare
 from launch_testing.actions import ReadyToTest
-from launch_testing_ros import WaitForTopics
 import launch_testing.markers
+from launch_testing_ros import WaitForTopics
 import rclpy
 from rclpy.node import Node
 from std_msgs.msg import Float64MultiArray

--- a/ros2_controllers_test_nodes/test/test_publisher_forward_position_controller_launch.py
+++ b/ros2_controllers_test_nodes/test/test_publisher_forward_position_controller_launch.py
@@ -35,14 +35,12 @@ import time
 from launch import LaunchDescription
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
+import launch_ros.actions
 from launch_testing.actions import ReadyToTest
 from launch_testing_ros import WaitForTopics
-
 import launch_testing.markers
 import rclpy
-import launch_ros.actions
 from rclpy.node import Node
-
 from std_msgs.msg import Float64MultiArray
 
 

--- a/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
+++ b/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
@@ -35,12 +35,11 @@ import time
 from launch import LaunchDescription
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
+import launch_ros.actions
 from launch_testing.actions import ReadyToTest
 from launch_testing_ros import WaitForTopics
-
 import launch_testing.markers
 import rclpy
-import launch_ros.actions
 from rclpy.node import Node
 from trajectory_msgs.msg import JointTrajectory
 

--- a/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
+++ b/ros2_controllers_test_nodes/test/test_publisher_joint_trajectory_controller_launch.py
@@ -34,11 +34,11 @@ import time
 
 from launch import LaunchDescription
 from launch.substitutions import PathJoinSubstitution
-from launch_ros.substitutions import FindPackageShare
 import launch_ros.actions
+from launch_ros.substitutions import FindPackageShare
 from launch_testing.actions import ReadyToTest
-from launch_testing_ros import WaitForTopics
 import launch_testing.markers
+from launch_testing_ros import WaitForTopics
 import rclpy
 from rclpy.node import Node
 from trajectory_msgs.msg import JointTrajectory


### PR DESCRIPTION
Closes https://github.com/ros-controls/ros2_controllers/issues/1377


```
2024-11-20T04:17:11.0314151Z     from launch_ros.substitutions import FindPackageShare
2024-11-20T04:17:11.0315851Z E   ModuleNotFoundError: No module named 'launch_ros'
2024-11-20T04:17:11.0318975Z - generated xml file: /__w/ros2_controllers/ros2_controllers/ros_ws/build/ros2_controllers_test_nodes/pytest.xml -
```