### PR TITLE
Remove CMAKE_CXX_STANDARD

### DIFF
--- a/range_sensor_broadcaster/CMakeLists.txt
+++ b/range_sensor_broadcaster/CMakeLists.txt
@@ -1,12 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(range_sensor_broadcaster)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 find_package(ros2_control_cmake REQUIRED)
 set_compiler_options()
 export_windows_symbols()


### PR DESCRIPTION
because it is defined here now: https://github.com/ros-controls/ros2_control_cmake/pull/7