### PR TITLE
fix jerk limiter in diff_drive_controller

### DIFF
--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -123,7 +123,7 @@ double SpeedLimiter::limit_jerk(double & v, double v0, double v1, double dt)
     const double dv = v - v0;
     const double dv0 = v0 - v1;
 
-    const double dt2 = 2. * dt * dt;
+    const double dt2 = dt * dt;
 
     const double da_min = min_jerk_ * dt2;
     const double da_max = max_jerk_ * dt2;


### PR DESCRIPTION
There seem to be an error in the jerk limiter ([speed_limiter.cpp#L117-L134](https://github.com/ros-controls/ros2_controllers/blob/9b344c7b5c06879b85cd4bcc135e35b5f7eedc2f/diff_drive_controller/src/speed_limiter.cpp#L117-L134)) caused by the (as far as I can tell) incorrect factor 2 in the computation of the velocity limit resulting from jerk limits.

The consequence is an overshoot of the configured jerk limit.
To illustrate the effect of this factor, let us set the linear jerk limit as $J_{max} = 20 \text{ m.s}^{-3}$ such that
```yaml
diffbot_base_controller:
  ros__parameters:
    type: diff_drive_controller/DiffDriveController
    ...

    # Velocity and acceleration limits
    # Whenever a min_* is unspecified, default to -max_*
    linear.x.has_velocity_limits: true
    linear.x.has_acceleration_limits: true
    linear.x.has_jerk_limits: true
    linear.x.max_velocity: 1.0
    linear.x.min_velocity: -1.0
    linear.x.max_acceleration: 2.0
    linear.x.min_acceleration: -5.0
    linear.x.max_jerk: 20.0
    linear.x.min_jerk: -20.0

    ...
```

Before this PR, the jerk reaches $40 \text{ m.s}^{-3}$:
![diif_drive_current](https://github.com/user-attachments/assets/86337dbb-8a1e-4028-90ac-99defc3ac374)


After this PR:
![diif_drive_new](https://github.com/user-attachments/assets/ca2a88e8-cb38-474d-b15f-b2ec0ee2a9f3)
