### PR TITLE
Add explicit cast to period.count()

### DIFF
--- a/gripper_controllers/include/gripper_controllers/hardware_interface_adapter.hpp
+++ b/gripper_controllers/include/gripper_controllers/hardware_interface_adapter.hpp
@@ -165,7 +165,8 @@ public:
     // Time since the last call to update
     const auto period = std::chrono::steady_clock::now() - last_update_time_;
     // Update PIDs
-    double command = pid_->computeCommand(error_position, error_velocity, period.count());
+    double command =
+      pid_->computeCommand(error_position, error_velocity, static_cast<uint64_t>(period.count()));
     command = std::min<double>(
       fabs(max_allowed_effort), std::max<double>(-fabs(max_allowed_effort), command));
     joint_handle_->get().set_value(command);


### PR DESCRIPTION
[period.count()](https://en.cppreference.com/w/cpp/chrono/duration/count) does not return an integer. 
Fails with changes from https://github.com/ros-controls/control_toolbox/pull/239 otherwise.