### PR TITLE
[CI] Add clang job and setup concurrency

### DIFF
--- a/.github/workflows/humble-abi-compatibility.yml
+++ b/.github/workflows/humble-abi-compatibility.yml
@@ -15,6 +15,11 @@ on:
       - '**/CMakeLists.txt'
       - 'ros2_controllers-not-released.humble.repos'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on humble branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'humble' }}
+
 jobs:
   abi_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/humble-abi-compatibility.yml
+++ b/.github/workflows/humble-abi-compatibility.yml
@@ -18,7 +18,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on humble branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'humble' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -51,14 +51,3 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_controllers-not-released.humble.repos
       ref_for_scheduled_build: humble
-  binary_clang:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
-    with:
-      ros_distro: humble
-      ros_repo: testing
-      upstream_workspace: ros2_controllers-not-released.humble.repos
-      ref_for_scheduled_build: humble
-      additional_debs: clang
-      c_compiler: clang
-      cxx_compiler: clang++
-      not_test_build: true

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -46,3 +46,14 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_controllers-not-released.humble.repos
       ref_for_scheduled_build: humble
+  binary_clang:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: humble
+      ros_repo: testing
+      upstream_workspace: ros2_controllers-not-released.humble.repos
+      ref_for_scheduled_build: humble
+      additional_debs: clang
+      c_compiler: clang
+      cxx_compiler: clang++
+      not_test_build: true

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -37,7 +37,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on humble branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'humble' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -34,6 +34,11 @@ on:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on humble branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'humble' }}
+
 jobs:
   binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master

--- a/.github/workflows/humble-check-docs.yml
+++ b/.github/workflows/humble-check-docs.yml
@@ -10,6 +10,10 @@ on:
       - '**.md'
       - '**.yaml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-docs:
     name: Check Docs

--- a/.github/workflows/humble-coverage-build.yml
+++ b/.github/workflows/humble-coverage-build.yml
@@ -33,7 +33,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on humble branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'humble' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   coverage_humble:

--- a/.github/workflows/humble-coverage-build.yml
+++ b/.github/workflows/humble-coverage-build.yml
@@ -30,6 +30,11 @@ on:
       - '**/CMakeLists.txt'
       - 'ros2_controllers.humble.repos'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on humble branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'humble' }}
+
 jobs:
   coverage_humble:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -21,7 +21,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on humble branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'humble' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   humble_debian:

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -18,6 +18,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on humble branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'humble' }}
 
 jobs:
   humble_debian:

--- a/.github/workflows/humble-pre-commit.yml
+++ b/.github/workflows/humble-pre-commit.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - humble
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-pre-commit.yml@master

--- a/.github/workflows/humble-rhel-semi-binary-build.yml
+++ b/.github/workflows/humble-rhel-semi-binary-build.yml
@@ -21,7 +21,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on humble branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'humble' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   humble_rhel_binary:

--- a/.github/workflows/humble-rhel-semi-binary-build.yml
+++ b/.github/workflows/humble-rhel-semi-binary-build.yml
@@ -18,6 +18,11 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on humble branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'humble' }}
+
 jobs:
   humble_rhel_binary:
     name: Humble RHEL binary build

--- a/.github/workflows/humble-semi-binary-build.yml
+++ b/.github/workflows/humble-semi-binary-build.yml
@@ -50,3 +50,14 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_controllers.humble.repos
       ref_for_scheduled_build: humble
+  semi_binary_clang:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: humble
+      ros_repo: testing
+      upstream_workspace: ros2_controllers-not-released.humble.repos
+      ref_for_scheduled_build: humble
+      additional_debs: clang
+      c_compiler: clang
+      cxx_compiler: clang++
+      not_test_build: true

--- a/.github/workflows/humble-semi-binary-build.yml
+++ b/.github/workflows/humble-semi-binary-build.yml
@@ -36,7 +36,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on humble branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'humble' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   semi_binary:

--- a/.github/workflows/humble-semi-binary-build.yml
+++ b/.github/workflows/humble-semi-binary-build.yml
@@ -33,6 +33,11 @@ on:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '33 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on humble branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'humble' }}
+
 jobs:
   semi_binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master

--- a/.github/workflows/humble-semi-binary-build.yml
+++ b/.github/workflows/humble-semi-binary-build.yml
@@ -41,13 +41,9 @@ concurrency:
 jobs:
   semi_binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_REPO: [testing]
     with:
       ros_distro: humble
-      ros_repo: ${{ matrix.ROS_REPO }}
+      ros_repo: testing
       upstream_workspace: ros2_controllers.humble.repos
       ref_for_scheduled_build: humble
   semi_binary_clang:

--- a/.github/workflows/jazzy-abi-compatibility.yml
+++ b/.github/workflows/jazzy-abi-compatibility.yml
@@ -14,6 +14,11 @@ on:
       - '**/CMakeLists.txt'
       - 'ros2_controllers-not-released.jazzy.repos'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   abi_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/jazzy-abi-compatibility.yml
+++ b/.github/workflows/jazzy-abi-compatibility.yml
@@ -17,7 +17,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -38,7 +38,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -35,6 +35,11 @@ on:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -52,14 +52,3 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_controllers-not-released.jazzy.repos
       ref_for_scheduled_build: master
-  binary_clang:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
-    with:
-      ros_distro: jazzy
-      ros_repo: testing
-      upstream_workspace: ros2_controllers-not-released.jazzy.repos
-      ref_for_scheduled_build: jazzy
-      additional_debs: clang
-      c_compiler: clang
-      cxx_compiler: clang++
-      not_test_build: true

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -47,3 +47,14 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_controllers-not-released.jazzy.repos
       ref_for_scheduled_build: master
+  binary_clang:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: jazzy
+      ros_repo: testing
+      upstream_workspace: ros2_controllers-not-released.jazzy.repos
+      ref_for_scheduled_build: jazzy
+      additional_debs: clang
+      c_compiler: clang
+      cxx_compiler: clang++
+      not_test_build: true

--- a/.github/workflows/jazzy-check-docs.yml
+++ b/.github/workflows/jazzy-check-docs.yml
@@ -10,6 +10,10 @@ on:
       - '**.md'
       - '**.yaml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-docs:
     name: Check Docs

--- a/.github/workflows/jazzy-coverage-build.yml
+++ b/.github/workflows/jazzy-coverage-build.yml
@@ -33,6 +33,11 @@ on:
   #     - '**/CMakeLists.txt'
   #     - 'ros2_controllers.jazzy.repos'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   coverage_jazzy:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master

--- a/.github/workflows/jazzy-coverage-build.yml
+++ b/.github/workflows/jazzy-coverage-build.yml
@@ -36,7 +36,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   coverage_jazzy:

--- a/.github/workflows/jazzy-debian-build.yml
+++ b/.github/workflows/jazzy-debian-build.yml
@@ -21,7 +21,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   jazzy_debian:

--- a/.github/workflows/jazzy-debian-build.yml
+++ b/.github/workflows/jazzy-debian-build.yml
@@ -18,6 +18,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
 
 jobs:
   jazzy_debian:

--- a/.github/workflows/jazzy-pre-commit.yml
+++ b/.github/workflows/jazzy-pre-commit.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-pre-commit.yml@master

--- a/.github/workflows/jazzy-rhel-semi-binary-build.yml
+++ b/.github/workflows/jazzy-rhel-semi-binary-build.yml
@@ -21,7 +21,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   jazzy_rhel:

--- a/.github/workflows/jazzy-rhel-semi-binary-build.yml
+++ b/.github/workflows/jazzy-rhel-semi-binary-build.yml
@@ -18,6 +18,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
 
 jobs:
   jazzy_rhel:

--- a/.github/workflows/jazzy-semi-binary-build.yml
+++ b/.github/workflows/jazzy-semi-binary-build.yml
@@ -35,6 +35,11 @@ on:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '33 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   semi_binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master

--- a/.github/workflows/jazzy-semi-binary-build.yml
+++ b/.github/workflows/jazzy-semi-binary-build.yml
@@ -43,13 +43,9 @@ concurrency:
 jobs:
   semi_binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_REPO: [testing]
     with:
       ros_distro: jazzy
-      ros_repo: ${{ matrix.ROS_REPO }}
+      ros_repo: testing
       upstream_workspace: ros2_controllers.jazzy.repos
       ref_for_scheduled_build: master
   semi_binary_clang:

--- a/.github/workflows/jazzy-semi-binary-build.yml
+++ b/.github/workflows/jazzy-semi-binary-build.yml
@@ -38,7 +38,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   semi_binary:

--- a/.github/workflows/jazzy-semi-binary-build.yml
+++ b/.github/workflows/jazzy-semi-binary-build.yml
@@ -52,3 +52,14 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_controllers.jazzy.repos
       ref_for_scheduled_build: master
+  semi_binary_clang:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: jazzy
+      ros_repo: testing
+      upstream_workspace: ros2_controllers.jazzy.repos
+      ref_for_scheduled_build: jazzy
+      additional_debs: clang
+      c_compiler: clang
+      cxx_compiler: clang++
+      not_test_build: true

--- a/.github/workflows/rolling-abi-compatibility.yml
+++ b/.github/workflows/rolling-abi-compatibility.yml
@@ -14,6 +14,11 @@ on:
       - '**/CMakeLists.txt'
       - 'ros2_controllers-not-released.rolling.repos'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   abi_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rolling-abi-compatibility.yml
+++ b/.github/workflows/rolling-abi-compatibility.yml
@@ -17,7 +17,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -48,3 +48,14 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_controllers-not-released.rolling.repos
       ref_for_scheduled_build: master
+  binary_clang:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: rolling
+      ros_repo: testing
+      upstream_workspace: ros2_controllers-not-released.rolling.repos
+      ref_for_scheduled_build: rolling
+      additional_debs: clang
+      c_compiler: clang
+      cxx_compiler: clang++
+      not_test_build: true

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -53,14 +53,3 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_controllers-not-released.rolling.repos
       ref_for_scheduled_build: master
-  binary_clang:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
-    with:
-      ros_distro: rolling
-      ros_repo: testing
-      upstream_workspace: ros2_controllers-not-released.rolling.repos
-      ref_for_scheduled_build: rolling
-      additional_debs: clang
-      c_compiler: clang
-      cxx_compiler: clang++
-      not_test_build: true

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -39,7 +39,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -36,6 +36,11 @@ on:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master

--- a/.github/workflows/rolling-check-docs.yml
+++ b/.github/workflows/rolling-check-docs.yml
@@ -11,6 +11,10 @@ on:
       - '**.yaml'
       - '.github/workflows/rolling-check-docs.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-docs:
     name: Check Docs

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -36,7 +36,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   build-on-humble:

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -33,6 +33,11 @@ on:
       - '**/CMakeLists.txt'
       - 'ros2_controllers.rolling.repos'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   build-on-humble:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -41,13 +41,8 @@ concurrency:
 jobs:
   build-on-humble:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_DISTRO: [humble]
-        ROS_REPO: [testing]
     with:
-      ros_distro: ${{ matrix.ROS_DISTRO }}
-      ros_repo: ${{ matrix.ROS_REPO }}
+      ros_distro: humble
+      ros_repo: testing
       upstream_workspace: ros2_controllers.rolling.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -41,13 +41,8 @@ concurrency:
 jobs:
   build-on-jazzy:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_DISTRO: [jazzy]
-        ROS_REPO: [testing]
     with:
-      ros_distro: ${{ matrix.ROS_DISTRO }}
-      ros_repo: ${{ matrix.ROS_REPO }}
+      ros_distro: jazzy
+      ros_repo: testing
       upstream_workspace: ros2_controllers.rolling.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -36,7 +36,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   build-on-jazzy:

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -33,6 +33,11 @@ on:
       - '**/CMakeLists.txt'
       - 'ros2_controllers.rolling.repos'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   build-on-jazzy:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master

--- a/.github/workflows/rolling-coverage-build.yml
+++ b/.github/workflows/rolling-coverage-build.yml
@@ -33,7 +33,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   coverage_rolling:

--- a/.github/workflows/rolling-coverage-build.yml
+++ b/.github/workflows/rolling-coverage-build.yml
@@ -30,6 +30,11 @@ on:
       - '**/CMakeLists.txt'
       - 'ros2_controllers.rolling.repos'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   coverage_rolling:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -18,6 +18,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
 
 jobs:
   rolling_debian:

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -21,7 +21,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   rolling_debian:

--- a/.github/workflows/rolling-pre-commit.yml
+++ b/.github/workflows/rolling-pre-commit.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-pre-commit.yml@master

--- a/.github/workflows/rolling-rhel-semi-binary-build.yml
+++ b/.github/workflows/rolling-rhel-semi-binary-build.yml
@@ -21,7 +21,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   rolling_rhel:

--- a/.github/workflows/rolling-rhel-semi-binary-build.yml
+++ b/.github/workflows/rolling-rhel-semi-binary-build.yml
@@ -18,6 +18,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
 
 jobs:
   rolling_rhel:

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -43,13 +43,9 @@ concurrency:
 jobs:
   semi_binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_REPO: [testing]
     with:
       ros_distro: rolling
-      ros_repo: ${{ matrix.ROS_REPO }}
+      ros_repo: testing
       upstream_workspace: ros2_controllers.rolling.repos
       ref_for_scheduled_build: master
   semi_binary_clang:

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -35,6 +35,11 @@ on:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '33 1 * * *'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'master' }}
+
 jobs:
   semi_binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -38,7 +38,7 @@ on:
 concurrency:
   # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'master' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
 
 jobs:
   semi_binary:

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -52,3 +52,14 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_controllers.rolling.repos
       ref_for_scheduled_build: master
+  semi_binary_clang:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: rolling
+      ros_repo: testing
+      upstream_workspace: ros2_controllers.rolling.repos
+      ref_for_scheduled_build: rolling
+      additional_debs: clang
+      c_compiler: clang
+      cxx_compiler: clang++
+      not_test_build: true

--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -8,6 +8,9 @@ on:
       - ros2_controllers/rosdoc2.yaml
       - ros2_controllers/package.xml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/admittance_controller/include/admittance_controller/admittance_rule.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_rule.hpp
@@ -63,10 +63,11 @@ struct AdmittanceState
     mass_inv.setZero();
     stiffness.setZero();
     selected_axes.setZero();
-    current_joint_pos = Eigen::VectorXd::Zero(num_joints);
-    joint_pos = Eigen::VectorXd::Zero(num_joints);
-    joint_vel = Eigen::VectorXd::Zero(num_joints);
-    joint_acc = Eigen::VectorXd::Zero(num_joints);
+    auto idx = static_cast<Eigen::Index>(num_joints);
+    current_joint_pos = Eigen::VectorXd::Zero(idx);
+    joint_pos = Eigen::VectorXd::Zero(idx);
+    joint_vel = Eigen::VectorXd::Zero(idx);
+    joint_acc = Eigen::VectorXd::Zero(idx);
   }
 
   Eigen::VectorXd current_joint_pos;

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -304,7 +304,7 @@ controller_interface::CallbackReturn AdmittanceController::on_activate(
   {
     auto it =
       std::find(allowed_interface_types_.begin(), allowed_interface_types_.end(), interface);
-    auto index = std::distance(allowed_interface_types_.begin(), it);
+    auto index = static_cast<size_t>(std::distance(allowed_interface_types_.begin(), it));
     if (!controller_interface::get_ordered_interfaces(
           state_interfaces_, admittance_->parameters_.joints, interface,
           joint_state_interface_[index]))
@@ -319,7 +319,7 @@ controller_interface::CallbackReturn AdmittanceController::on_activate(
   {
     auto it =
       std::find(allowed_interface_types_.begin(), allowed_interface_types_.end(), interface);
-    auto index = std::distance(allowed_interface_types_.begin(), it);
+    auto index = static_cast<size_t>(std::distance(allowed_interface_types_.begin(), it));
     if (!controller_interface::get_ordered_interfaces(
           command_interfaces_, command_joint_names_, interface, joint_command_interface_[index]))
     {

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -292,7 +292,7 @@ controller_interface::CallbackReturn DiffDriveController::on_configure(
   const double right_wheel_radius = params_.right_wheel_radius_multiplier * params_.wheel_radius;
 
   odometry_.setWheelParams(wheel_separation, left_wheel_radius, right_wheel_radius);
-  odometry_.setVelocityRollingWindowSize(params_.velocity_rolling_window_size);
+  odometry_.setVelocityRollingWindowSize(static_cast<size_t>(params_.velocity_rolling_window_size));
 
   cmd_vel_timeout_ = std::chrono::milliseconds{static_cast<int>(params_.cmd_vel_timeout * 1000.0)};
   publish_limited_velocity_ = params_.publish_limited_velocity;

--- a/forward_command_controller/test/test_load_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_load_forward_command_controller.cpp
@@ -30,7 +30,7 @@ TEST(TestLoadForwardCommandController, load_controller)
     std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
   controller_manager::ControllerManager cm(
-    executor, ros2_control_test_assets::minimal_robot_urdf, "test_controller_manager");
+    executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
 
   ASSERT_NE(
     cm.load_controller(

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -1091,10 +1091,10 @@ void JointStateBroadcasterTest::test_published_dynamic_joint_state_message(
     ASSERT_THAT(
       dynamic_joint_state_msg->interface_values[i].interface_names,
       ElementsAreArray(INTERFACE_NAMES));
-    const auto index_in_original_order = std::distance(
+    const auto index_in_original_order = static_cast<size_t>(std::distance(
       joint_names_.cbegin(),
       std::find(
-        joint_names_.cbegin(), joint_names_.cend(), dynamic_joint_state_msg->joint_names[i]));
+        joint_names_.cbegin(), joint_names_.cend(), dynamic_joint_state_msg->joint_names[i])));
     ASSERT_THAT(
       dynamic_joint_state_msg->interface_values[i].values,
       Each(joint_values_[index_in_original_order]));

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -199,7 +199,7 @@ SegmentTolerances get_segment_tolerances(
           .c_str());
       return default_tolerances;
     }
-    auto i = std::distance(joints.cbegin(), it);
+    auto i = static_cast<size_t>(std::distance(joints.cbegin(), it));
     std::string interface = "";
     try
     {

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -246,7 +246,7 @@ SegmentTolerances get_segment_tolerances(
           .c_str());
       return default_tolerances;
     }
-    auto i = std::distance(joints.cbegin(), it);
+    auto i = static_cast<size_t>(std::distance(joints.cbegin(), it));
     std::string interface = "";
     try
     {

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -206,8 +206,8 @@ inline std::vector<size_t> mapping(const T & t1, const T & t2)
     }
     else
     {
-      const size_t t1_dist = std::distance(t1.begin(), t1_it);
-      const size_t t2_dist = std::distance(t2.begin(), t2_it);
+      const size_t t1_dist = static_cast<size_t>(std::distance(t1.begin(), t1_it));
+      const size_t t2_dist = static_cast<size_t>(std::distance(t2.begin(), t2_it));
       mapping_vector[t1_dist] = t2_dist;
     }
   }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -907,7 +907,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
   {
     auto it =
       std::find(allowed_interface_types_.begin(), allowed_interface_types_.end(), interface);
-    auto index = std::distance(allowed_interface_types_.begin(), it);
+    auto index = static_cast<size_t>(std::distance(allowed_interface_types_.begin(), it));
     if (!controller_interface::get_ordered_interfaces(
           command_interfaces_, command_joint_names_, interface, joint_command_interface_[index]))
     {
@@ -921,7 +921,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
   {
     auto it =
       std::find(allowed_interface_types_.begin(), allowed_interface_types_.end(), interface);
-    auto index = std::distance(allowed_interface_types_.begin(), it);
+    auto index = static_cast<size_t>(std::distance(allowed_interface_types_.begin(), it));
     if (!controller_interface::get_ordered_interfaces(
           state_interfaces_, params_.joints, interface, joint_state_interface_[index]))
     {

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -385,7 +385,7 @@ controller_interface::return_type JointTrajectoryController::update(
             rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
             rt_has_pending_goal_.writeFromNonRT(false);
 
-            RCLCPP_WARN(logger, error_string.c_str());
+            RCLCPP_WARN(logger, "%s", error_string.c_str());
 
             traj_msg_external_point_ptr_.reset();
             traj_msg_external_point_ptr_.initRT(set_hold_position());

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -175,8 +175,8 @@ bool Trajectory::sample(
 
         interpolate_between_points(t0, point, t1, next_point, sample_time, output_state);
       }
-      start_segment_itr = begin() + static_cast<std::ptrdiff_t>(i);
-      end_segment_itr = begin() + static_cast<std::ptrdiff_t>(i + 1);
+      start_segment_itr = begin() + static_cast<TrajectoryPointConstIter::difference_type>(i);
+      end_segment_itr = begin() + static_cast<TrajectoryPointConstIter::difference_type>(i + 1);
       if (search_monotonically_increasing)
       {
         last_sample_idx_ = i;

--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -175,8 +175,8 @@ bool Trajectory::sample(
 
         interpolate_between_points(t0, point, t1, next_point, sample_time, output_state);
       }
-      start_segment_itr = begin() + i;
-      end_segment_itr = begin() + (i + 1);
+      start_segment_itr = begin() + static_cast<std::ptrdiff_t>(i);
+      end_segment_itr = begin() + static_cast<std::ptrdiff_t>(i + 1);
       if (search_monotonically_increasing)
       {
         last_sample_idx_ = i;

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -467,7 +467,8 @@ public:
     if (joint_names.empty())
     {
       traj_msg.joint_names = {
-        joint_names_.begin(), joint_names_.begin() + points_positions[0].size()};
+        joint_names_.begin(),
+        joint_names_.begin() + static_cast<std::ptrdiff_t>(points_positions[0].size())};
     }
     else
     {

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -468,7 +468,8 @@ public:
     {
       traj_msg.joint_names = {
         joint_names_.begin(),
-        joint_names_.begin() + static_cast<std::ptrdiff_t>(points_positions[0].size())};
+        joint_names_.begin() +
+          static_cast<std::vector<std::string>::difference_type>(points_positions[0].size())};
     }
     else
     {

--- a/pid_controller/src/pid_controller.cpp
+++ b/pid_controller/src/pid_controller.cpp
@@ -320,7 +320,7 @@ void PidController::reference_callback(const std::shared_ptr<ControllerReference
         break;
       }
 
-      auto position = std::distance(ref_msg->dof_names.begin(), found_it);
+      auto position = static_cast<size_t>(std::distance(ref_msg->dof_names.begin(), found_it));
       ref_msg->values[position] = msg->values[i];
       ref_msg->values_dot[position] = msg->values_dot[i];
     }

--- a/ros2_controllers.humble.repos
+++ b/ros2_controllers.humble.repos
@@ -6,7 +6,7 @@ repositories:
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
-    version: master
+    version: humble
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git

--- a/ros2_controllers.jazzy.repos
+++ b/ros2_controllers.jazzy.repos
@@ -14,7 +14,7 @@ repositories:
   control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
-    version: ci/clang
+    version: ros2-master
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git

--- a/ros2_controllers.jazzy.repos
+++ b/ros2_controllers.jazzy.repos
@@ -2,7 +2,7 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: master
+    version: ci/clang
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git

--- a/ros2_controllers.jazzy.repos
+++ b/ros2_controllers.jazzy.repos
@@ -14,7 +14,7 @@ repositories:
   control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
-    version: ros2-master
+    version: ci/clang
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git

--- a/ros2_controllers.jazzy.repos
+++ b/ros2_controllers.jazzy.repos
@@ -2,7 +2,7 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: ci/clang
+    version: master
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git

--- a/ros2_controllers.rolling.repos
+++ b/ros2_controllers.rolling.repos
@@ -14,7 +14,7 @@ repositories:
   control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
-    version: ci/clang
+    version: ros2-master
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git

--- a/ros2_controllers.rolling.repos
+++ b/ros2_controllers.rolling.repos
@@ -2,7 +2,7 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: master
+    version: ci/clang
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git

--- a/ros2_controllers.rolling.repos
+++ b/ros2_controllers.rolling.repos
@@ -14,7 +14,7 @@ repositories:
   control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
-    version: ros2-master
+    version: ci/clang
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git

--- a/ros2_controllers.rolling.repos
+++ b/ros2_controllers.rolling.repos
@@ -2,7 +2,7 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: ci/clang
+    version: master
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git

--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -81,7 +81,8 @@ controller_interface::CallbackReturn SteeringControllersLibrary::on_configure(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
   params_ = param_listener_->get_params();
-  odometry_.set_velocity_rolling_window_size(params_.velocity_rolling_window_size);
+  odometry_.set_velocity_rolling_window_size(
+    static_cast<size_t>(params_.velocity_rolling_window_size));
 
   configure_odometry();
 

--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -204,7 +204,10 @@ void SteeringOdometry::set_velocity_rolling_window_size(size_t velocity_rolling_
   reset_accumulators();
 }
 
-void SteeringOdometry::set_odometry_type(const unsigned int type) { config_type_ = type; }
+void SteeringOdometry::set_odometry_type(const unsigned int type)
+{
+  config_type_ = static_cast<int>(type);
+}
 
 double SteeringOdometry::convert_twist_to_steering_angle(double v_bx, double omega_bz)
 {

--- a/tricycle_controller/src/tricycle_controller.cpp
+++ b/tricycle_controller/src/tricycle_controller.cpp
@@ -236,7 +236,7 @@ CallbackReturn TricycleController::on_configure(const rclcpp_lifecycle::State & 
   }
 
   odometry_.setWheelParams(params_.wheelbase, params_.wheel_radius);
-  odometry_.setVelocityRollingWindowSize(params_.velocity_rolling_window_size);
+  odometry_.setVelocityRollingWindowSize(static_cast<size_t>(params_.velocity_rolling_window_size));
 
   cmd_vel_timeout_ = std::chrono::milliseconds{params_.cmd_vel_timeout};
   params_.publish_ackermann_command =


### PR DESCRIPTION
- This adds a semi-binary job using clang. I fixed all what clang was complaining about.
- use humble branch of realtime_tools for humble CI

Additionally, I added the concurrency settings which now automatically cancel running workflows if anything is pushed to PRs.
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs