### PR TITLE
[pid_controller] Fix logic for feedforward_mode with single reference interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+/.vscode
+diff_drive_controller/.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-
-/.vscode
-diff_drive_controller/.vscode/settings.json

--- a/pid_controller/src/pid_controller.cpp
+++ b/pid_controller/src/pid_controller.cpp
@@ -500,7 +500,6 @@ controller_interface::return_type PidController::update_and_write_commands(
   {
     double tmp_command = 0.0;
 
-    // Using feedforward
     if (!std::isnan(reference_interfaces_[i]) && !std::isnan(measured_state_values_[i]))
     {
       // calculate feed-forward
@@ -509,9 +508,7 @@ controller_interface::return_type PidController::update_and_write_commands(
         // two interfaces
         if (reference_interfaces_.size() == 2 * dof_ && measured_state_values_.size() == 2 * dof_)
         {
-          if (
-            std::isfinite(reference_interfaces_[dof_ + i]) &&
-            std::isfinite(measured_state_values_[dof_ + i]))
+          if (std::isfinite(reference_interfaces_[dof_ + i]))
           {
             tmp_command = reference_interfaces_[dof_ + i] *
                           params_.gains.dof_names_map[params_.dof_names[i]].feedforward_gain;

--- a/pid_controller/src/pid_controller.cpp
+++ b/pid_controller/src/pid_controller.cpp
@@ -509,14 +509,15 @@ controller_interface::return_type PidController::update_and_write_commands(
         // two interfaces
         if (reference_interfaces_.size() == 2 * dof_ && measured_state_values_.size() == 2 * dof_)
         {
-          if (!std::isnan(reference_interfaces_[dof_ + i]) &&
-              !std::isnan(measured_state_values_[dof_ + i]))
+          if (
+            !std::isnan(reference_interfaces_[dof_ + i]) &&
+            !std::isnan(measured_state_values_[dof_ + i]))
           {
             tmp_command = reference_interfaces_[dof_ + i] *
                           params_.gains.dof_names_map[params_.dof_names[i]].feedforward_gain;
           }
         }
-        else // one interface
+        else  // one interface
         {
           tmp_command = reference_interfaces_[i] *
                         params_.gains.dof_names_map[params_.dof_names[i]].feedforward_gain;

--- a/pid_controller/src/pid_controller.cpp
+++ b/pid_controller/src/pid_controller.cpp
@@ -510,8 +510,8 @@ controller_interface::return_type PidController::update_and_write_commands(
         if (reference_interfaces_.size() == 2 * dof_ && measured_state_values_.size() == 2 * dof_)
         {
           if (
-            !std::isnan(reference_interfaces_[dof_ + i]) &&
-            !std::isnan(measured_state_values_[dof_ + i]))
+            std::isfinite(reference_interfaces_[dof_ + i]) &&
+            std::isfinite(measured_state_values_[dof_ + i]))
           {
             tmp_command = reference_interfaces_[dof_ + i] *
                           params_.gains.dof_names_map[params_.dof_names[i]].feedforward_gain;

--- a/pid_controller/test/pid_controller_params.yaml
+++ b/pid_controller/test/pid_controller_params.yaml
@@ -9,3 +9,16 @@ test_pid_controller:
 
     gains:
       joint1: {p: 1.0, i: 2.0, d: 10.0, i_clamp_max: 5.0, i_clamp_min: -5.0}
+
+
+test_pid_controller_with_feedforward_gain:
+  ros__parameters:
+    dof_names:
+      - joint1
+
+    command_interface: position
+
+    reference_and_state_interfaces: ["position"]
+
+    gains:
+      joint1: {p: 0.5, i: 0.0, d: 0.0, i_clamp_max: 5.0, i_clamp_min: -5.0, feedforward_gain: 1.0}

--- a/pid_controller/test/test_pid_controller.cpp
+++ b/pid_controller/test/test_pid_controller.cpp
@@ -550,8 +550,8 @@ TEST_F(PidControllerTest, test_update_chained_feedforward_with_gain)
   // state interface value is 1.1 as defined in test fixture
   // with p gain 0.5, the command value should be 0.5 * (5.0 - 1.1) = 1.95
   // with feedforward gain 1.0, the command value should be 1.95 + 1.0 * 5.0 = 6.95
-  auto target_value = 5.0;
-  auto exepected_command_value = 6.95;
+  const double target_value = 5.0;
+  const double expected_command_value = 6.95;
 
   SetUpController("test_pid_controller_with_feedforward_gain");
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
@@ -604,7 +604,7 @@ TEST_F(PidControllerTest, test_update_chained_feedforward_with_gain)
     controller_interface::return_type::OK);
 
   // check on result from update
-  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), exepected_command_value);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), expected_command_value);
 }
 
 /**
@@ -617,8 +617,8 @@ TEST_F(PidControllerTest, test_update_chained_feedforward_off_with_gain)
   // with p gain 0.5, the command value should be 0.5 * (5.0 - 1.1) = 1.95
   // with feedforward off, the command value should be still 1.95 even though feedforward gain
   // is 1.0
-  auto target_value = 5.0;
-  auto exepected_command_value = 1.95;
+  const double target_value = 5.0;
+  const double expected_command_value = 1.95;
 
   SetUpController("test_pid_controller_with_feedforward_gain");
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
@@ -670,7 +670,7 @@ TEST_F(PidControllerTest, test_update_chained_feedforward_off_with_gain)
     controller_interface::return_type::OK);
 
   // check on result from update
-  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), exepected_command_value);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), expected_command_value);
 }
 
 int main(int argc, char ** argv)

--- a/pid_controller/test/test_pid_controller.cpp
+++ b/pid_controller/test/test_pid_controller.cpp
@@ -521,6 +521,71 @@ TEST_F(PidControllerTest, receive_message_and_publish_updated_status)
   }
 }
 
+/**
+ * @brief check chained pid controller with feedforward and gain as non-zero, single interface
+ */
+TEST_F(PidControllerTest, test_update_chained_feedforward_with_gain)
+{
+  // state interface value is 1.1 as defined in test fixture
+  // with p gain 0.5, the command value should be 0.5 * (5.0 - 1.1) = 1.95
+  // with feedforward gain 1.0, the command value should be 1.95 + 1.0 * 5.0 = 6.95
+  auto target_value = 5.0;
+  auto exepected_command_value = 6.95;
+
+  SetUpController("test_pid_controller_with_feedforward_gain");
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+
+  // check on interfaces & pid gain parameters
+  for (const auto & dof_name : dof_names_)
+  {
+    ASSERT_EQ(controller_->params_.gains.dof_names_map[dof_name].p, 0.5);
+    ASSERT_EQ(controller_->params_.gains.dof_names_map[dof_name].feedforward_gain, 1.0);
+  }
+  ASSERT_EQ(controller_->params_.command_interface, command_interface_);
+  EXPECT_THAT(
+    controller_->params_.reference_and_state_interfaces,
+    testing::ElementsAreArray(state_interfaces_));
+  ASSERT_FALSE(controller_->params_.use_external_measured_states);
+
+  // setup executor
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
+  executor.add_node(service_caller_node_->get_node_base_interface());
+
+  controller_->set_chained_mode(true);
+
+  // activate controller
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(controller_->is_in_chained_mode());
+
+  // turn on feedforward
+  controller_->control_mode_.writeFromNonRT(feedforward_mode_type::ON);
+  ASSERT_EQ(*(controller_->control_mode_.readFromRT()), feedforward_mode_type::ON);
+
+  // send a message to update reference interface
+  std::shared_ptr<ControllerCommandMsg> msg = std::make_shared<ControllerCommandMsg>();
+  msg->dof_names = controller_->params_.dof_names;
+  msg->values.resize(msg->dof_names.size(), 0.0);
+  for (size_t i = 0; i < msg->dof_names.size(); ++i)
+  {
+    msg->values[i] = target_value;
+  }
+  msg->values_dot.resize(msg->dof_names.size(), std::numeric_limits<double>::quiet_NaN());
+  controller_->input_ref_.writeFromNonRT(msg);
+  ASSERT_EQ(
+    controller_->update_reference_from_subscribers(
+      rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // run update
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // check on result from update
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), exepected_command_value);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/pid_controller/test/test_pid_controller.hpp
+++ b/pid_controller/test/test_pid_controller.hpp
@@ -59,6 +59,7 @@ class TestablePidController : public pid_controller::PidController
   FRIEND_TEST(PidControllerTest, test_update_logic_chainable_feedforward_on);
   FRIEND_TEST(PidControllerTest, subscribe_and_get_messages_success);
   FRIEND_TEST(PidControllerTest, receive_message_and_publish_updated_status);
+  FRIEND_TEST(PidControllerTest, test_update_chained_feedforward_with_gain);
 
 public:
   controller_interface::CallbackReturn on_configure(

--- a/pid_controller/test/test_pid_controller.hpp
+++ b/pid_controller/test/test_pid_controller.hpp
@@ -60,6 +60,7 @@ class TestablePidController : public pid_controller::PidController
   FRIEND_TEST(PidControllerTest, subscribe_and_get_messages_success);
   FRIEND_TEST(PidControllerTest, receive_message_and_publish_updated_status);
   FRIEND_TEST(PidControllerTest, test_update_chained_feedforward_with_gain);
+  FRIEND_TEST(PidControllerTest, test_update_chained_feedforward_off_with_gain);
 
 public:
   controller_interface::CallbackReturn on_configure(


### PR DESCRIPTION
Address https://github.com/ros-controls/ros2_controllers/issues/1270.  The scope of the fix only covers single reference interface. The changes for two reference interfaces will be covered in different PR. 

Testing of the code changes was done with https://github.com/ros-controls/ros2_control_demos/pull/710. 