### PR TITLE
[ForwardCommandController] Fix the duplicate command interface types when reconfiguring the controller

### DIFF
--- a/forward_command_controller/src/forward_command_controller.cpp
+++ b/forward_command_controller/src/forward_command_controller.cpp
@@ -45,6 +45,7 @@ controller_interface::CallbackReturn ForwardCommandController::read_parameters()
     return controller_interface::CallbackReturn::ERROR;
   }
 
+  command_interface_types_.clear();
   for (const auto & joint : params_.joints)
   {
     command_interface_types_.push_back(joint + "/" + params_.interface_name);


### PR DESCRIPTION
if we reconfigure the controller now, it simply appends and creates duplicates. Found the issue with : https://github.com/ros-controls/ros2_control/pull/2090