### PR TITLE
Cleanup dependencies (add `angles`, rm `filters`)

### DIFF
--- a/admittance_controller/package.xml
+++ b/admittance_controller/package.xml
@@ -27,20 +27,19 @@
   <depend>control_msgs</depend>
   <depend>control_toolbox</depend>
   <depend>controller_interface</depend>
-  <depend>kinematics_interface</depend>
-  <depend>filters</depend>
   <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
+  <depend>kinematics_interface</depend>
   <depend>pluginlib</depend>
-  <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>rclcpp</depend>
   <depend>realtime_tools</depend>
-  <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_kdl</depend>
   <depend>tf2_ros</depend>
+  <depend>tf2</depend>
   <depend>trajectory_msgs</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>

--- a/admittance_controller/package.xml
+++ b/admittance_controller/package.xml
@@ -22,6 +22,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>angles</depend>
   <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>control_toolbox</depend>


### PR DESCRIPTION
Might fix the failing job: https://build.ros2.org/job/Hbin_uJ64__admittance_controller__ubuntu_jammy_amd64__binary/155/consoleFull#console-section-15

It could be that one of the dependencies of the package removed this dependency and that's why we are noticing it now