### PR TITLE
[pose_broadcaster] Check for valid pose before attempting to publish a tf for it

### DIFF
--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -28,9 +28,15 @@ namespace pose_broadcaster
 
 bool is_pose_valid(const geometry_msgs::msg::Pose & pose)
 {
-         std::abs((pose.orientation.x * pose.orientation.x + pose.orientation.y * pose.orientation.y +
-          pose.orientation.z * pose.orientation.z + pose.orientation.w * pose.orientation.w) -
-          1.0) <= 10e-3;
+  return std::isfinite(pose.position.x) && std::isfinite(pose.position.y) &&
+         std::isfinite(pose.position.z) && std::isfinite(pose.orientation.x) &&
+         std::isfinite(pose.orientation.y) && std::isfinite(pose.orientation.z) &&
+         std::isfinite(pose.orientation.w) &&
+
+         std::abs(
+           pose.orientation.x * pose.orientation.x + pose.orientation.y * pose.orientation.y +
+           pose.orientation.z * pose.orientation.z + pose.orientation.w * pose.orientation.w -
+           1.0) <= 10e-3;
 }
 
 controller_interface::InterfaceConfiguration PoseBroadcaster::command_interface_configuration()

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -164,6 +164,10 @@ controller_interface::return_type PoseBroadcaster::update(
   {
     if (!is_pose_valid(pose))
     {
+      RCLCPP_ERROR(
+        get_node()->get_logger(), "Invalid pose [%f, %f, %f], [%f, %f, %f, %f]", pose.position.x,
+        pose.position.y, pose.position.z, pose.orientation.x, pose.orientation.y,
+        pose.orientation.z, pose.orientation.w);
       realtime_tf_publisher_->unlock();
       return controller_interface::return_type::ERROR;
     }

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -28,13 +28,8 @@ namespace pose_broadcaster
 
 bool is_pose_valid(const geometry_msgs::msg::Pose & pose)
 {
-  return std::isfinite(pose.position.x) && std::isfinite(pose.position.y) &&
-         std::isfinite(pose.position.z) && std::isfinite(pose.orientation.x) &&
-         std::isfinite(pose.orientation.y) && std::isfinite(pose.orientation.z) &&
-         std::isfinite(pose.orientation.w) &&
-
-         (pose.orientation.x * pose.orientation.x + pose.orientation.y * pose.orientation.y +
-          pose.orientation.z * pose.orientation.z + pose.orientation.w * pose.orientation.w -
+         std::abs((pose.orientation.x * pose.orientation.x + pose.orientation.y * pose.orientation.y +
+          pose.orientation.z * pose.orientation.z + pose.orientation.w * pose.orientation.w) -
           1.0) <= 10e-3;
 }
 

--- a/pose_broadcaster/test/test_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 #include "test_pose_broadcaster.hpp"
 
+#include <cmath>
 #include <utility>
 #include <vector>
 
@@ -184,6 +185,87 @@ TEST_F(PoseBroadcasterTest, PublishSuccess)
   EXPECT_EQ(tf_msg.transforms[0].transform.rotation.y, pose_values_[4]);
   EXPECT_EQ(tf_msg.transforms[0].transform.rotation.z, pose_values_[5]);
   EXPECT_EQ(tf_msg.transforms[0].transform.rotation.w, pose_values_[6]);
+}
+
+TEST_F(PoseBroadcasterTest, invalid_pose_deactivates_controller)
+{
+  SetUpPoseBroadcaster();
+
+  // Set 'pose_name' and 'frame_id' parameters
+  pose_broadcaster_->get_node()->set_parameter({"pose_name", pose_name_});
+  pose_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
+
+  // Set 'tf.enable' and 'tf.child_frame_id' parameters
+  pose_broadcaster_->get_node()->set_parameter({"tf.enable", true});
+  pose_broadcaster_->get_node()->set_parameter({"tf.child_frame_id", tf_child_frame_id_});
+
+  // Configure and activate controller
+  ASSERT_EQ(
+    pose_broadcaster_->on_configure(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_EQ(
+    pose_broadcaster_->on_activate(rclcpp_lifecycle::State{}),
+    controller_interface::CallbackReturn::SUCCESS);
+
+  double temp = 0;
+  ASSERT_TRUE(pose_position_x_.get_value(temp));
+  ASSERT_TRUE(pose_position_x_.set_value(std::numeric_limits<double>::quiet_NaN()));
+  ASSERT_EQ(
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::ERROR);
+  ASSERT_TRUE(pose_position_x_.set_value(temp));
+
+  ASSERT_TRUE(pose_position_y_.get_value(temp));
+  ASSERT_TRUE(pose_position_y_.set_value(std::numeric_limits<double>::quiet_NaN()));
+  ASSERT_EQ(
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::ERROR);
+  ASSERT_TRUE(pose_position_y_.set_value(temp));
+
+  ASSERT_TRUE(pose_position_z_.get_value(temp));
+  ASSERT_TRUE(pose_position_z_.set_value(std::numeric_limits<double>::quiet_NaN()));
+  ASSERT_EQ(
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::ERROR);
+  ASSERT_TRUE(pose_position_z_.set_value(temp));
+
+  ASSERT_TRUE(pose_orientation_x_.get_value(temp));
+  ASSERT_TRUE(pose_orientation_x_.set_value(std::numeric_limits<double>::quiet_NaN()));
+  ASSERT_EQ(
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::ERROR);
+  ASSERT_TRUE(pose_orientation_x_.set_value(temp));
+
+  ASSERT_TRUE(pose_orientation_y_.get_value(temp));
+  ASSERT_TRUE(pose_orientation_y_.set_value(std::numeric_limits<double>::quiet_NaN()));
+  ASSERT_EQ(
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::ERROR);
+  ASSERT_TRUE(pose_orientation_y_.set_value(temp));
+
+  ASSERT_TRUE(pose_orientation_z_.get_value(temp));
+  ASSERT_TRUE(pose_orientation_z_.set_value(std::numeric_limits<double>::quiet_NaN()));
+  ASSERT_EQ(
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::ERROR);
+  ASSERT_TRUE(pose_orientation_z_.set_value(temp));
+
+  ASSERT_TRUE(pose_orientation_w_.get_value(temp));
+  ASSERT_TRUE(pose_orientation_w_.set_value(std::numeric_limits<double>::quiet_NaN()));
+  ASSERT_EQ(
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::ERROR);
+  ASSERT_TRUE(pose_orientation_w_.set_value(temp));
+
+  ASSERT_TRUE(pose_orientation_x_.set_value(0));
+  ASSERT_TRUE(pose_orientation_y_.set_value(0));
+  ASSERT_TRUE(pose_orientation_z_.set_value(0));
+  ASSERT_TRUE(pose_orientation_w_.set_value(0));
+
+  ASSERT_EQ(
+    pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::ERROR);
+
 }
 
 int main(int argc, char * argv[])

--- a/pose_broadcaster/test/test_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.cpp
@@ -213,12 +213,6 @@ TEST_F(PoseBroadcasterTest, invalid_pose_no_tf_published)
 
   // Subscribe to pose topic
   geometry_msgs::msg::PoseStamped pose_msg;
-  pose_msg.pose.position.x = 0.0;
-  pose_msg.pose.position.y = 0.0;
-  pose_msg.pose.position.z = 0.0;
-  pose_msg.pose.orientation.x = 0.0;
-  pose_msg.pose.orientation.y = 0.0;
-  pose_msg.pose.orientation.z = 0.0;
   pose_msg.pose.orientation.w = 1.0;
   subscribe_and_get_message("/test_pose_broadcaster/pose", pose_msg);
 

--- a/pose_broadcaster/test/test_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.cpp
@@ -14,6 +14,7 @@
 #include "test_pose_broadcaster.hpp"
 
 #include <cmath>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -265,7 +266,6 @@ TEST_F(PoseBroadcasterTest, invalid_pose_deactivates_controller)
   ASSERT_EQ(
     pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::ERROR);
-
 }
 
 int main(int argc, char * argv[])

--- a/pose_broadcaster/test/test_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.cpp
@@ -17,7 +17,6 @@
 #include <limits>
 #include <utility>
 #include <vector>
-#include "gtest/gtest.h"
 
 using hardware_interface::LoanedStateInterface;
 
@@ -213,7 +212,6 @@ TEST_F(PoseBroadcasterTest, invalid_pose_no_tf_published)
 
   // Subscribe to pose topic
   geometry_msgs::msg::PoseStamped pose_msg;
-  pose_msg.pose.orientation.w = 1.0;
   subscribe_and_get_message("/test_pose_broadcaster/pose", pose_msg);
 
   // Verify content of pose message
@@ -238,6 +236,10 @@ TEST_F(PoseBroadcasterTest, invalid_pose_no_tf_published)
   ASSERT_TRUE(pose_orientation_y_.set_value(0.0));
   ASSERT_TRUE(pose_orientation_z_.set_value(0.0));
   ASSERT_TRUE(pose_orientation_w_.set_value(0.0));
+
+  EXPECT_THROW(subscribe_and_get_message("/tf", tf_msg), std::runtime_error);
+  // Verify that no tf message was sent
+  ASSERT_EQ(tf_msg.transforms.size(), 0lu);
 }
 
 int main(int argc, char * argv[])

--- a/pose_broadcaster/test/test_pose_broadcaster.hpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.hpp
@@ -39,7 +39,8 @@ protected:
   const std::string frame_id_ = "pose_base_frame";
   const std::string tf_child_frame_id_ = "pose_frame";
 
-  std::array<double, 7> pose_values_ = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7}};
+  std::array<double, 7> pose_values_ = {
+    {1.1, 2.2, 3.3, 0.39190382, 0.20056212, 0.53197575, 0.72331744}};
 
   hardware_interface::StateInterface pose_position_x_{pose_name_, "position.x", &pose_values_[0]};
   hardware_interface::StateInterface pose_position_y_{pose_name_, "position.x", &pose_values_[1]};
@@ -77,7 +78,10 @@ void PoseBroadcasterTest::subscribe_and_get_message(const std::string & topic, T
   constexpr size_t max_sub_check_loop_count = 5;
   for (size_t i = 0; !received_msg; ++i)
   {
-    ASSERT_LT(i, max_sub_check_loop_count);
+    if (i >= max_sub_check_loop_count)
+    {
+      throw std::runtime_error("Failed to receive message on topic: " + topic);
+    }
 
     pose_broadcaster_->update(rclcpp::Time{0}, rclcpp::Duration::from_seconds(0.01));
 


### PR DESCRIPTION
Deactivate the controller otherwise

When using the pose_broadcaster e.g. with mock hardware, the pose state interfaces might not contain any value (NaN), if there are no initial values inside the URDF. However, it might not make sense to set an initial value as this would be plain wrong information. Imagine a robot-calculated forward kinematics that generates that pose. Initializing this to any fixed value will just be wrong. IMHO it would be better to explicitly state that there is no valid information available.

Currently, attempting to publish a tf with no pose information will result in spamming the shell with
```
TF_NAN_INPUT: Ignoring transform for child_frame_id "tool0_controller" from authority "Authority undetectable" because of a nan value in the transform (nan nan nan) (nan nan nan nan)
```

In this PR I added a check for a valid pose before attempting to publish a tf and return an error in case of an invalid pose.