### PR TITLE
Draft: Fix deprecation warnings in controllers from recent ros2_control variant changes.

### DIFF
--- a/velocity_controllers/src/joint_group_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_group_velocity_controller.cpp
@@ -59,7 +59,11 @@ controller_interface::CallbackReturn JointGroupVelocityController::on_deactivate
   // stop all joints
   for (auto & command_interface : command_interfaces_)
   {
-    command_interface.set_value(0.0);
+    if (!command_interface.set_value(0.0))
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "Error while setting command_interface value to 0.0");
+      return CallbackReturn::FAILURE;
+    }
   }
 
   return ret;


### PR DESCRIPTION

- Updated `get_value` and `set_value` in `diff_drive_controller` to fix deprecation warnings.

Fixes https://github.com/ros-controls/ros2_controllers/issues/1442