### PR TITLE
Fix use of M_PI in steering_controllers_library and tricycle_controller

### DIFF
--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -17,6 +17,8 @@
  * Author: Dr. Ing. Denis Stogl
  */
 
+#define _USE_MATH_DEFINES
+
 #include "steering_controllers_library/steering_odometry.hpp"
 
 #include <cmath>

--- a/steering_controllers_library/test/test_steering_odometry.cpp
+++ b/steering_controllers_library/test/test_steering_odometry.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define _USE_MATH_DEFINES
+
 #include <gmock/gmock.h>
 
 #include "steering_controllers_library/steering_odometry.hpp"

--- a/tricycle_controller/src/tricycle_controller.cpp
+++ b/tricycle_controller/src/tricycle_controller.cpp
@@ -16,6 +16,8 @@
  * Author: Tony Najjar
  */
 
+#define _USE_MATH_DEFINES
+
 #include <memory>
 #include <queue>
 #include <string>


### PR DESCRIPTION
The PR https://github.com/ros-controls/ros2_controllers/pull/1451 also accidentally deleted some `_USE_MATH_DEFINES` definition defined at the CMake level, that were added in https://github.com/ros-controls/ros2_controllers/pull/1036 . To fix this, I reintroduce the `_USE_MATH_DEFINES`, just at compilation unit level instead of CMake level, as discussed in https://github.com/ros-controls/ros2_control/pull/2001#issuecomment-2593684492 .



To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
