### PR TITLE
test_nodes: Add another dependency

### DIFF
--- a/ros2_controllers_test_nodes/package.xml
+++ b/ros2_controllers_test_nodes/package.xml
@@ -17,6 +17,7 @@
   <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
 
   <depend>rclpy</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>trajectory_msgs</depend>
 


### PR DESCRIPTION
idk why this ever worked before. (this was not added with my latest tests but was there already before).

```
2024-11-22T11:04:00.2715563Z     from sensor_msgs.msg import JointState
2024-11-22T11:04:00.2716343Z ModuleNotFoundError: No module named 'sensor_msgs'
```

Closes #1375 (different error, but will fail tonight https://github.com/ros-controls/ros2_controllers/actions/workflows/jazzy-source-build.yml)