### PR TITLE
Fix SpeedLimiter Constructor regression

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
@@ -123,8 +123,8 @@ protected:
   std::queue<TwistStamped> previous_commands_;  // last two commands
 
   // speed limiters
-  SpeedLimiter limiter_linear_;
-  SpeedLimiter limiter_angular_;
+  std::unique_ptr<SpeedLimiter> limiter_linear_;
+  std::unique_ptr<SpeedLimiter> limiter_angular_;
 
   bool publish_limited_velocity_ = false;
   std::shared_ptr<rclcpp::Publisher<TwistStamped>> limited_velocity_publisher_ = nullptr;

--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.hpp
@@ -40,7 +40,7 @@ public:
    * \param [in] min_jerk Minimum jerk [m/s^3], usually <= 0
    * \param [in] max_jerk Maximum jerk [m/s^3], usually >= 0
    */
-  [[deprecated]] SpeedLimiter(
+  [[deprecated]] explicit SpeedLimiter(
     bool has_velocity_limits = true, bool has_acceleration_limits = true,
     bool has_jerk_limits = true, double min_velocity = std::numeric_limits<double>::quiet_NaN(),
     double max_velocity = std::numeric_limits<double>::quiet_NaN(),
@@ -79,16 +79,16 @@ public:
    * >= 0
    * \param [in] min_jerk Minimum jerk [m/s^3], usually <= 0
    * \param [in] max_jerk Maximum jerk [m/s^3], usually >= 0
+   *
+   * \note
+   * If max_* values are NAN, the respective limit is deactivated
+   * If min_* values are NAN (unspecified), defaults to -max
+   * If min_first_derivative_pos/max_first_derivative_neg values are NAN, symmetric limits are used
    */
-  SpeedLimiter(
-    double min_velocity = std::numeric_limits<double>::quiet_NaN(),
-    double max_velocity = std::numeric_limits<double>::quiet_NaN(),
-    double max_acceleration_reverse = std::numeric_limits<double>::quiet_NaN(),
-    double max_acceleration = std::numeric_limits<double>::quiet_NaN(),
-    double max_deceleration = std::numeric_limits<double>::quiet_NaN(),
-    double max_deceleration_reverse = std::numeric_limits<double>::quiet_NaN(),
-    double min_jerk = std::numeric_limits<double>::quiet_NaN(),
-    double max_jerk = std::numeric_limits<double>::quiet_NaN())
+  explicit SpeedLimiter(
+    double min_velocity, double max_velocity, double max_acceleration_reverse,
+    double max_acceleration, double max_deceleration, double max_deceleration_reverse,
+    double min_jerk, double max_jerk)
   {
     speed_limiter_ = control_toolbox::RateLimiter<double>(
       min_velocity, max_velocity, max_acceleration_reverse, max_acceleration, max_deceleration,


### PR DESCRIPTION
After the https://github.com/ros-controls/ros2_controllers/pull/1315 and recent tag 4.18.0

I observed a regression in a controller that the SpeedLimiter is offering 2 constructors with default argument and this creates the following error: `error: call of overloaded 'SpeedLimiter()' is ambiguous`

I think it makes sense to have the new constructor more explicit without any default arguments. Moreover, the construction `limiter_angular_(std::numeric_limits<double>::quiet_NaN())` still doesn't help as it is still implicitly casting things to the deprecated constructor

`diff_drive_controller.cpp:50:1: warning: ‘diff_drive_controller::SpeedLimiter::SpeedLimiter(bool, bool, bool, double, double, double, double, double, double)’ is deprecated [-Wdeprecated-declarations]`


I decided to fix this also in the same PR by changing them to unique_ptr. I don't think it should be a problem as the controller is used as a plugin.