### PR TITLE
Fix jazzy debian build's job name

### DIFF
--- a/.github/workflows/jazzy-debian-build.yml
+++ b/.github/workflows/jazzy-debian-build.yml
@@ -1,4 +1,4 @@
-name: Debian Rolling Source Build
+name: Debian Jazzy Source Build
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
The job gets cancelled by the rolling job otherwise

> Canceling since a higher priority waiting request for 'Debian Rolling Source Build-refs/pull/1196/merge' exists
