### PR TITLE
Use urdf/model.hpp for rolling

### DIFF
--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -26,7 +26,13 @@
 #include "joint_state_broadcaster_parameters.hpp"
 #include "realtime_tools/realtime_publisher.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
+
+#include "rclcpp/version.h"
+#if RCLCPP_VERSION_GTE(29, 0, 0)
+#include "urdf/model.hpp"
+#else
 #include "urdf/model.h"
+#endif
 
 namespace joint_state_broadcaster
 {

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -26,12 +26,7 @@
 #include "rclcpp/time.hpp"
 #include "std_msgs/msg/header.hpp"
 
-#include "rclcpp/version.h"
-#if RCLCPP_VERSION_GTE(29, 0, 0)
-#include "urdf/model.hpp"
-#else
 #include "urdf/model.h"
-#endif
 
 namespace rclcpp_lifecycle
 {

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -26,7 +26,6 @@
 #include "rclcpp/time.hpp"
 #include "std_msgs/msg/header.hpp"
 
-#include "urdf/model.h"
 
 namespace rclcpp_lifecycle
 {

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -26,7 +26,6 @@
 #include "rclcpp/time.hpp"
 #include "std_msgs/msg/header.hpp"
 
-
 namespace rclcpp_lifecycle
 {
 class State;


### PR DESCRIPTION
### Description
- Replaced deprecated `urdf/model.h` with conditional includes using `urdf/model.hpp` for Rolling.
- Maintained compatibility for Humble and Jazzy using `rclcpp/version.h`.

Solve https://github.com/ros-controls/ros2_controllers/pull/1473#pullrequestreview-2534902220
