### PR TITLE
Fix LifecycleNode in tests

### DIFF
--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
@@ -128,7 +128,14 @@ public:
 
   void TearDown()
   {
-    controller_->get_node()->shutdown();
+    try
+    {
+      controller_->get_node()->shutdown();
+    }
+    catch (...)
+    {
+      // ignore case where node is not initialized
+    }
     controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 

--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
@@ -126,9 +126,13 @@ public:
       "/test_ackermann_steering_controller/reference", rclcpp::SystemDefaultsQoS());
   }
 
-  static void TearDownTestCase() {}
+  void TearDown()
+  {
+    controller_->get_node()->shutdown();
+    controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+  }
 
-  void TearDown() { controller_.reset(nullptr); }
+  static void TearDownTestCase() {}
 
 protected:
   void SetUpController(const std::string controller_name = "test_ackermann_steering_controller")

--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -133,7 +133,14 @@ public:
 
   void TearDown()
   {
-    controller_->get_node()->shutdown();
+    try
+    {
+      controller_->get_node()->shutdown();
+    }
+    catch (...)
+    {
+      // ignore case where node is not initialized
+    }
     controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 

--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -129,12 +129,13 @@ public:
     test_broadcaster_node_ = std::make_shared<rclcpp::Node>("test_broadcaster_node");
   }
 
-  static void TearDownTestCase()
-  {
-    //    rclcpp::shutdown();
-  }
+  static void TearDownTestCase() {}
 
-  void TearDown() { controller_.reset(nullptr); }
+  void TearDown()
+  {
+    controller_->get_node()->shutdown();
+    controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+  }
 
 protected:
   controller_interface::return_type SetUpController(

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -124,9 +124,13 @@ public:
       "/test_bicycle_steering_controller/reference", rclcpp::SystemDefaultsQoS());
   }
 
-  static void TearDownTestCase() {}
+  void TearDown()
+  {
+    controller_->get_node()->shutdown();
+    controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+  }
 
-  void TearDown() { controller_.reset(nullptr); }
+  static void TearDownTestCase() {}
 
 protected:
   void SetUpController(const std::string controller_name = "test_bicycle_steering_controller")

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -126,7 +126,14 @@ public:
 
   void TearDown()
   {
-    controller_->get_node()->shutdown();
+    try
+    {
+      controller_->get_node()->shutdown();
+    }
+    catch (...)
+    {
+      // ignore case where node is not initialized
+    }
     controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -101,7 +101,14 @@ protected:
 
   void TearDown()
   {
-    controller_->get_node()->shutdown();
+    try
+    {
+      controller_->get_node()->shutdown();
+    }
+    catch (...)
+    {
+      // ignore case where node is not initialized
+    }
     controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -85,7 +85,9 @@ public:
 class TestDiffDriveController : public ::testing::Test
 {
 protected:
-  void SetUp() override
+  static void SetUpTestCase() {}
+
+  void SetUp()
   {
     // use the name of the test as the controller name (i.e, the node name) to be able to set
     // parameters from yaml for each test
@@ -97,7 +99,13 @@ protected:
       controller_name + "/cmd_vel", rclcpp::SystemDefaultsQoS());
   }
 
-  static void TearDownTestCase() { rclcpp::shutdown(); }
+  void TearDown()
+  {
+    controller_->get_node()->shutdown();
+    controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+  }
+
+  static void TearDownTestCase() {}
 
   /// Publish velocity msgs
   /**

--- a/effort_controllers/test/test_joint_group_effort_controller.cpp
+++ b/effort_controllers/test/test_joint_group_effort_controller.cpp
@@ -34,7 +34,11 @@ void JointGroupEffortControllerTest::SetUp()
   controller_ = std::make_unique<FriendJointGroupEffortController>();
 }
 
-void JointGroupEffortControllerTest::TearDown() { controller_.reset(nullptr); }
+void JointGroupEffortControllerTest::TearDown()
+{
+  controller_->get_node()->shutdown();
+  controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void JointGroupEffortControllerTest::SetUpController()
 {

--- a/effort_controllers/test/test_joint_group_effort_controller.cpp
+++ b/effort_controllers/test/test_joint_group_effort_controller.cpp
@@ -36,7 +36,14 @@ void JointGroupEffortControllerTest::SetUp()
 
 void JointGroupEffortControllerTest::TearDown()
 {
-  controller_->get_node()->shutdown();
+  try
+  {
+    controller_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
@@ -48,7 +48,11 @@ void ForceTorqueSensorBroadcasterTest::SetUp()
   fts_broadcaster_ = std::make_unique<FriendForceTorqueSensorBroadcaster>();
 }
 
-void ForceTorqueSensorBroadcasterTest::TearDown() { fts_broadcaster_.reset(nullptr); }
+void ForceTorqueSensorBroadcasterTest::TearDown()
+{
+  fts_broadcaster_->get_node()->shutdown();
+  fts_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void ForceTorqueSensorBroadcasterTest::SetUpFTSBroadcaster()
 {

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
@@ -50,7 +50,14 @@ void ForceTorqueSensorBroadcasterTest::SetUp()
 
 void ForceTorqueSensorBroadcasterTest::TearDown()
 {
-  fts_broadcaster_->get_node()->shutdown();
+  try
+  {
+    fts_broadcaster_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   fts_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -46,7 +46,11 @@ void ForwardCommandControllerTest::SetUp()
   controller_ = std::make_unique<FriendForwardCommandController>();
 }
 
-void ForwardCommandControllerTest::TearDown() { controller_.reset(nullptr); }
+void ForwardCommandControllerTest::TearDown()
+{
+  controller_->get_node()->shutdown();
+  controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void ForwardCommandControllerTest::SetUpController()
 {

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -48,7 +48,14 @@ void ForwardCommandControllerTest::SetUp()
 
 void ForwardCommandControllerTest::TearDown()
 {
-  controller_->get_node()->shutdown();
+  try
+  {
+    controller_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
@@ -50,7 +50,14 @@ void MultiInterfaceForwardCommandControllerTest::SetUp()
 
 void MultiInterfaceForwardCommandControllerTest::TearDown()
 {
-  controller_->get_node()->shutdown();
+  try
+  {
+    controller_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
@@ -48,7 +48,11 @@ void MultiInterfaceForwardCommandControllerTest::SetUp()
   controller_ = std::make_unique<FriendMultiInterfaceForwardCommandController>();
 }
 
-void MultiInterfaceForwardCommandControllerTest::TearDown() { controller_.reset(nullptr); }
+void MultiInterfaceForwardCommandControllerTest::TearDown()
+{
+  controller_->get_node()->shutdown();
+  controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void MultiInterfaceForwardCommandControllerTest::SetUpController(bool set_params_and_activate)
 {

--- a/gripper_controllers/test/test_gripper_controllers.cpp
+++ b/gripper_controllers/test/test_gripper_controllers.cpp
@@ -52,7 +52,8 @@ void GripperControllerTest<T>::SetUp()
 template <typename T>
 void GripperControllerTest<T>::TearDown()
 {
-  controller_.reset(nullptr);
+  controller_->get_node()->shutdown();
+  controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 
 template <typename T>

--- a/gripper_controllers/test/test_gripper_controllers.cpp
+++ b/gripper_controllers/test/test_gripper_controllers.cpp
@@ -52,7 +52,14 @@ void GripperControllerTest<T>::SetUp()
 template <typename T>
 void GripperControllerTest<T>::TearDown()
 {
-  controller_->get_node()->shutdown();
+  try
+  {
+    controller_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
@@ -50,7 +50,14 @@ void IMUSensorBroadcasterTest::SetUp()
 
 void IMUSensorBroadcasterTest::TearDown()
 {
-  imu_broadcaster_->get_node()->shutdown();
+  try
+  {
+    imu_broadcaster_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   imu_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
@@ -48,7 +48,11 @@ void IMUSensorBroadcasterTest::SetUp()
   imu_broadcaster_ = std::make_unique<FriendIMUSensorBroadcaster>();
 }
 
-void IMUSensorBroadcasterTest::TearDown() { imu_broadcaster_.reset(nullptr); }
+void IMUSensorBroadcasterTest::TearDown()
+{
+  imu_broadcaster_->get_node()->shutdown();
+  imu_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void IMUSensorBroadcasterTest::SetUpIMUBroadcaster()
 {

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -59,7 +59,14 @@ void JointStateBroadcasterTest::SetUp()
 
 void JointStateBroadcasterTest::TearDown()
 {
-  state_broadcaster_->get_node()->shutdown();
+  try
+  {
+    state_broadcaster_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   state_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -57,7 +57,11 @@ void JointStateBroadcasterTest::SetUp()
   state_broadcaster_ = std::make_unique<FriendJointStateBroadcaster>();
 }
 
-void JointStateBroadcasterTest::TearDown() { state_broadcaster_.reset(nullptr); }
+void JointStateBroadcasterTest::TearDown()
+{
+  state_broadcaster_->get_node()->shutdown();
+  state_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void JointStateBroadcasterTest::SetUpStateBroadcaster(
   const std::vector<std::string> & joint_names, const std::vector<std::string> & interfaces)

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -404,7 +404,14 @@ public:
           traj_controller_->get_node()->deactivate().id(),
           lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
       }
-      traj_controller_->get_node()->shutdown();
+      try
+      {
+        traj_controller_->get_node()->shutdown();
+      }
+      catch (...)
+      {
+        // ignore case where node is not initialized
+      }
     }
   }
 

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -404,6 +404,7 @@ public:
           traj_controller_->get_node()->deactivate().id(),
           lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
       }
+      traj_controller_->get_node()->shutdown();
     }
   }
 

--- a/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
+++ b/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
@@ -154,9 +154,17 @@ public:
     tf_odom_s_publisher_ = tf_odom_s_publisher_node_->create_publisher<TfStateMsg>(
       "/test_mecanum_drive_controller/tf_odometry", rclcpp::SystemDefaultsQoS());
   }
+
   void TearDown()
   {
-    controller_->get_node()->shutdown();
+    try
+    {
+      controller_->get_node()->shutdown();
+    }
+    catch (...)
+    {
+      // ignore case where node is not initialized
+    }
     controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 

--- a/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
+++ b/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
@@ -154,10 +154,13 @@ public:
     tf_odom_s_publisher_ = tf_odom_s_publisher_node_->create_publisher<TfStateMsg>(
       "/test_mecanum_drive_controller/tf_odometry", rclcpp::SystemDefaultsQoS());
   }
+  void TearDown()
+  {
+    controller_->get_node()->shutdown();
+    controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+  }
 
   static void TearDownTestCase() {}
-
-  void TearDown() { controller_.reset(nullptr); }
 
 protected:
   void SetUpController(const std::string controller_name = "test_mecanum_drive_controller")

--- a/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
+++ b/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
@@ -46,7 +46,14 @@ void GripperControllerTest::SetUp()
 
 void GripperControllerTest::TearDown()
 {
-  controller_->get_node()->shutdown();
+  try
+  {
+    controller_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
+++ b/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
@@ -44,7 +44,11 @@ void GripperControllerTest::SetUp()
   controller_ = std::make_unique<FriendGripperController>();
 }
 
-void GripperControllerTest::TearDown() { controller_.reset(nullptr); }
+void GripperControllerTest::TearDown()
+{
+  controller_->get_node()->shutdown();
+  controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void GripperControllerTest::SetUpController(
   const std::string & controller_name = "test_gripper_action_position_controller",

--- a/pid_controller/test/test_pid_controller.hpp
+++ b/pid_controller/test/test_pid_controller.hpp
@@ -130,7 +130,14 @@ public:
 
   void TearDown()
   {
-    controller_->get_node()->shutdown();
+    try
+    {
+      controller_->get_node()->shutdown();
+    }
+    catch (...)
+    {
+      // ignore case where node is not initialized
+    }
     controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 

--- a/pid_controller/test/test_pid_controller.hpp
+++ b/pid_controller/test/test_pid_controller.hpp
@@ -128,9 +128,13 @@ public:
       "/test_pid_controller/set_feedforward_control");
   }
 
-  static void TearDownTestCase() { rclcpp::shutdown(); }
+  void TearDown()
+  {
+    controller_->get_node()->shutdown();
+    controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+  }
 
-  void TearDown() { controller_.reset(nullptr); }
+  static void TearDownTestCase() {}
 
 protected:
   void SetUpController(const std::string controller_name = "test_pid_controller")

--- a/pose_broadcaster/test/test_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.cpp
@@ -20,7 +20,11 @@ using hardware_interface::LoanedStateInterface;
 
 void PoseBroadcasterTest::SetUp() { pose_broadcaster_ = std::make_unique<PoseBroadcaster>(); }
 
-void PoseBroadcasterTest::TearDown() { pose_broadcaster_.reset(nullptr); }
+void PoseBroadcasterTest::TearDown()
+{
+  pose_broadcaster_->get_node()->shutdown();
+  pose_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void PoseBroadcasterTest::SetUpPoseBroadcaster()
 {

--- a/pose_broadcaster/test/test_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.cpp
@@ -22,7 +22,14 @@ void PoseBroadcasterTest::SetUp() { pose_broadcaster_ = std::make_unique<PoseBro
 
 void PoseBroadcasterTest::TearDown()
 {
-  pose_broadcaster_->get_node()->shutdown();
+  try
+  {
+    pose_broadcaster_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   pose_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/position_controllers/test/test_joint_group_position_controller.cpp
+++ b/position_controllers/test/test_joint_group_position_controller.cpp
@@ -34,7 +34,11 @@ void JointGroupPositionControllerTest::SetUp()
   controller_ = std::make_unique<FriendJointGroupPositionController>();
 }
 
-void JointGroupPositionControllerTest::TearDown() { controller_.reset(nullptr); }
+void JointGroupPositionControllerTest::TearDown()
+{
+  controller_->get_node()->shutdown();
+  controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void JointGroupPositionControllerTest::SetUpController()
 {

--- a/position_controllers/test/test_joint_group_position_controller.cpp
+++ b/position_controllers/test/test_joint_group_position_controller.cpp
@@ -36,7 +36,14 @@ void JointGroupPositionControllerTest::SetUp()
 
 void JointGroupPositionControllerTest::TearDown()
 {
-  controller_->get_node()->shutdown();
+  try
+  {
+    controller_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
+++ b/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
@@ -33,7 +33,11 @@ void RangeSensorBroadcasterTest::SetUp()
   range_broadcaster_ = std::make_unique<range_sensor_broadcaster::RangeSensorBroadcaster>();
 }
 
-void RangeSensorBroadcasterTest::TearDown() { range_broadcaster_.reset(nullptr); }
+void RangeSensorBroadcasterTest::TearDown()
+{
+  range_broadcaster_->get_node()->shutdown();
+  range_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 controller_interface::return_type RangeSensorBroadcasterTest::init_broadcaster(
   std::string broadcaster_name)

--- a/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
+++ b/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
@@ -35,7 +35,14 @@ void RangeSensorBroadcasterTest::SetUp()
 
 void RangeSensorBroadcasterTest::TearDown()
 {
-  range_broadcaster_->get_node()->shutdown();
+  try
+  {
+    range_broadcaster_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   range_broadcaster_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -147,9 +147,13 @@ public:
       "/test_steering_controllers_library/reference", rclcpp::SystemDefaultsQoS());
   }
 
-  static void TearDownTestCase() {}
+  void TearDown()
+  {
+    controller_->get_node()->shutdown();
+    controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+  }
 
-  void TearDown() { controller_.reset(nullptr); }
+  static void TearDownTestCase() {}
 
 protected:
   void SetUpController(const std::string controller_name = "test_steering_controllers_library")

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -149,7 +149,14 @@ public:
 
   void TearDown()
   {
-    controller_->get_node()->shutdown();
+    try
+    {
+      controller_->get_node()->shutdown();
+    }
+    catch (...)
+    {
+      // ignore case where node is not initialized
+    }
     controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 

--- a/tricycle_controller/test/test_tricycle_controller.cpp
+++ b/tricycle_controller/test/test_tricycle_controller.cpp
@@ -92,7 +92,14 @@ protected:
 
   void TearDown()
   {
-    controller_->get_node()->shutdown();
+    try
+    {
+      controller_->get_node()->shutdown();
+    }
+    catch (...)
+    {
+      // ignore case where node is not initialized
+    }
     controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 

--- a/tricycle_controller/test/test_tricycle_controller.cpp
+++ b/tricycle_controller/test/test_tricycle_controller.cpp
@@ -82,12 +82,18 @@ class TestTricycleController : public ::testing::Test
 protected:
   static void SetUpTestCase() { rclcpp::init(0, nullptr); }
 
-  void SetUp() override
+  void SetUp()
   {
     controller_ = std::make_unique<TestableTricycleController>();
     pub_node = std::make_shared<rclcpp::Node>("velocity_publisher");
     velocity_publisher = pub_node->create_publisher<geometry_msgs::msg::TwistStamped>(
       controller_name + "/cmd_vel", rclcpp::SystemDefaultsQoS());
+  }
+
+  void TearDown()
+  {
+    controller_->get_node()->shutdown();
+    controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 
   static void TearDownTestCase() { rclcpp::shutdown(); }

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
@@ -125,9 +125,13 @@ public:
       "/test_tricycle_steering_controller/reference", rclcpp::SystemDefaultsQoS());
   }
 
-  static void TearDownTestCase() {}
+  void TearDown()
+  {
+    controller_->get_node()->shutdown();
+    controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+  }
 
-  void TearDown() { controller_.reset(nullptr); }
+  static void TearDownTestCase() {}
 
 protected:
   void SetUpController(const std::string controller_name = "test_tricycle_steering_controller")

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
@@ -127,7 +127,14 @@ public:
 
   void TearDown()
   {
-    controller_->get_node()->shutdown();
+    try
+    {
+      controller_->get_node()->shutdown();
+    }
+    catch (...)
+    {
+      // ignore case where node is not initialized
+    }
     controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
   }
 

--- a/velocity_controllers/test/test_joint_group_velocity_controller.cpp
+++ b/velocity_controllers/test/test_joint_group_velocity_controller.cpp
@@ -36,7 +36,14 @@ void JointGroupVelocityControllerTest::SetUp()
 
 void JointGroupVelocityControllerTest::TearDown()
 {
-  controller_->get_node()->shutdown();
+  try
+  {
+    controller_->get_node()->shutdown();
+  }
+  catch (...)
+  {
+    // ignore case where node is not initialized
+  }
   controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
 }
 

--- a/velocity_controllers/test/test_joint_group_velocity_controller.cpp
+++ b/velocity_controllers/test/test_joint_group_velocity_controller.cpp
@@ -34,7 +34,11 @@ void JointGroupVelocityControllerTest::SetUp()
   controller_ = std::make_unique<FriendJointGroupVelocityController>();
 }
 
-void JointGroupVelocityControllerTest::TearDown() { controller_.reset(nullptr); }
+void JointGroupVelocityControllerTest::TearDown()
+{
+  controller_->get_node()->shutdown();
+  controller_.reset(nullptr);  // this calls the dtor, but does not call shutdown transition
+}
 
 void JointGroupVelocityControllerTest::SetUpController()
 {


### PR DESCRIPTION
Since https://github.com/ros2/rclcpp/pull/2562 we get lots of warnings in the test logs like
```
[WARN] [1735845337.264023881] [rclcpp_lifecycle]: LifecycleNode is not shut down: Node still in state(1) in destructor
```

Triggering the shutdown transition before calling the destructor fixes this.