### PR TITLE
Deprecate tf.publish_rate parameter for pose_broadcaster

### DIFF
--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -63,7 +63,7 @@ private:
   std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>
     realtime_publisher_;
 
-  // TODO: Remove these two member variables
+  // TODO(amronos): Remove these two member variables
   std::optional<rclcpp::Duration> tf_publish_period_;
   rclcpp::Time tf_last_publish_time_{0, 0, RCL_CLOCK_UNINITIALIZED};
 

--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -63,8 +63,10 @@ private:
   std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>
     realtime_publisher_;
 
+  // TODO: Remove these two member variables
   std::optional<rclcpp::Duration> tf_publish_period_;
   rclcpp::Time tf_last_publish_time_{0, 0, RCL_CLOCK_UNINITIALIZED};
+
   rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr tf_publisher_;
   std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>>
     realtime_tf_publisher_;

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -79,7 +79,7 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
 
   pose_sensor_ = std::make_unique<semantic_components::PoseSensor>(params_.pose_name);
 
-  // TODO: Remove this check and its contents
+  // TODO(amronos): Remove this check and its contents
   if (params_.tf.publish_rate == 0.0)
   {
     tf_publish_period_ = std::nullopt;

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -78,10 +78,21 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
   params_ = param_listener_->get_params();
 
   pose_sensor_ = std::make_unique<semantic_components::PoseSensor>(params_.pose_name);
-  tf_publish_period_ =
-    params_.tf.publish_rate == 0.0
-      ? std::nullopt
-      : std::optional{rclcpp::Duration::from_seconds(1.0 / params_.tf.publish_rate)};
+
+  // TODO: Remove this check and its contents
+  if (params_.tf.publish_rate == 0.0)
+  {
+    tf_publish_period_ = std::nullopt;
+  }
+  else
+  {
+    tf_publish_period_ =
+      std::optional{rclcpp::Duration::from_seconds(1.0 / params_.tf.publish_rate)};
+    RCLCPP_WARN(
+      get_node()->get_logger(),
+      "[deprecated] tf.publish_rate parameter is deprecated, please set the value to 0.0. "
+      "The publish rate of TF messages is no longer limited by this parameter.");
+  }
 
   try
   {
@@ -172,39 +183,19 @@ controller_interface::return_type PoseBroadcaster::update(
   }
   else if (realtime_tf_publisher_ && realtime_tf_publisher_->trylock())
   {
-    bool do_publish = false;
-    // rlcpp::Time comparisons throw if clock types are not the same
-    if (tf_last_publish_time_.get_clock_type() != time.get_clock_type())
-    {
-      do_publish = true;
-    }
-    else if (!tf_publish_period_ || (tf_last_publish_time_ + *tf_publish_period_ <= time))
-    {
-      do_publish = true;
-    }
+    auto & tf_transform = realtime_tf_publisher_->msg_.transforms[0];
+    tf_transform.header.stamp = time;
 
-    if (do_publish)
-    {
-      auto & tf_transform = realtime_tf_publisher_->msg_.transforms[0];
-      tf_transform.header.stamp = time;
+    tf_transform.transform.translation.x = pose.position.x;
+    tf_transform.transform.translation.y = pose.position.y;
+    tf_transform.transform.translation.z = pose.position.z;
 
-      tf_transform.transform.translation.x = pose.position.x;
-      tf_transform.transform.translation.y = pose.position.y;
-      tf_transform.transform.translation.z = pose.position.z;
+    tf_transform.transform.rotation.x = pose.orientation.x;
+    tf_transform.transform.rotation.y = pose.orientation.y;
+    tf_transform.transform.rotation.z = pose.orientation.z;
+    tf_transform.transform.rotation.w = pose.orientation.w;
 
-      tf_transform.transform.rotation.x = pose.orientation.x;
-      tf_transform.transform.rotation.y = pose.orientation.y;
-      tf_transform.transform.rotation.z = pose.orientation.z;
-      tf_transform.transform.rotation.w = pose.orientation.w;
-
-      realtime_tf_publisher_->unlockAndPublish();
-
-      tf_last_publish_time_ = time;
-    }
-    else
-    {
-      realtime_tf_publisher_->unlock();
-    }
+    realtime_tf_publisher_->unlockAndPublish();
   }
 
   return controller_interface::return_type::OK;

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -91,7 +91,7 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
     RCLCPP_WARN(
       get_node()->get_logger(),
       "[deprecated] tf.publish_rate parameter is deprecated, please set the value to 0.0. "
-      "The publish rate of TF messages is no longer limited by this parameter.");
+      "The publish rate of TF messages should not be limited.");
   }
 
   try
@@ -181,21 +181,42 @@ controller_interface::return_type PoseBroadcaster::update(
       pose.position.z, pose.orientation.x, pose.orientation.y, pose.orientation.z,
       pose.orientation.w);
   }
+  // TODO(amronos): Remove publish rate functionality
   else if (realtime_tf_publisher_ && realtime_tf_publisher_->trylock())
   {
-    auto & tf_transform = realtime_tf_publisher_->msg_.transforms[0];
-    tf_transform.header.stamp = time;
+    bool do_publish = false;
+    // rlcpp::Time comparisons throw if clock types are not the same
+    if (tf_last_publish_time_.get_clock_type() != time.get_clock_type())
+    {
+      do_publish = true;
+    }
+    else if (!tf_publish_period_ || (tf_last_publish_time_ + *tf_publish_period_ <= time))
+    {
+      do_publish = true;
+    }
 
-    tf_transform.transform.translation.x = pose.position.x;
-    tf_transform.transform.translation.y = pose.position.y;
-    tf_transform.transform.translation.z = pose.position.z;
+    if (do_publish)
+    {
+      auto & tf_transform = realtime_tf_publisher_->msg_.transforms[0];
+      tf_transform.header.stamp = time;
 
-    tf_transform.transform.rotation.x = pose.orientation.x;
-    tf_transform.transform.rotation.y = pose.orientation.y;
-    tf_transform.transform.rotation.z = pose.orientation.z;
-    tf_transform.transform.rotation.w = pose.orientation.w;
+      tf_transform.transform.translation.x = pose.position.x;
+      tf_transform.transform.translation.y = pose.position.y;
+      tf_transform.transform.translation.z = pose.position.z;
 
-    realtime_tf_publisher_->unlockAndPublish();
+      tf_transform.transform.rotation.x = pose.orientation.x;
+      tf_transform.transform.rotation.y = pose.orientation.y;
+      tf_transform.transform.rotation.z = pose.orientation.z;
+      tf_transform.transform.rotation.w = pose.orientation.w;
+
+      realtime_tf_publisher_->unlockAndPublish();
+
+      tf_last_publish_time_ = time;
+    }
+    else
+    {
+      realtime_tf_publisher_->unlock();
+    }
   }
 
   return controller_interface::return_type::OK;

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -23,10 +23,11 @@ pose_broadcaster:
       default_value: ""
       description: "Child frame id of published tf transforms. Defaults to ``pose_name`` if left
       empty."
+    # TODO: Remove this parameter as it is deprecated
     publish_rate:
       type: double
       default_value: 0.0
       description: "Rate to limit publishing of tf transforms to (Hz). If set to 0, no limiting is
-      performed."
+      performed. This parameter is deprecated and limiting is no longer performed."
       validation:
         gt_eq<>: 0.0

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -28,6 +28,6 @@ pose_broadcaster:
       type: double
       default_value: 0.0
       description: "Rate to limit publishing of tf transforms to (Hz). If set to 0, no limiting is
-      performed. This parameter is deprecated and limiting is no longer performed."
+      performed. This parameter is deprecated and limiting should not be performed."
       validation:
         gt_eq<>: 0.0

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -23,7 +23,7 @@ pose_broadcaster:
       default_value: ""
       description: "Child frame id of published tf transforms. Defaults to ``pose_name`` if left
       empty."
-    # TODO: Remove this parameter as it is deprecated
+    # TODO(amronos): Remove this parameter as it is deprecated
     publish_rate:
       type: double
       default_value: 0.0


### PR DESCRIPTION
First step towards #473.

I have deprecated the ``tf.publish_rate`` parameter and added necessary warnings.
I have added TODOs wherever needed for whenever Jazzy is branched off.