### PR TITLE
Use smart pointer of ctrl in GpsSensor and GpioCommandController tests

### DIFF
--- a/gpio_controllers/test/test_gpio_command_controller.cpp
+++ b/gpio_controllers/test/test_gpio_command_controller.cpp
@@ -95,7 +95,13 @@ public:
     rclcpp::init(0, nullptr);
     node = std::make_unique<rclcpp::Node>("node");
   }
+
   ~GpioCommandControllerTestSuite() { rclcpp::shutdown(); }
+
+  void SetUp() { controller_ = std::make_unique<FriendGpioCommandController>(); }
+
+  void TearDown() { controller_.reset(nullptr); }
+
   void setup_command_and_state_interfaces()
   {
     std::vector<LoanedCommandInterface> command_interfaces;
@@ -108,15 +114,15 @@ public:
     state_interfaces.emplace_back(gpio_1_2_dig_state);
     state_interfaces.emplace_back(gpio_2_ana_state);
 
-    controller.assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
+    controller_->assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
   }
 
   void move_to_activate_state(controller_interface::return_type result_of_initialization)
   {
     ASSERT_EQ(result_of_initialization, controller_interface::return_type::OK);
-    ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+    ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
     setup_command_and_state_interfaces();
-    ASSERT_EQ(controller.on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+    ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
   }
 
   void stop_test_when_message_cannot_be_published(int max_sub_check_loop_count)
@@ -138,7 +144,7 @@ public:
   void update_controller_loop()
   {
     ASSERT_EQ(
-      controller.update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+      controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
       controller_interface::return_type::OK);
   }
 
@@ -165,10 +171,10 @@ public:
   void wait_one_miliseconds_for_timeout()
   {
     rclcpp::executors::SingleThreadedExecutor executor;
-    executor.add_node(controller.get_node()->get_node_base_interface());
+    executor.add_node(controller_->get_node()->get_node_base_interface());
     const auto timeout = std::chrono::milliseconds{1};
-    const auto until = controller.get_node()->get_clock()->now() + timeout;
-    while (controller.get_node()->get_clock()->now() < until)
+    const auto until = controller_->get_node()->get_clock()->now() + timeout;
+    while (controller_->get_node()->get_clock()->now() < until)
     {
       executor.spin_some();
       std::this_thread::sleep_for(std::chrono::microseconds(10));
@@ -182,7 +188,7 @@ public:
     wait_set.add_subscription(subscription);
     while (max_sub_check_loop_count--)
     {
-      controller.update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+      controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
       if (wait_set.wait(std::chrono::milliseconds(2)).kind() == rclcpp::WaitResultKind::Ready)
       {
         break;
@@ -191,7 +197,7 @@ public:
     return max_sub_check_loop_count;
   }
 
-  FriendGpioCommandController controller;
+  std::unique_ptr<FriendGpioCommandController> controller_;
 
   const std::vector<std::string> gpio_names{"gpio1", "gpio2"};
   std::vector<double> gpio_commands{1.0, 0.0, 3.1};
@@ -209,9 +215,9 @@ public:
 
 TEST_F(GpioCommandControllerTestSuite, WhenNoParametersAreSetInitShouldFail)
 {
-  const auto result = controller.init(
+  const auto result = controller_->init(
     "test_gpio_command_controller", ros2_control_test_assets::minimal_robot_urdf, 0, "",
-    controller.define_custom_node_options());
+    controller_->define_custom_node_options());
   ASSERT_EQ(result, controller_interface::return_type::ERROR);
 }
 
@@ -219,7 +225,7 @@ TEST_F(GpioCommandControllerTestSuite, WhenGpiosParameterIsEmptyInitShouldFail)
 {
   const auto node_options =
     create_node_options_with_overriden_parameters({{"gpios", std::vector<std::string>{}}});
-  const auto result = controller.init("test_gpio_command_controller", "", 0, "", node_options);
+  const auto result = controller_->init("test_gpio_command_controller", "", 0, "", node_options);
 
   ASSERT_EQ(result, controller_interface::return_type::ERROR);
 }
@@ -230,7 +236,7 @@ TEST_F(GpioCommandControllerTestSuite, WhenInterfacesParameterForGpioIsEmptyInit
     {{"gpios", std::vector<std::string>{"gpio1"}},
      {"command_interfaces.gpio1.interfaces", std::vector<std::string>{}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{}}});
-  const auto result = controller.init("test_gpio_command_controller", "", 0, "", node_options);
+  const auto result = controller_->init("test_gpio_command_controller", "", 0, "", node_options);
 
   ASSERT_EQ(result, controller_interface::return_type::OK);
 }
@@ -239,7 +245,7 @@ TEST_F(GpioCommandControllerTestSuite, WhenInterfacesParameterForGpioIsNotSetIni
 {
   const auto node_options =
     create_node_options_with_overriden_parameters({{"gpios", std::vector<std::string>{"gpio1"}}});
-  const auto result = controller.init("test_gpio_command_controller", "", 0, "", node_options);
+  const auto result = controller_->init("test_gpio_command_controller", "", 0, "", node_options);
 
   ASSERT_EQ(result, controller_interface::return_type::OK);
 }
@@ -255,7 +261,7 @@ TEST_F(
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
 
-  const auto result = controller.init("test_gpio_command_controller", "", 0, "", node_options);
+  const auto result = controller_->init("test_gpio_command_controller", "", 0, "", node_options);
   ASSERT_EQ(result, controller_interface::return_type::OK);
 }
 
@@ -267,11 +273,11 @@ TEST_F(
     {{"gpios", std::vector<std::string>{"gpio1"}},
      {"command_interfaces.gpio1.interfaces", std::vector<std::string>{}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{}}});
-  const auto result = controller.init(
+  const auto result = controller_->init(
     "test_gpio_command_controller", ros2_control_test_assets::minimal_robot_urdf, 0, "",
     node_options);
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 }
 
 TEST_F(
@@ -282,11 +288,11 @@ TEST_F(
     {{"gpios", std::vector<std::string>{"gpio1"}},
      {"command_interfaces.gpio1.interfaces", std::vector<std::string>{}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{}}});
-  const auto result = controller.init(
+  const auto result = controller_->init(
     "test_gpio_command_controller", minimal_robot_urdf_with_gpio, 0, "", node_options);
 
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 }
 
 TEST_F(
@@ -297,10 +303,10 @@ TEST_F(
     {{"gpios", std::vector<std::string>{"gpio1"}},
      {"command_interfaces.gpio1.interfaces", std::vector<std::string>{}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{}}});
-  const auto result = controller.init("test_gpio_command_controller", "", 0, "", node_options);
+  const auto result = controller_->init("test_gpio_command_controller", "", 0, "", node_options);
 
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 }
 
 TEST_F(GpioCommandControllerTestSuite, ConfigureAndActivateParamsSuccess)
@@ -311,12 +317,12 @@ TEST_F(GpioCommandControllerTestSuite, ConfigureAndActivateParamsSuccess)
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  const auto result = controller.init("test_gpio_command_controller", "", 0, "", node_options);
+  const auto result = controller_->init("test_gpio_command_controller", "", 0, "", node_options);
 
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
   setup_command_and_state_interfaces();
-  ASSERT_EQ(controller.on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 }
 
 TEST_F(
@@ -329,10 +335,10 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  const auto result = controller.init("test_gpio_command_controller", "", 0, "", node_options);
+  const auto result = controller_->init("test_gpio_command_controller", "", 0, "", node_options);
 
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   std::vector<LoanedCommandInterface> command_interfaces;
   command_interfaces.emplace_back(gpio_1_1_dig_cmd);
@@ -343,8 +349,8 @@ TEST_F(
   state_interfaces.emplace_back(gpio_1_2_dig_state);
   state_interfaces.emplace_back(gpio_2_ana_state);
 
-  controller.assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
-  ASSERT_EQ(controller.on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  controller_->assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 }
 
 TEST_F(
@@ -357,10 +363,10 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  const auto result = controller.init("test_gpio_command_controller", "", 0, "", node_options);
+  const auto result = controller_->init("test_gpio_command_controller", "", 0, "", node_options);
 
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   std::vector<LoanedCommandInterface> command_interfaces;
   command_interfaces.emplace_back(gpio_1_1_dig_cmd);
@@ -371,9 +377,9 @@ TEST_F(
   state_interfaces.emplace_back(gpio_1_1_dig_state);
   state_interfaces.emplace_back(gpio_1_2_dig_state);
 
-  controller.assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
+  controller_->assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
 
-  ASSERT_EQ(controller.on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
 }
 
 TEST_F(
@@ -386,10 +392,10 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  const auto result = controller.init("test_gpio_command_controller", "", 0, "", node_options);
+  const auto result = controller_->init("test_gpio_command_controller", "", 0, "", node_options);
 
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   std::vector<LoanedCommandInterface> command_interfaces;
   command_interfaces.emplace_back(gpio_1_1_dig_cmd);
@@ -400,9 +406,9 @@ TEST_F(
   state_interfaces.emplace_back(gpio_1_1_dig_state);
   state_interfaces.emplace_back(gpio_2_ana_state);
 
-  controller.assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
+  controller_->assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
 
-  ASSERT_EQ(controller.on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 }
 
 TEST_F(
@@ -416,7 +422,8 @@ TEST_F(
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
 
-  move_to_activate_state(controller.init("test_gpio_command_controller", "", 0, "", node_options));
+  move_to_activate_state(
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options));
   assert_default_command_and_state_values();
   update_controller_loop();
   assert_default_command_and_state_values();
@@ -432,14 +439,15 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  move_to_activate_state(controller.init("test_gpio_command_controller", "", 0, "", node_options));
+  move_to_activate_state(
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options));
 
   const auto command = createGpioCommand(
     {"gpio1", "gpio2"}, {createInterfaceValue({"dig.1", "dig.2"}, {0.0, 1.0, 1.0}),
                          createInterfaceValue({"ana.1"}, {30.0})});
-  controller.rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
+  controller_->rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
   ASSERT_EQ(
-    controller.update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::ERROR);
 }
 
@@ -453,14 +461,15 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  move_to_activate_state(controller.init("test_gpio_command_controller", "", 0, "", node_options));
+  move_to_activate_state(
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options));
 
   const auto command = createGpioCommand(
     {"gpio1", "gpio2"},
     {createInterfaceValue({"dig.1", "dig.2"}, {0.0}), createInterfaceValue({"ana.1"}, {30.0})});
-  controller.rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
+  controller_->rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
   ASSERT_EQ(
-    controller.update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::ERROR);
 }
 
@@ -474,12 +483,13 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  move_to_activate_state(controller.init("test_gpio_command_controller", "", 0, "", node_options));
+  move_to_activate_state(
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options));
 
   const auto command = createGpioCommand(
     {"gpio1", "gpio2"}, {createInterfaceValue({"dig.1", "dig.2"}, {0.0, 1.0}),
                          createInterfaceValue({"ana.1"}, {30.0})});
-  controller.rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
+  controller_->rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
   update_controller_loop();
 
   ASSERT_EQ(gpio_1_1_dig_cmd.get_value(), 0.0);
@@ -497,12 +507,13 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  move_to_activate_state(controller.init("test_gpio_command_controller", "", 0, "", node_options));
+  move_to_activate_state(
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options));
 
   const auto command = createGpioCommand(
     {"gpio2", "gpio1"}, {createInterfaceValue({"ana.1"}, {30.0}),
                          createInterfaceValue({"dig.2", "dig.1"}, {1.0, 0.0})});
-  controller.rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
+  controller_->rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
   update_controller_loop();
 
   ASSERT_EQ(gpio_1_1_dig_cmd.get_value(), 0.0);
@@ -520,12 +531,13 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  move_to_activate_state(controller.init("test_gpio_command_controller", "", 0, "", node_options));
+  move_to_activate_state(
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options));
 
   const auto command =
     createGpioCommand({"gpio1"}, {createInterfaceValue({"dig.1", "dig.2"}, {0.0, 1.0})});
 
-  controller.rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
+  controller_->rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
   update_controller_loop();
 
   ASSERT_EQ(gpio_1_1_dig_cmd.get_value(), 0.0);
@@ -543,13 +555,14 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  move_to_activate_state(controller.init("test_gpio_command_controller", "", 0, "", node_options));
+  move_to_activate_state(
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options));
 
   const auto command = createGpioCommand(
     {"gpio1", "gpio3"}, {createInterfaceValue({"dig.3", "dig.4"}, {20.0, 25.0}),
                          createInterfaceValue({"ana.1"}, {21.0})});
 
-  controller.rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
+  controller_->rt_command_ptr_.writeFromNonRT(std::make_shared<CmdType>(command));
   update_controller_loop();
 
   ASSERT_EQ(gpio_1_1_dig_cmd.get_value(), gpio_commands.at(0));
@@ -567,10 +580,11 @@ TEST_F(
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  move_to_activate_state(controller.init("test_gpio_command_controller", "", 0, "", node_options));
+  move_to_activate_state(
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options));
 
   auto command_pub = node->create_publisher<CmdType>(
-    std::string(controller.get_node()->get_name()) + "/commands", rclcpp::SystemDefaultsQoS());
+    std::string(controller_->get_node()->get_name()) + "/commands", rclcpp::SystemDefaultsQoS());
   const auto command = createGpioCommand(
     {"gpio1", "gpio2"}, {createInterfaceValue({"dig.1", "dig.2"}, {0.0, 1.0}),
                          createInterfaceValue({"ana.1"}, {30.0})});
@@ -591,10 +605,11 @@ TEST_F(GpioCommandControllerTestSuite, ControllerShouldPublishGpioStatesWithCurr
      {"command_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}},
      {"state_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1", "dig.2"}},
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
-  move_to_activate_state(controller.init("test_gpio_command_controller", "", 0, "", node_options));
+  move_to_activate_state(
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options));
 
   auto subscription = node->create_subscription<StateType>(
-    std::string(controller.get_node()->get_name()) + "/gpio_states", 10,
+    std::string(controller_->get_node()->get_name()) + "/gpio_states", 10,
     [&](const StateType::SharedPtr) {});
 
   stop_test_when_message_cannot_be_published(wait_for_subscription(subscription));
@@ -630,15 +645,15 @@ TEST_F(
   state_interfaces.emplace_back(gpio_1_1_dig_state);
   state_interfaces.emplace_back(gpio_2_ana_state);
 
-  const auto result_of_initialization = controller.init(
+  const auto result_of_initialization = controller_->init(
     "test_gpio_command_controller", minimal_robot_urdf_with_gpio, 0, "", node_options);
   ASSERT_EQ(result_of_initialization, controller_interface::return_type::OK);
-  ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
-  controller.assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
-  ASSERT_EQ(controller.on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  controller_->assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   auto subscription = node->create_subscription<StateType>(
-    std::string(controller.get_node()->get_name()) + "/gpio_states", 10,
+    std::string(controller_->get_node()->get_name()) + "/gpio_states", 10,
     [&](const StateType::SharedPtr) {});
 
   stop_test_when_message_cannot_be_published(wait_for_subscription(subscription));
@@ -667,14 +682,14 @@ TEST_F(
   state_interfaces.emplace_back(gpio_2_ana_state);
 
   const auto result_of_initialization =
-    controller.init("test_gpio_command_controller", "", 0, "", node_options);
+    controller_->init("test_gpio_command_controller", "", 0, "", node_options);
   ASSERT_EQ(result_of_initialization, controller_interface::return_type::OK);
-  ASSERT_EQ(controller.on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
-  controller.assign_interfaces({}, std::move(state_interfaces));
-  ASSERT_EQ(controller.on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  controller_->assign_interfaces({}, std::move(state_interfaces));
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   auto subscription = node->create_subscription<StateType>(
-    std::string(controller.get_node()->get_name()) + "/gpio_states", 10,
+    std::string(controller_->get_node()->get_name()) + "/gpio_states", 10,
     [&](const StateType::SharedPtr) {});
 
   stop_test_when_message_cannot_be_published(wait_for_subscription(subscription));

--- a/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
+++ b/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
@@ -60,11 +60,7 @@ class GPSSensorBroadcasterTest : public ::testing::Test
 public:
   GPSSensorBroadcasterTest() { rclcpp::init(0, nullptr); }
 
-  ~GPSSensorBroadcasterTest()
-  {
-    gps_broadcaster_.reset(nullptr);
-    rclcpp::shutdown();
-  }
+  ~GPSSensorBroadcasterTest() { rclcpp::shutdown(); }
 
   void SetUp()
   {


### PR DESCRIPTION
**Summary:**
I am updating the tests to use smart pointers for the gps broadcaster and gpio controller. This is similar to other tests e.g. test_pose_broadcaster.cpp
This to remove warning LifecycleNode is not shut down during test as shown in test log [https://github.com/ros-controls/ros2_controllers/actions/runs/14608595520/job/40982298949](). Issue is captured in https://github.com/ros-controls/ros2_controllers/issues/1656
 
 **Qualification**
 $ pre-commit install
 $ colcon build --packages-select gpio_controllers gps_sensor_broadcaster
 $ colcon test --packages-select gpio_controllers gps_sensor_broadcaster --event-handlers console_direct+
 See that the warnings are no longer present

I am relatively new to ROS/2 and ros_control ecosystems, let me know if I am missing anything, thanks!

 ===
 
 
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. Don’t be afraid to request reviews from maintainers.
5. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
