### PR TITLE
Remove build_dep generate_parameter_library from public dependencies of steering_controllers_library

### DIFF
--- a/steering_controllers_library/CMakeLists.txt
+++ b/steering_controllers_library/CMakeLists.txt
@@ -15,7 +15,6 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   control_msgs
   controller_interface
-  generate_parameter_library
   geometry_msgs
   hardware_interface
   nav_msgs
@@ -32,6 +31,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 
 find_package(ament_cmake REQUIRED)
 find_package(backward_ros REQUIRED)
+find_package(generate_parameter_library)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()

--- a/steering_controllers_library/package.xml
+++ b/steering_controllers_library/package.xml
@@ -27,6 +27,7 @@
   <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>
+  <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>

--- a/steering_controllers_library/package.xml
+++ b/steering_controllers_library/package.xml
@@ -27,7 +27,6 @@
   <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>
-  <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>


### PR DESCRIPTION
`steering_controllers_library` already depended on `generate_parameter_library` in the CMake, but this dependency was not reflected in the package.xml metadata.

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
