### PR TITLE
Improve antiwindup description

### DIFF
--- a/pid_controller/src/pid_controller.yaml
+++ b/pid_controller/src/pid_controller.yaml
@@ -63,17 +63,20 @@ pid_controller:
       antiwindup: {
         type: bool,
         default_value: false,
-        description: "Antiwindup functionality."
+        description: "Antiwindup functionality. When set to true, limits
+        the integral error to prevent windup; otherwise, constrains the
+        integral contribution to the control output. i_clamp_max and
+        i_clamp_min are applied in both scenarios."
       }
       i_clamp_max: {
         type: double,
         default_value: 0.0,
-        description: "Upper integral clamp. Only used if antiwindup is activated."
+        description: "Upper integral clamp."
       }
       i_clamp_min: {
         type: double,
         default_value: 0.0,
-        description: "Lower integral clamp. Only used if antiwindup is activated."
+        description: "Lower integral clamp."
       }
       feedforward_gain: {
         type: double,


### PR DESCRIPTION
Enhance the antiwindup description to accurately reflect its functionality in control_toolbox code.

[control_toolbox/src/pid.cpp::170:173](https://github.com/ros-controls/control_toolbox/blob/ros2-master/src/pid.cpp#L170C1-L173C4)
``` 
 if (!gains.antiwindup_) {
    // Limit i_term so that the limit is meaningful in the output
    i_term = std::clamp(i_term, gains.i_min_, gains.i_max_);
  }
```