### PR TITLE
Fix reference in chained diff drive controller

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -618,7 +618,9 @@ bool DiffDriveController::reset()
 
 void DiffDriveController::reset_buffers()
 {
-  reference_interfaces_ = std::vector<double>(2, std::numeric_limits<double>::quiet_NaN());
+  std::fill(
+    reference_interfaces_.begin(), reference_interfaces_.end(),
+    std::numeric_limits<double>::quiet_NaN());
   // Empty out the old queue. Fill with zeros (not NaN) to catch early accelerations.
   std::queue<std::array<double, 2>> empty;
   std::swap(previous_two_commands_, empty);

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -335,6 +335,10 @@ controller_interface::CallbackReturn DiffDriveController::on_configure(
   cmd_vel_timeout_ = rclcpp::Duration::from_seconds(params_.cmd_vel_timeout);
   publish_limited_velocity_ = params_.publish_limited_velocity;
 
+  // Allocate reference interfaces if needed
+  const int nr_ref_itfs = 2;
+  reference_interfaces_.resize(nr_ref_itfs, std::numeric_limits<double>::quiet_NaN());
+
   // TODO(christophfroehlich) remove deprecated parameters
   // START DEPRECATED
   if (!params_.linear.x.has_velocity_limits)
@@ -716,10 +720,8 @@ bool DiffDriveController::on_set_chained_mode(bool chained_mode)
 std::vector<hardware_interface::CommandInterface>
 DiffDriveController::on_export_reference_interfaces()
 {
-  const int nr_ref_itfs = 2;
-  reference_interfaces_.resize(nr_ref_itfs, std::numeric_limits<double>::quiet_NaN());
   std::vector<hardware_interface::CommandInterface> reference_interfaces;
-  reference_interfaces.reserve(nr_ref_itfs);
+  reference_interfaces.reserve(reference_interfaces_.size());
 
   reference_interfaces.push_back(hardware_interface::CommandInterface(
     get_node()->get_name(), std::string("linear/") + hardware_interface::HW_IF_VELOCITY,


### PR DESCRIPTION
Hi,

There seems to be an issue with the new chained diff drive implementation from PR #1485.

I initially had an issue when chaining this (`malloc(): unaligned tcache chunk detected` after loading the upstream controller). However, while hunting down the error, I found that the cleanup phase is a more easily replicable scenario to get the same problem.
The bug can be reproduced following [these steps](https://github.com/tpoignonec/test_chained_diff_drive_controller )), but it boils down to dereferencing of the `reference_interfaces_` data in `DiffDriveController::reset_buffers()`: 

https://github.com/ros-controls/ros2_controllers/blob/5486fcd2a651e0f6ca9a1827d5d2871917b99c2c/diff_drive_controller/src/diff_drive_controller.cpp#L619-L627

This method is called at different points in the controller: `on_configure()`, `on_error()`, and `on_cleanup`. Each time, the previously exported reference interface is invalidated.

The `reset_buffer` method should not assign a new vector, at it invalidates the references. 
As far as I can see, there are only two options:

```cpp
// Keeps size, just updates values
reference_interfaces_.assign(
  reference_interfaces_.size(),
  std::numeric_limits<double>::quiet_NaN()); 

// or just use std::fill
std::fill(
  reference_interfaces_.begin(),
  reference_interfaces_.end(),
  std::numeric_limits<double>::quiet_NaN());
```

In the PR, I went with the `std::fill(...)` option, not sure if there is any argument for one against the other...

Additionally, I moved the resize to the `on_configure()` method to make sure the memory is allocated right away. Otherwise, some tests break (`reference_interfaces_` not allocated at first use).
Are there any guidelines about that?
That seems to be the way it is done in ros2_control_demos ([example_12](https://github.com/ros-controls/ros2_control_demos/blob/332ede0ee44f9c3382666df91a0b7d49a368652f/example_12/controllers/src/passthrough_controller.cpp#L82-L86)), but not in the steering_controllers_library.cpp:

https://github.com/ros-controls/ros2_controllers/blob/5486fcd2a651e0f6ca9a1827d5d2871917b99c2c/steering_controllers_library/src/steering_controllers_library.cpp#L311-L328
