### PR TITLE
[CI] Add downstream jobs

### DIFF
--- a/.github/workflows/humble-semi-binary-downstream-build.yml
+++ b/.github/workflows/humble-semi-binary-downstream-build.yml
@@ -17,24 +17,10 @@ on:
       - '**/package.xml'
       - '**/CMakeLists.txt'
       - 'ros_controls.humble.repos'
-  push:
-    branches:
-      - humble
-    paths:
-      - '**.hpp'
-      - '**.h'
-      - '**.cpp'
-      - '**.py'
-      - '**.yaml'
-      - '.github/workflows/humble-semi-binary-downstream-build.yml'
-      - '**/package.xml'
-      - '**/CMakeLists.txt'
-      - 'ros_controls.humble.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: true
 
 jobs:
   build-downstream:

--- a/.github/workflows/humble-semi-binary-downstream-build.yml
+++ b/.github/workflows/humble-semi-binary-downstream-build.yml
@@ -45,7 +45,5 @@ jobs:
       # we don't test this repository, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization
-      downstream_workspace: |
-        ros_controls.humble.repos
-        downstream.humble.repos
+      downstream_workspace: downstream.humble.repos
       not_test_downstream: true

--- a/.github/workflows/humble-semi-binary-downstream-build.yml
+++ b/.github/workflows/humble-semi-binary-downstream-build.yml
@@ -1,0 +1,49 @@
+name: Humble Downstream Build
+# description: 'Build & test downstream packages from source.'
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - humble
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/humble-semi-binary-downstream-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros_controls.humble.repos'
+  push:
+    branches:
+      - humble
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/humble-semi-binary-downstream-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros_controls.humble.repos'
+
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on humble branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+
+jobs:
+  build-downstream:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: humble
+      ros_repo: testing
+      ref_for_scheduled_build: master
+      not_test_build: true
+      upstream_workspace: ros2_controllers.humble.repos
+      downstream_workspace: ros_controls.humble.repos
+      not_test_downstream: true

--- a/.github/workflows/humble-semi-binary-downstream-build.yml
+++ b/.github/workflows/humble-semi-binary-downstream-build.yml
@@ -29,7 +29,6 @@ jobs:
       ros_distro: humble
       ros_repo: testing
       ref_for_scheduled_build: master
-      not_test_build: true
       upstream_workspace: ros2_controllers.humble.repos
-      downstream_workspace: ros_controls.humble.repos
+      target_workspace: ros_controls.humble.repos
       not_test_downstream: true

--- a/.github/workflows/humble-semi-binary-downstream-build.yml
+++ b/.github/workflows/humble-semi-binary-downstream-build.yml
@@ -28,7 +28,24 @@ jobs:
     with:
       ros_distro: humble
       ros_repo: testing
-      ref_for_scheduled_build: master
+      ref_for_scheduled_build: humble
       upstream_workspace: ros2_controllers.humble.repos
-      target_workspace: ros_controls.humble.repos
+      # we don't test this repository, we just build it
+      not_test_build: true
+      # we test the downstream packages, which are part of our organization
+      downstream_workspace: ros_controls.humble.repos
+      not_test_downstream: false
+  build-downstream-3rd-party:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: humble
+      ros_repo: testing
+      ref_for_scheduled_build: humble
+      upstream_workspace: ros2_controllers.humble.repos
+      # we don't test this repository, we just build it
+      not_test_build: true
+      # we don't test the downstream packages, which are outside of our organization
+      downstream_workspace: |
+        ros_controls.humble.repos
+        downstream.humble.repos
       not_test_downstream: true

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -30,5 +30,22 @@ jobs:
       ros_repo: testing
       ref_for_scheduled_build: master
       upstream_workspace: ros2_controllers.jazzy.repos
-      target_workspace: ros_controls.jazzy.repos
+      # we don't test this repository, we just build it
+      not_test_build: true
+      # we test the downstream packages, which are part of our organization
+      downstream_workspace: ros_controls.jazzy.repos
+      not_test_downstream: false
+  build-downstream-3rd-party:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: jazzy
+      ros_repo: testing
+      ref_for_scheduled_build: master
+      upstream_workspace: ros2_controllers.jazzy.repos
+      # we don't test this repository, we just build it
+      not_test_build: true
+      # we don't test the downstream packages, which are outside of our organization
+      downstream_workspace: |
+        ros_controls.jazzy.repos
+        downstream.jazzy.repos
       not_test_downstream: true

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -29,7 +29,6 @@ jobs:
       ros_distro: jazzy
       ros_repo: testing
       ref_for_scheduled_build: master
-      not_test_build: true
       upstream_workspace: ros2_controllers.jazzy.repos
-      downstream_workspace: ros_controls.jazzy.repos
+      target_workspace: ros_controls.jazzy.repos
       not_test_downstream: true

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -45,7 +45,5 @@ jobs:
       # we don't test this repository, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization
-      downstream_workspace: |
-        ros_controls.jazzy.repos
-        downstream.jazzy.repos
+      downstream_workspace: downstream.jazzy.repos
       not_test_downstream: true

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -17,24 +17,10 @@ on:
       - '**/package.xml'
       - '**/CMakeLists.txt'
       - 'ros_controls.jazzy.repos'
-  push:
-    branches:
-      - master
-    paths:
-      - '**.hpp'
-      - '**.h'
-      - '**.cpp'
-      - '**.py'
-      - '**.yaml'
-      - '.github/workflows/jazzy-semi-binary-downstream-build.yml'
-      - '**/package.xml'
-      - '**/CMakeLists.txt'
-      - 'ros_controls.jazzy.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: true
 
 jobs:
   build-downstream:

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -1,0 +1,49 @@
+name: Jazzy Downstream Build
+# description: 'Build & test downstream packages from source.'
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/jazzy-semi-binary-downstream-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros_controls.jazzy.repos'
+  push:
+    branches:
+      - master
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/jazzy-semi-binary-downstream-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros_controls.jazzy.repos'
+
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+
+jobs:
+  build-downstream:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    with:
+      ros_distro: jazzy
+      ros_repo: testing
+      ref_for_scheduled_build: master
+      not_test_build: true
+      upstream_workspace: ros2_controllers.jazzy.repos
+      downstream_workspace: ros_controls.jazzy.repos
+      not_test_downstream: true

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -29,10 +29,9 @@ jobs:
       fail-fast: false
       matrix:
         ROS_DISTRO: [rolling]
-        ROS_REPO: [testing]
     with:
       ros_distro: ${{ matrix.ROS_DISTRO }}
-      ros_repo: ${{ matrix.ROS_REPO }}
+      ros_repo: testing
       ref_for_scheduled_build: master
       not_test_build: true
       upstream_workspace: ros2_controllers.${{ matrix.ROS_DISTRO }}.repos

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -34,5 +34,26 @@ jobs:
       ros_repo: testing
       ref_for_scheduled_build: master
       upstream_workspace: ros2_controllers.${{ matrix.ROS_DISTRO }}.repos
-      target_workspace: ros_controls.${{ matrix.ROS_DISTRO }}.repos
+      # we don't test this repository, we just build it
+      not_test_build: true
+      # we test the downstream packages, which are part of our organization
+      downstream_workspace: ros_controls.${{ matrix.ROS_DISTRO }}.repos
+      not_test_downstream: false
+  build-downstream-3rd-party:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [rolling]
+    with:
+      ros_distro: ${{ matrix.ROS_DISTRO }}
+      ros_repo: testing
+      ref_for_scheduled_build: master
+      upstream_workspace: ros2_controllers.${{ matrix.ROS_DISTRO }}.repos
+      # we don't test this repository, we just build it
+      not_test_build: true
+      # we don't test the downstream packages, which are outside of our organization
+      downstream_workspace: |
+        ros_controls.${{ matrix.ROS_DISTRO }}.repos
+        downstream.${{ matrix.ROS_DISTRO }}.repos
       not_test_downstream: true

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -1,0 +1,54 @@
+name: Rolling Downstream Build
+# description: 'Build & test downstream packages from source.'
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/rolling-semi-binary-downstream-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros_controls.rolling.repos'
+  push:
+    branches:
+      - master
+    paths:
+      - '**.hpp'
+      - '**.h'
+      - '**.cpp'
+      - '**.py'
+      - '**.yaml'
+      - '.github/workflows/rolling-semi-binary-downstream-build.yml'
+      - '**/package.xml'
+      - '**/CMakeLists.txt'
+      - 'ros_controls.rolling.repos'
+
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+
+jobs:
+  build-downstream:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [rolling]
+        ROS_REPO: [testing]
+    with:
+      ros_distro: ${{ matrix.ROS_DISTRO }}
+      ros_repo: ${{ matrix.ROS_REPO }}
+      ref_for_scheduled_build: master
+      not_test_build: true
+      upstream_workspace: ros2_controllers.${{ matrix.ROS_DISTRO }}.repos
+      downstream_workspace: ros_controls.${{ matrix.ROS_DISTRO }}.repos
+      not_test_downstream: true

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -53,7 +53,5 @@ jobs:
       # we don't test this repository, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization
-      downstream_workspace: |
-        ros_controls.${{ matrix.ROS_DISTRO }}.repos
-        downstream.${{ matrix.ROS_DISTRO }}.repos
+      downstream_workspace: downstream.${{ matrix.ROS_DISTRO }}.repos
       not_test_downstream: true

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -33,7 +33,6 @@ jobs:
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: testing
       ref_for_scheduled_build: master
-      not_test_build: true
       upstream_workspace: ros2_controllers.${{ matrix.ROS_DISTRO }}.repos
       target_workspace: ros_controls.${{ matrix.ROS_DISTRO }}.repos
       not_test_downstream: true

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -36,5 +36,5 @@ jobs:
       ref_for_scheduled_build: master
       not_test_build: true
       upstream_workspace: ros2_controllers.${{ matrix.ROS_DISTRO }}.repos
-      downstream_workspace: ros_controls.${{ matrix.ROS_DISTRO }}.repos
+      target_workspace: ros_controls.${{ matrix.ROS_DISTRO }}.repos
       not_test_downstream: true

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -17,24 +17,10 @@ on:
       - '**/package.xml'
       - '**/CMakeLists.txt'
       - 'ros_controls.rolling.repos'
-  push:
-    branches:
-      - master
-    paths:
-      - '**.hpp'
-      - '**.h'
-      - '**.cpp'
-      - '**.py'
-      - '**.yaml'
-      - '.github/workflows/rolling-semi-binary-downstream-build.yml'
-      - '**/package.xml'
-      - '**/CMakeLists.txt'
-      - 'ros_controls.rolling.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: true
 
 jobs:
   build-downstream:

--- a/downstream.humble.repos
+++ b/downstream.humble.repos
@@ -1,0 +1,5 @@
+repositories:
+  UniversalRobots/Universal_Robots_ROS2_Driver:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+    version: humble

--- a/downstream.jazzy.repos
+++ b/downstream.jazzy.repos
@@ -1,0 +1,5 @@
+repositories:
+  UniversalRobots/Universal_Robots_ROS2_Driver:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+    version: main

--- a/downstream.rolling.repos
+++ b/downstream.rolling.repos
@@ -1,0 +1,5 @@
+repositories:
+  UniversalRobots/Universal_Robots_ROS2_Driver:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+    version: main

--- a/ros_controls.humble.repos
+++ b/ros_controls.humble.repos
@@ -1,0 +1,13 @@
+repositories:
+  ros-controls/gazebo_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gazebo_ros2_control.git
+    version: humble
+  ros-controls/gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: humble
+  ros-controls/ros2_control_demos:
+    type: git
+    url: https://github.com/ros-controls/ros2_control_demos.git
+    version: humble

--- a/ros_controls.jazzy.repos
+++ b/ros_controls.jazzy.repos
@@ -1,0 +1,9 @@
+repositories:
+  ros-controls/gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: jazzy
+  ros-controls/ros2_control_demos:
+    type: git
+    url: https://github.com/ros-controls/ros2_control_demos.git
+    version: master

--- a/ros_controls.rolling.repos
+++ b/ros_controls.rolling.repos
@@ -1,0 +1,9 @@
+repositories:
+  ros-controls/gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: rolling
+  ros-controls/ros2_control_demos:
+    type: git
+    url: https://github.com/ros-controls/ros2_control_demos.git
+    version: master


### PR DESCRIPTION
- run them only in PRs
- build+test downstream ros-controls packages
- build-only some downstream 3rd party packages. any more we should add?