### PR TITLE
Update generate_parameter_library dependency in steering_controllers_library

### DIFF
--- a/steering_controllers_library/package.xml
+++ b/steering_controllers_library/package.xml
@@ -22,11 +22,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>generate_parameter_library</build_depend>
-
   <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>
+  <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>


### PR DESCRIPTION
Technically the `generate_parameter_library` is a build dependency, but it generate an header and a target that are part of the public interface of the library, and that depend on a series of CMake targets (`fmt::fmt`, `rsl::rsl` and more, see https://github.com/PickNikRobotics/generate_parameter_library/blob/0346fde52ba515593bd51b96bc520fa872af5b2a/generate_parameter_library/cmake/generate_parameter_library.cmake#L85) that are not listed as dependency of the `steering_controllers_library` package. The easiest solution to ensure that all the transitive dependencies of the code generated by `generate_parameter_library`  are available is to simply add `generate_parameter_library` as a regular dependency, that is also the solution suggested by `generate_parameter_library` documentation.



Checklist:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
