### PR TITLE
Add missing dependency to gpio_controllers

### DIFF
--- a/gpio_controllers/package.xml
+++ b/gpio_controllers/package.xml
@@ -4,9 +4,20 @@
   <name>gpio_controllers</name>
   <version>4.15.0</version>
   <description>Controllers to interact with gpios.</description>
-  <maintainer email="macbednarczyk@gmail.com">Maciej Bednarczyk</maintainer>
-  <maintainer email="wiktorbajor1@gmail.com">Wiktor Bajor</maintainer>
+
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
   <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="macbednarczyk@gmail.com">Maciej Bednarczyk</author>
+  <author email="wiktorbajor1@gmail.com">Wiktor Bajor</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/gpio_controllers/package.xml
+++ b/gpio_controllers/package.xml
@@ -22,6 +22,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>


### PR DESCRIPTION
Some tests were failing in the backport https://github.com/ros-controls/ros2_controllers/pull/1372 due to a missing test dependency.

I also updated the maintainers in the package.xml

@mergifyio backport mergify/bp/humble/pr-1251