### PR TITLE
Revert temporary logging changes added for CI timeout investigation

### DIFF
--- a/force_torque_sensor_broadcaster/src/force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/src/force_torque_sensor_broadcaster.cpp
@@ -76,12 +76,6 @@ controller_interface::CallbackReturn ForceTorqueSensorBroadcaster::on_configure(
   {
     force_torque_sensor_ = std::make_unique<semantic_components::ForceTorqueSensor>(
       semantic_components::ForceTorqueSensor(params_.sensor_name));
-
-    // TODO(juliaj): remove the logging after resolving
-    // https://github.com/ros-controls/ros2_controllers/issues/1574
-    RCLCPP_INFO(
-      get_node()->get_logger(), "Initialized force_torque_sensor with sensor name %s",
-      params_.sensor_name.c_str());
   }
   else
   {
@@ -91,14 +85,6 @@ controller_interface::CallbackReturn ForceTorqueSensorBroadcaster::on_configure(
       semantic_components::ForceTorqueSensor(
         force_names.x, force_names.y, force_names.z, torque_names.x, torque_names.y,
         torque_names.z));
-
-    // TODO(juliaj): remove the logging after resolving
-    // https://github.com/ros-controls/ros2_controllers/issues/1574
-    RCLCPP_INFO(
-      get_node()->get_logger(),
-      "Initialized force_torque_sensor with interface names %s, %s, %s, %s, %s, %s",
-      force_names.x.c_str(), force_names.y.c_str(), force_names.z.c_str(), torque_names.x.c_str(),
-      torque_names.y.c_str(), torque_names.z.c_str());
   }
 
   try
@@ -116,19 +102,11 @@ controller_interface::CallbackReturn ForceTorqueSensorBroadcaster::on_configure(
     return controller_interface::CallbackReturn::ERROR;
   }
 
-  // TODO(juliaj): remove the logging after resolving
-  // https://github.com/ros-controls/ros2_controllers/issues/1574
-  RCLCPP_INFO(get_node()->get_logger(), "Locking realtime publisher");
   realtime_publisher_->lock();
-  RCLCPP_INFO(get_node()->get_logger(), "Locked realtime publisher");
-
   realtime_publisher_->msg_.header.frame_id = params_.frame_id;
-
-  RCLCPP_INFO(get_node()->get_logger(), "Unlocking realtime publisher");
   realtime_publisher_->unlock();
-  RCLCPP_INFO(get_node()->get_logger(), "Unlocked realtime publisher");
 
-  RCLCPP_INFO(get_node()->get_logger(), "Configure successful");
+  RCLCPP_INFO(get_node()->get_logger(), "configure successful");
   return controller_interface::CallbackReturn::SUCCESS;
 }
 

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
@@ -48,13 +48,7 @@ void ForceTorqueSensorBroadcasterTest::SetUp()
   fts_broadcaster_ = std::make_unique<FriendForceTorqueSensorBroadcaster>();
 }
 
-void ForceTorqueSensorBroadcasterTest::TearDown()
-{
-  // TODO(juliaj): remove the logging after resolving
-  // https://github.com/ros-controls/ros2_controllers/issues/1574
-  RCLCPP_INFO(fts_broadcaster_->get_node()->get_logger(), "In TearDown");
-  fts_broadcaster_.reset(nullptr);
-}
+void ForceTorqueSensorBroadcasterTest::TearDown() { fts_broadcaster_.reset(nullptr); }
 
 void ForceTorqueSensorBroadcasterTest::SetUpFTSBroadcaster()
 {
@@ -72,9 +66,6 @@ void ForceTorqueSensorBroadcasterTest::SetUpFTSBroadcaster()
   state_ifs.emplace_back(fts_torque_z_);
 
   fts_broadcaster_->assign_interfaces({}, std::move(state_ifs));
-  // TODO(juliaj): remove the logging after resolving
-  // https://github.com/ros-controls/ros2_controllers/issues/1574
-  RCLCPP_INFO(fts_broadcaster_->get_node()->get_logger(), "FTSBroadcaster setup done");
 }
 
 void ForceTorqueSensorBroadcasterTest::subscribe_and_get_message(
@@ -188,10 +179,6 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_Configure_Success)
 TEST_F(ForceTorqueSensorBroadcasterTest, InterfaceNames_Configure_Success)
 {
   SetUpFTSBroadcaster();
-
-  // TODO(juliaj): remove the logging after resolving
-  // https://github.com/ros-controls/ros2_controllers/issues/1574
-  RCLCPP_INFO(fts_broadcaster_->get_node()->get_logger(), "Setting up interface names");
 
   // set the 'interface_names'
   fts_broadcaster_->get_node()->set_parameter({"interface_names.force.x", "fts_sensor/force.x"});


### PR DESCRIPTION
Revert https://github.com/ros-controls/ros2_controllers/pull/1639.  

It looks like @saikishor's  [fix](https://github.com/ros-controls/realtime_tools/pull/320) in the the destructor of `RealtimePublisher` is working. 