### PR TITLE
docs for chainable diff_drive_controller (fixes #1512)

### DIFF
--- a/diff_drive_controller/doc/userdoc.rst
+++ b/diff_drive_controller/doc/userdoc.rst
@@ -20,6 +20,7 @@ Other features
    + Odometry publishing
    + Task-space velocity, acceleration and jerk limits
    + Automatic stop after command time-out
+   + Chainable Controller
 
 
 Description of controller's interfaces
@@ -28,7 +29,13 @@ Description of controller's interfaces
 References
 ,,,,,,,,,,,,,,,,,,
 
-(the controller is not yet implemented as chainable controller)
+When controller is in chained mode, it exposes the following references which can be commanded by the preceding controller:
+
+- ``<controller_name>/linear/velocity``      double, in m/s
+- ``<controller_name>/angular/velocity``     double, in rad/s
+
+Together, these represent the body twist (which in unchained-mode would be obtained from ~/cmd_vel).
+The ``<controller_name>`` is commonly set to ``diff_drive_controller``.
 
 Feedback
 ,,,,,,,,,,,,,,


### PR DESCRIPTION
I forgot to add documentation when I made the diff_drive_controller into a ChainableControllerInterface. Now the docs are updated.
