### PR TITLE
Remove deprecated parameter from pose_broadcaster

### DIFF
--- a/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
+++ b/pose_broadcaster/include/pose_broadcaster/pose_broadcaster.hpp
@@ -63,10 +63,6 @@ private:
   std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>
     realtime_publisher_;
 
-  // TODO(amronos): Remove these two member variables
-  std::optional<rclcpp::Duration> tf_publish_period_;
-  rclcpp::Time tf_last_publish_time_{0, 0, RCL_CLOCK_UNINITIALIZED};
-
   rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr tf_publisher_;
   std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>>
     realtime_tf_publisher_;

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -79,21 +79,6 @@ controller_interface::CallbackReturn PoseBroadcaster::on_configure(
 
   pose_sensor_ = std::make_unique<semantic_components::PoseSensor>(params_.pose_name);
 
-  // TODO(amronos): Remove this check and its contents
-  if (params_.tf.publish_rate == 0.0)
-  {
-    tf_publish_period_ = std::nullopt;
-  }
-  else
-  {
-    tf_publish_period_ =
-      std::optional{rclcpp::Duration::from_seconds(1.0 / params_.tf.publish_rate)};
-    RCLCPP_WARN(
-      get_node()->get_logger(),
-      "[deprecated] tf.publish_rate parameter is deprecated, please set the value to 0.0. "
-      "The publish rate of TF messages should not be limited.");
-  }
-
   try
   {
     pose_publisher_ = get_node()->create_publisher<geometry_msgs::msg::PoseStamped>(

--- a/pose_broadcaster/src/pose_broadcaster.cpp
+++ b/pose_broadcaster/src/pose_broadcaster.cpp
@@ -166,7 +166,6 @@ controller_interface::return_type PoseBroadcaster::update(
       pose.position.z, pose.orientation.x, pose.orientation.y, pose.orientation.z,
       pose.orientation.w);
   }
-  // TODO(amronos): Remove publish rate functionality
   else if (realtime_tf_publisher_ && realtime_tf_publisher_->trylock())
   {
     auto & tf_transform = realtime_tf_publisher_->msg_.transforms[0];
@@ -182,8 +181,6 @@ controller_interface::return_type PoseBroadcaster::update(
     tf_transform.transform.rotation.w = pose.orientation.w;
 
     realtime_tf_publisher_->unlockAndPublish();
-
-    tf_last_publish_time_ = time;
   }
 
   return controller_interface::return_type::OK;

--- a/pose_broadcaster/src/pose_broadcaster_parameters.yaml
+++ b/pose_broadcaster/src/pose_broadcaster_parameters.yaml
@@ -23,11 +23,3 @@ pose_broadcaster:
       default_value: ""
       description: "Child frame id of published tf transforms. Defaults to ``pose_name`` if left
       empty."
-    # TODO(amronos): Remove this parameter as it is deprecated
-    publish_rate:
-      type: double
-      default_value: 0.0
-      description: "Rate to limit publishing of tf transforms to (Hz). If set to 0, no limiting is
-      performed. This parameter is deprecated and limiting should not be performed."
-      validation:
-        gt_eq<>: 0.0


### PR DESCRIPTION
Related to #1614 which was released to rolling 4.24.0, which got not synced already -> we should not merge/release this before the sync