### PR TITLE
Fix: Reset both sec and nanosec in time_from_start

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -167,7 +167,8 @@ controller_interface::return_type JointTrajectoryController::update(
   }
 
   // current state update
-  state_current_.time_from_start.set__sec(0);
+  state_current_.time_from_start.sec = 0;
+  state_current_.time_from_start.nanosec = 0;
   read_state_from_state_interfaces(state_current_);
 
   // currently carrying out a trajectory


### PR DESCRIPTION
Fixes issue #1708 by resetting both seconds and nanoseconds in `time_from_start`.

Previously, only seconds were reset with `set__sec(0)`, but nanoseconds remained unchanged, causing incorrect time resets.

This patch sets both `sec` and `nanosec` to zero explicitly.