### PR TITLE
Fix atomic variables in JTC

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -155,7 +155,7 @@ protected:
   // True if holding position or repeating last trajectory point in case of success
   std::atomic<bool> rt_is_holding_{false};
   // TODO(karsten1987): eventually activate and deactivate subscriber directly when its supported
-  bool subscriber_is_active_ = false;
+  std::atomic<bool> subscriber_is_active_{false};
   rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr joint_command_subscriber_ =
     nullptr;
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -153,7 +153,7 @@ protected:
   // Timeout to consider commands old
   double cmd_timeout_;
   // True if holding position or repeating last trajectory point in case of success
-  std::atomic<bool> rt_is_holding_;
+  std::atomic<bool> rt_is_holding_{false};
   // TODO(karsten1987): eventually activate and deactivate subscriber directly when its supported
   bool subscriber_is_active_ = false;
   rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr joint_command_subscriber_ =
@@ -179,8 +179,8 @@ protected:
   using RealtimeGoalHandleBuffer = realtime_tools::RealtimeBuffer<RealtimeGoalHandlePtr>;
 
   rclcpp_action::Server<FollowJTrajAction>::SharedPtr action_server_;
-  RealtimeGoalHandleBuffer rt_active_goal_;  ///< Currently active action goal, if any.
-  std::atomic<bool> rt_has_pending_goal_;    ///< Is there a pending action goal?
+  RealtimeGoalHandleBuffer rt_active_goal_;       ///< Currently active action goal, if any.
+  std::atomic<bool> rt_has_pending_goal_{false};  ///< Is there a pending action goal?
   rclcpp::TimerBase::SharedPtr goal_handle_timer_;
   rclcpp::Duration action_monitor_period_ = rclcpp::Duration(50ms);
 


### PR DESCRIPTION
Explicitly initialize them, should fix the error reported with https://github.com/ros-controls/ros2_controllers/pull/1720#issuecomment-2954973398

I don't know why the tests did not cover this?

Furthermore, I saw that `subscriber_is_active_` should be atomic too, as it is used in both threads.