### PR TITLE
[jtc tests] avoid dangling ref of command / state interfaces

### DIFF
--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -122,6 +122,7 @@ protected:
   {
     TearDownControllerHardware();
     TearDownExecutor();
+    TrajectoryControllerTest::TearDown();
   }
 
   void TearDownExecutor()

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -259,6 +259,12 @@ public:
       controller_name_ + "/joint_trajectory", rclcpp::SystemDefaultsQoS());
   }
 
+  void TearDown() override
+  {
+    DeactivateTrajectoryController();
+    traj_controller_.reset();
+  }
+
   void SetUpTrajectoryController(
     rclcpp::Executor & executor, const std::vector<rclcpp::Parameter> & parameters = {},
     const std::string & urdf = ros2_control_test_assets::minimal_robot_urdf)

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -821,7 +821,7 @@ public:
     state_interface_types_ = std::get<1>(GetParam());
   }
 
-  virtual void TearDown() { TrajectoryControllerTest::DeactivateTrajectoryController(); }
+  virtual void TearDown() { TrajectoryControllerTest::TearDown(); }
 
   static void TearDownTestCase() { TrajectoryControllerTest::TearDownTestCase(); }
 };


### PR DESCRIPTION
This should avoid the problem mentioned in #1588. This makes the JTC tests run with ASAN without issues, but I haven't tested all the other packages.