### PR TITLE
Fix JSB CMakeLists

### DIFF
--- a/gpio_controllers/CMakeLists.txt
+++ b/gpio_controllers/CMakeLists.txt
@@ -32,7 +32,6 @@ target_link_libraries(gpio_controllers PUBLIC
                       pluginlib::pluginlib
                       rclcpp::rclcpp
                       rclcpp_lifecycle::rclcpp_lifecycle
-                      rcutils::rcutils
                       realtime_tools::realtime_tools
                       ${control_msgs_TARGETS}
                       ${builtin_interfaces_TARGETS})

--- a/joint_state_broadcaster/CMakeLists.txt
+++ b/joint_state_broadcaster/CMakeLists.txt
@@ -37,7 +37,6 @@ target_include_directories(joint_state_broadcaster PUBLIC
 )
 target_link_libraries(joint_state_broadcaster PUBLIC
                       joint_state_broadcaster_parameters
-                      controller_manager::controller_manager
                       controller_interface::controller_interface
                       pluginlib::pluginlib
                       rclcpp::rclcpp
@@ -61,6 +60,9 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_load_joint_state_broadcaster
     joint_state_broadcaster
+    controller_manager::controller_manager
+    hardware_interface::hardware_interface
+    rclcpp::rclcpp
     ros2_control_test_assets::ros2_control_test_assets)
 
   ament_add_gmock(test_joint_state_broadcaster

--- a/joint_state_broadcaster/CMakeLists.txt
+++ b/joint_state_broadcaster/CMakeLists.txt
@@ -12,7 +12,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   generate_parameter_library
   pluginlib
   rclcpp_lifecycle
-  rcutils
   realtime_tools
   sensor_msgs
   urdf
@@ -45,7 +44,6 @@ target_link_libraries(joint_state_broadcaster PUBLIC
                       rclcpp_lifecycle::rclcpp_lifecycle
                       realtime_tools::realtime_tools
                       urdf::urdf
-                      rcutils::rcutils
                       ${sensor_msgs_TARGETS}
                       ${control_msgs_TARGETS}
                       ${builtin_interfaces_TARGETS})

--- a/joint_state_broadcaster/package.xml
+++ b/joint_state_broadcaster/package.xml
@@ -30,7 +30,6 @@
   <depend>pluginlib</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rclcpp</depend>
-  <depend>rcutils</depend>
   <depend>realtime_tools</depend>
   <depend>sensor_msgs</depend>
   <depend>urdf</depend>


### PR DESCRIPTION
https://build.ros2.org/job/Rbin_uN64__joint_state_broadcaster__ubuntu_noble_amd64__binary/115/console

```
16:05:19 CMake Error at CMakeLists.txt:39 (target_link_libraries):
16:05:19   Target "joint_state_broadcaster" links to:
16:05:19 
16:05:19     controller_manager::controller_manager
16:05:19 
16:05:19   but the target was not found.  Possible reasons include:
16:05:19 
16:05:19     * There is a typo in the target name.
16:05:19     * A find_package call is missing for an IMPORTED target.
16:05:19     * An ALIAS target is missing.
```

We don't need to link the CM here? and some other cleanups.