### PR TITLE
Remove deprecated feedforward parameter+service

### DIFF
--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -11,3 +11,7 @@ The ``effort_controllers/GripperActionController`` and ``position_controllers/Gr
 diff_drive_controller
 *****************************
 * Parameters ``has_velocity_limits``, ``has_acceleration_limits``, and ``has_jerk_limits`` are removed. Instead, set the respective limits to ``.NAN``. (`#1653 <https://github.com/ros-controls/ros2_controllers/pull/1653>`_).
+
+pid_controller
+*****************************
+* Parameters ``enable_feedforward`` and service ``set_feedforward_control`` are removed. Instead, set the feedforward_gain to zero or a non-zero value. (`#1553 <https://github.com/ros-controls/ros2_controllers/pull/1553>`_).

--- a/pid_controller/doc/userdoc.rst
+++ b/pid_controller/doc/userdoc.rst
@@ -69,14 +69,6 @@ If controller parameter ``use_external_measured_states`` is true:
 
 - <controller_name>/measured_state  [control_msgs/msg/MultiDOFCommand]
 
-Services
-,,,,,,,,,,,
-
-- <controller_name>/set_feedforward_control  [std_srvs/srv/SetBool]
-
-.. warning::
-   This service is being deprecated in favour of setting the ``feedforward_gain`` parameter to a non-zero value.
-
 Publishers
 ,,,,,,,,,,,
 - <controller_name>/controller_state  [control_msgs/msg/MultiDOFStateStamped]
@@ -88,10 +80,6 @@ The PID controller uses the `generate_parameter_library <https://github.com/Pick
 
 List of parameters
 =========================
-.. warning::
-   The parameter ``enable_feedforward`` is being deprecated in favor of setting the ``feedforward_gain`` parameter to a non-zero value.
-   This might cause different behavior in the future if currently the ``feedforward_gain`` is set to a non-zero value and not activated.
-
 .. generate_parameter_library_details:: ../src/pid_controller.yaml
 
 

--- a/pid_controller/include/pid_controller/pid_controller.hpp
+++ b/pid_controller/include/pid_controller/pid_controller.hpp
@@ -77,8 +77,6 @@ protected:
 
   using PidPtr = std::shared_ptr<control_toolbox::PidROS>;
   std::vector<PidPtr> pids_;
-  // Feed-forward velocity weight factor when calculating closed loop pid adapter's command
-  std::vector<double> feedforward_gain_;
 
   // Command subscribers and Controller State publisher
   rclcpp::Subscription<ControllerReferenceMsg>::SharedPtr ref_subscriber_ = nullptr;
@@ -86,9 +84,6 @@ protected:
 
   rclcpp::Subscription<ControllerMeasuredStateMsg>::SharedPtr measured_state_subscriber_ = nullptr;
   realtime_tools::RealtimeBuffer<std::shared_ptr<ControllerMeasuredStateMsg>> measured_state_;
-
-  rclcpp::Service<ControllerModeSrvType>::SharedPtr set_feedforward_control_service_;
-  realtime_tools::RealtimeBuffer<bool> feedforward_mode_enabled_;
 
   using ControllerStatePublisher = realtime_tools::RealtimePublisher<ControllerStateMsg>;
 

--- a/pid_controller/src/pid_controller.cpp
+++ b/pid_controller/src/pid_controller.cpp
@@ -74,8 +74,6 @@ PidController::PidController() : controller_interface::ChainableControllerInterf
 
 controller_interface::CallbackReturn PidController::on_init()
 {
-  feedforward_mode_enabled_.initRT(false);
-
   try
   {
     param_listener_ = std::make_shared<pid_controller::ParamListener>(get_node());
@@ -96,8 +94,6 @@ void PidController::update_parameters()
     return;
   }
   params_ = param_listener_->get_params();
-
-  feedforward_mode_enabled_.writeFromNonRT(params_.enable_feedforward);
 }
 
 controller_interface::CallbackReturn PidController::configure_parameters()
@@ -240,24 +236,6 @@ controller_interface::CallbackReturn PidController::on_configure(
 
   measured_state_values_.resize(
     dof_ * params_.reference_and_state_interfaces.size(), std::numeric_limits<double>::quiet_NaN());
-
-  auto set_feedforward_control_callback =
-    [&](
-      const std::shared_ptr<ControllerModeSrvType::Request> request,
-      std::shared_ptr<ControllerModeSrvType::Response> response)
-  {
-    feedforward_mode_enabled_.writeFromNonRT(request->data);
-
-    RCLCPP_WARN(
-      get_node()->get_logger(),
-      "This service will be deprecated in favour of setting the ``feedforward_gain`` parameter to "
-      "a non-zero value.");
-
-    response->success = true;
-  };
-
-  set_feedforward_control_service_ = get_node()->create_service<ControllerModeSrvType>(
-    "~/set_feedforward_control", set_feedforward_control_callback, qos_services);
 
   try
   {
@@ -494,7 +472,10 @@ controller_interface::return_type PidController::update_and_write_commands(
   {
     for (size_t i = 0; i < measured_state_values_.size(); ++i)
     {
-      measured_state_values_[i] = state_interfaces_[i].get_value();
+      const auto measured_state = state_interfaces_[i].get_optional();
+      measured_state_values_[i] = measured_state.has_value()
+                                    ? measured_state.value()
+                                    : std::numeric_limits<double>::quiet_NaN();
     }
   }
 
@@ -512,22 +493,19 @@ controller_interface::return_type PidController::update_and_write_commands(
     if (std::isfinite(reference_interfaces_[i]) && std::isfinite(measured_state_values_[i]))
     {
       // calculate feed-forward
-      if (*(feedforward_mode_enabled_.readFromRT()))
+      // two interfaces
+      if (reference_interfaces_.size() == 2 * dof_)
       {
-        // two interfaces
-        if (reference_interfaces_.size() == 2 * dof_)
+        if (std::isfinite(reference_interfaces_[dof_ + i]))
         {
-          if (std::isfinite(reference_interfaces_[dof_ + i]))
-          {
-            tmp_command = reference_interfaces_[dof_ + i] *
-                          params_.gains.dof_names_map[params_.dof_names[i]].feedforward_gain;
-          }
-        }
-        else  // one interface
-        {
-          tmp_command = reference_interfaces_[i] *
+          tmp_command = reference_interfaces_[dof_ + i] *
                         params_.gains.dof_names_map[params_.dof_names[i]].feedforward_gain;
         }
+      }
+      else  // one interface
+      {
+        tmp_command = reference_interfaces_[i] *
+                      params_.gains.dof_names_map[params_.dof_names[i]].feedforward_gain;
       }
 
       double error = reference_interfaces_[i] - measured_state_values_[i];
@@ -599,7 +577,11 @@ controller_interface::return_type PidController::update_and_write_commands(
       state_publisher_->msg_.dof_states[i].time_step = period.seconds();
       // Command can store the old calculated values. This should be obvious because at least one
       // another value is NaN.
-      state_publisher_->msg_.dof_states[i].output = command_interfaces_[i].get_value();
+
+      const auto cmd_interface = command_interfaces_[i].get_optional();
+      state_publisher_->msg_.dof_states[i].output = cmd_interface.has_value()
+                                                      ? cmd_interface.value()
+                                                      : std::numeric_limits<double>::quiet_NaN();
     }
     state_publisher_->unlockAndPublish();
   }

--- a/pid_controller/src/pid_controller.cpp
+++ b/pid_controller/src/pid_controller.cpp
@@ -472,10 +472,7 @@ controller_interface::return_type PidController::update_and_write_commands(
   {
     for (size_t i = 0; i < measured_state_values_.size(); ++i)
     {
-      const auto measured_state = state_interfaces_[i].get_optional();
-      measured_state_values_[i] = measured_state.has_value()
-                                    ? measured_state.value()
-                                    : std::numeric_limits<double>::quiet_NaN();
+      measured_state_values_[i] = state_interfaces_[i].get_value();
     }
   }
 
@@ -577,11 +574,7 @@ controller_interface::return_type PidController::update_and_write_commands(
       state_publisher_->msg_.dof_states[i].time_step = period.seconds();
       // Command can store the old calculated values. This should be obvious because at least one
       // another value is NaN.
-
-      const auto cmd_interface = command_interfaces_[i].get_optional();
-      state_publisher_->msg_.dof_states[i].output = cmd_interface.has_value()
-                                                      ? cmd_interface.value()
-                                                      : std::numeric_limits<double>::quiet_NaN();
+      state_publisher_->msg_.dof_states[i].output = command_interfaces_[i].get_value();
     }
     state_publisher_->unlockAndPublish();
   }

--- a/pid_controller/src/pid_controller.yaml
+++ b/pid_controller/src/pid_controller.yaml
@@ -43,11 +43,6 @@ pid_controller:
     default_value: false,
     description: "Use external states from a topic instead from state interfaces."
   }
-  enable_feedforward: {
-    type: bool,
-    default_value: false,
-    description: "Enables feedforward gain. (Will be deprecated in favour of setting feedforward_gain to a non-zero value.)"
-  }
   gains:
     __map_dof_names:
       p: {

--- a/pid_controller/test/test_pid_controller.cpp
+++ b/pid_controller/test/test_pid_controller.cpp
@@ -179,15 +179,15 @@ TEST_F(PidControllerTest, reactivate_success)
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(std::isnan(controller_->reference_interfaces_[0]));
   ASSERT_TRUE(std::isnan(controller_->measured_state_values_[0]));
-  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), 101.101);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), 101.101);
   ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(std::isnan(controller_->reference_interfaces_[0]));
   ASSERT_TRUE(std::isnan(controller_->measured_state_values_[0]));
-  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), 101.101);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), 101.101);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(std::isnan(controller_->reference_interfaces_[0]));
   ASSERT_TRUE(std::isnan(controller_->measured_state_values_[0]));
-  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), 101.101);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), 101.101);
 
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
@@ -243,8 +243,7 @@ TEST_F(PidControllerTest, test_update_logic_zero_feedforward_gain)
     // -> cmd = p_term + i_term + d_term + feedforward_gain * ref = 30102.3 + 0 * 101.101 = 30102.3
     const double expected_command_value = 30102.301020;
 
-    double actual_value =
-      std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
+    double actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
     EXPECT_NEAR(actual_value, expected_command_value, 1e-5);
   }
 }
@@ -299,7 +298,7 @@ TEST_F(PidControllerTest, test_update_logic_chainable_not_use_subscriber_update)
   // feedforward OFF -> cmd = p_term + i_term + d_term = 3.9 + 0.078 + 1170.0 = 1173.978
   const double expected_command_value = 1173.978;
 
-  EXPECT_EQ(controller_->command_interfaces_[0].get_optional().value(), expected_command_value);
+  EXPECT_EQ(controller_->command_interfaces_[0].get_value(), expected_command_value);
 }
 
 /**
@@ -325,8 +324,7 @@ TEST_F(PidControllerTest, test_update_logic_angle_wraparound_off)
 
   // check the result of the commands - the values are not wrapped
   const double expected_command_value = 2679.078;
-  EXPECT_NEAR(
-    controller_->command_interfaces_[0].get_optional().value(), expected_command_value, 1e-5);
+  EXPECT_NEAR(controller_->command_interfaces_[0].get_value(), expected_command_value, 1e-5);
 }
 
 /**
@@ -356,8 +354,7 @@ TEST_F(PidControllerTest, test_update_logic_angle_wraparound_on)
 
   // Check the command value
   const double expected_command_value = 787.713559;
-  EXPECT_NEAR(
-    controller_->command_interfaces_[0].get_optional().value(), expected_command_value, 1e-5);
+  EXPECT_NEAR(controller_->command_interfaces_[0].get_value(), expected_command_value, 1e-5);
 }
 
 TEST_F(PidControllerTest, subscribe_and_get_messages_success)
@@ -489,7 +486,7 @@ TEST_F(PidControllerTest, test_update_chained_non_zero_feedforward_gain)
     controller_interface::return_type::OK);
 
   // check on result from update
-  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), expected_command_value);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), expected_command_value);
 }
 
 /**
@@ -552,8 +549,7 @@ TEST_F(PidControllerTest, test_update_chained_changing_feedforward_gain)
     controller_interface::return_type::OK);
 
   // check on result from update
-  ASSERT_EQ(
-    controller_->command_interfaces_[0].get_optional().value(), first_expected_command_value);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), first_expected_command_value);
 
   // turn on feedforward gain
   for (const auto & dof_name : dof_names_)
@@ -569,8 +565,7 @@ TEST_F(PidControllerTest, test_update_chained_changing_feedforward_gain)
     controller_interface::return_type::OK);
 
   // check on result from update
-  ASSERT_EQ(
-    controller_->command_interfaces_[0].get_optional().value(), second_expected_command_value);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), second_expected_command_value);
 
   // Check updated parameters
   for (const auto & dof_name : dof_names_)
@@ -611,8 +606,7 @@ TEST_F(PidControllerTest, test_save_i_term_off)
   // feedforward OFF -> cmd = p_term + i_term + d_term = 30102.3
   const double expected_command_value = 30102.30102;
 
-  double actual_value =
-    std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
+  double actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
   EXPECT_NEAR(actual_value, expected_command_value, 1e-5);
 
   // deactivate the controller and set command=state
@@ -625,7 +619,7 @@ TEST_F(PidControllerTest, test_save_i_term_off)
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
-  actual_value = std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
+  actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
   EXPECT_NEAR(actual_value, 0.0, 1e-5);
 }
 
@@ -661,8 +655,7 @@ TEST_F(PidControllerTest, test_save_i_term_on)
   // feedforward OFF -> cmd = p_term + i_term + d_term = 30102.3
   const double expected_command_value = 30102.30102;
 
-  double actual_value =
-    std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
+  double actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
   EXPECT_NEAR(actual_value, expected_command_value, 1e-5);
 
   // deactivate the controller and set command=state
@@ -675,7 +668,7 @@ TEST_F(PidControllerTest, test_save_i_term_on)
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
-  actual_value = std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
+  actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
   EXPECT_NEAR(actual_value, 2.00002, 1e-5);  // i_term from above
 }
 

--- a/pid_controller/test/test_pid_controller.cpp
+++ b/pid_controller/test/test_pid_controller.cpp
@@ -179,112 +179,37 @@ TEST_F(PidControllerTest, reactivate_success)
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(std::isnan(controller_->reference_interfaces_[0]));
   ASSERT_TRUE(std::isnan(controller_->measured_state_values_[0]));
-  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), 101.101);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), 101.101);
   ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(std::isnan(controller_->reference_interfaces_[0]));
   ASSERT_TRUE(std::isnan(controller_->measured_state_values_[0]));
-  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), 101.101);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), 101.101);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(std::isnan(controller_->reference_interfaces_[0]));
   ASSERT_TRUE(std::isnan(controller_->measured_state_values_[0]));
-  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), 101.101);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), 101.101);
 
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
-}
-
-TEST_F(PidControllerTest, test_feedforward_mode_service)
-{
-  SetUpController();
-
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
-
-  // initially set to OFF
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-
-  // should stay false
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-
-  // set to true
-  ASSERT_NO_THROW(call_service(true, executor));
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), true);
-
-  // set back to false
-  ASSERT_NO_THROW(call_service(false, executor));
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-}
-
-TEST_F(PidControllerTest, test_feedforward_mode_parameter)
-{
-  SetUpController();
-
-  // Check updating mode during on_configure
-
-  // initially set to OFF
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-
-  // Reconfigure after setting parameter to true
-  ASSERT_EQ(controller_->on_cleanup(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  EXPECT_TRUE(controller_->get_node()->set_parameter({"enable_feedforward", true}).successful);
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), true);
-  ASSERT_EQ(controller_->on_cleanup(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  EXPECT_TRUE(controller_->get_node()->set_parameter({"enable_feedforward", false}).successful);
-
-  // initially set to ON
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), true);
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-
-  // Check updating mode during update_and_write_commands
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-
-  // Switch to ON
-  ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
-    controller_interface::return_type::OK);
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-  EXPECT_TRUE(controller_->get_node()->set_parameter({"enable_feedforward", true}).successful);
-  ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
-    controller_interface::return_type::OK);
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), true);
-
-  // Switch to OFF
-  EXPECT_TRUE(controller_->get_node()->set_parameter({"enable_feedforward", false}).successful);
-  ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
-    controller_interface::return_type::OK);
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
 }
 
 /**
- * @brief Check the update logic in non chained mode with feedforward OFF
+ * @brief Check the update logic in non chained mode with feedforward gain is 0
  *
  */
 
-TEST_F(PidControllerTest, test_update_logic_feedforward_off)
+TEST_F(PidControllerTest, test_update_logic_zero_feedforward_gain)
 {
   SetUpController();
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   controller_->set_chained_mode(false);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_FALSE(controller_->is_in_chained_mode());
   EXPECT_TRUE(std::isnan((*(controller_->input_ref_.readFromRT()))->values[0]));
-  EXPECT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
   for (const auto & interface : controller_->reference_interfaces_)
   {
     EXPECT_TRUE(std::isnan(interface));
@@ -303,65 +228,6 @@ TEST_F(PidControllerTest, test_update_logic_feedforward_off)
     controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
 
-  EXPECT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-  EXPECT_EQ(
-    controller_->reference_interfaces_.size(), dof_names_.size() * state_interfaces_.size());
-  EXPECT_EQ(controller_->reference_interfaces_.size(), dof_state_values_.size());
-  for (size_t i = 0; i < dof_command_values_.size(); ++i)
-  {
-    EXPECT_TRUE(std::isnan((*(controller_->input_ref_.readFromRT()))->values[i]));
-  }
-  // check the command value
-  // error = ref - state = 100.001, error_dot = error/ds = 10000.1,
-  // p_term = 100.001 * 1, i_term = 1.00001 * 2 = 2.00002, d_term = error/ds = 10000.1 * 3
-  // feedforward OFF -> cmd = p_term + i_term + d_term = 30102.3
-  const double expected_command_value = 30102.30102;
-
-  double actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
-  EXPECT_NEAR(actual_value, expected_command_value, 1e-5);
-}
-
-/**
- * @brief Check the update logic in non chained mode with feedforward ON and feedforward gain is 0
- *
- */
-
-TEST_F(PidControllerTest, test_update_logic_feedforward_on_with_zero_feedforward_gain)
-{
-  SetUpController();
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
-
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  controller_->set_chained_mode(false);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_FALSE(controller_->is_in_chained_mode());
-  EXPECT_TRUE(std::isnan((*(controller_->input_ref_.readFromRT()))->values[0]));
-  EXPECT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
-  for (const auto & interface : controller_->reference_interfaces_)
-  {
-    EXPECT_TRUE(std::isnan(interface));
-  }
-
-  controller_->set_reference(dof_command_values_);
-
-  controller_->get_node()->set_parameter(rclcpp::Parameter("enable_feedforward", true));
-  controller_->feedforward_mode_enabled_.writeFromNonRT(true);
-  EXPECT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), true);
-
-  for (size_t i = 0; i < dof_command_values_.size(); ++i)
-  {
-    EXPECT_FALSE(std::isnan((*(controller_->input_ref_.readFromRT()))->values[i]));
-    EXPECT_EQ((*(controller_->input_ref_.readFromRT()))->values[i], dof_command_values_[i]);
-    EXPECT_TRUE(std::isnan(controller_->reference_interfaces_[i]));
-  }
-
-  ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
-    controller_interface::return_type::OK);
-
-  EXPECT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), true);
   EXPECT_EQ(
     controller_->reference_interfaces_.size(), dof_names_.size() * state_interfaces_.size());
   EXPECT_EQ(controller_->reference_interfaces_.size(), dof_state_values_.size());
@@ -377,7 +243,8 @@ TEST_F(PidControllerTest, test_update_logic_feedforward_on_with_zero_feedforward
     // -> cmd = p_term + i_term + d_term + feedforward_gain * ref = 30102.3 + 0 * 101.101 = 30102.3
     const double expected_command_value = 30102.301020;
 
-    double actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
+    double actual_value =
+      std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
     EXPECT_NEAR(actual_value, expected_command_value, 1e-5);
   }
 }
@@ -393,7 +260,6 @@ TEST_F(PidControllerTest, test_update_logic_chainable_not_use_subscriber_update)
   SetUpController();
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
 
   // set chain mode to true
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
@@ -401,7 +267,6 @@ TEST_F(PidControllerTest, test_update_logic_chainable_not_use_subscriber_update)
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(controller_->is_in_chained_mode());
   // feedforward mode is off as default, use this for convenience
-  EXPECT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
 
   // update reference interface which will be used for calculation
   const double ref_interface_value = 5.0;
@@ -434,7 +299,7 @@ TEST_F(PidControllerTest, test_update_logic_chainable_not_use_subscriber_update)
   // feedforward OFF -> cmd = p_term + i_term + d_term = 3.9 + 0.078 + 1170.0 = 1173.978
   const double expected_command_value = 1173.978;
 
-  EXPECT_EQ(controller_->command_interfaces_[0].get_value(), expected_command_value);
+  EXPECT_EQ(controller_->command_interfaces_[0].get_optional().value(), expected_command_value);
 }
 
 /**
@@ -445,7 +310,6 @@ TEST_F(PidControllerTest, test_update_logic_angle_wraparound_off)
   SetUpController();
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
@@ -461,7 +325,8 @@ TEST_F(PidControllerTest, test_update_logic_angle_wraparound_off)
 
   // check the result of the commands - the values are not wrapped
   const double expected_command_value = 2679.078;
-  EXPECT_NEAR(controller_->command_interfaces_[0].get_value(), expected_command_value, 1e-5);
+  EXPECT_NEAR(
+    controller_->command_interfaces_[0].get_optional().value(), expected_command_value, 1e-5);
 }
 
 /**
@@ -472,7 +337,6 @@ TEST_F(PidControllerTest, test_update_logic_angle_wraparound_on)
   SetUpController("test_pid_controller_angle_wraparound_on");
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   controller_->set_chained_mode(true);
@@ -492,7 +356,8 @@ TEST_F(PidControllerTest, test_update_logic_angle_wraparound_on)
 
   // Check the command value
   const double expected_command_value = 787.713559;
-  EXPECT_NEAR(controller_->command_interfaces_[0].get_value(), expected_command_value, 1e-5);
+  EXPECT_NEAR(
+    controller_->command_interfaces_[0].get_optional().value(), expected_command_value, 1e-5);
 }
 
 TEST_F(PidControllerTest, subscribe_and_get_messages_success)
@@ -576,9 +441,9 @@ TEST_F(PidControllerTest, receive_message_and_publish_updated_status)
 }
 
 /**
- * @brief check chained pid controller with feedforward and gain as non-zero, single interface
+ * @brief check chained pid controller with feedforward gain as non-zero, single interface
  */
-TEST_F(PidControllerTest, test_update_chained_feedforward_with_gain)
+TEST_F(PidControllerTest, test_update_chained_non_zero_feedforward_gain)
 {
   // state interface value is 1.1 as defined in test fixture
   // with p gain 0.5, the command value should be 0.5 * (5.0 - 1.1) = 1.95
@@ -587,7 +452,6 @@ TEST_F(PidControllerTest, test_update_chained_feedforward_with_gain)
   const double expected_command_value = 6.95;
 
   SetUpController("test_pid_controller_with_feedforward_gain");
-  controller_->get_node()->set_parameter(rclcpp::Parameter("enable_feedforward", true));
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
   // check on interfaces & pid gain parameters
@@ -605,17 +469,12 @@ TEST_F(PidControllerTest, test_update_chained_feedforward_with_gain)
   // setup executor
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
 
   controller_->set_chained_mode(true);
 
   // activate controller
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(controller_->is_in_chained_mode());
-
-  // turn on feedforward
-  controller_->feedforward_mode_enabled_.writeFromNonRT(true);
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), true);
 
   // send a message to update reference interface
   controller_->set_reference({target_value});
@@ -630,30 +489,39 @@ TEST_F(PidControllerTest, test_update_chained_feedforward_with_gain)
     controller_interface::return_type::OK);
 
   // check on result from update
-  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), expected_command_value);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), expected_command_value);
 }
 
 /**
- * @brief check chained pid controller with feedforward OFF and gain as non-zero, single interface
+ * @brief check chained pid controller with feedforward gain changed during runtime
  */
-TEST_F(PidControllerTest, test_update_chained_feedforward_off_with_gain)
+TEST_F(PidControllerTest, test_update_chained_changing_feedforward_gain)
 {
   // state interface value is 1.1 as defined in test fixture
   // given target value 5.0
   // with p gain 0.5, the command value should be 0.5 * (5.0 - 1.1) = 1.95
-  // with feedforward off, the command value should be still 1.95 even though feedforward gain
-  // is 1.0
-  const double target_value = 5.0;
-  const double expected_command_value = 1.95;
+  // with feedforward gain 1.0, the command value should be 1.95 + 1.0 * 5.0 = 6.95
+
+  constexpr double target_value = 5.0;
+  constexpr double first_expected_command_value = 1.95;
+  constexpr double second_expected_command_value = 6.95;
 
   SetUpController("test_pid_controller_with_feedforward_gain");
+
+  for (const auto & dof_name : dof_names_)
+  {
+    ASSERT_TRUE(controller_->get_node()
+                  ->set_parameter(rclcpp::Parameter("gains." + dof_name + ".feedforward_gain", 0.0))
+                  .successful);
+  }
+
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
   // check on interfaces & pid gain parameters
   for (const auto & dof_name : dof_names_)
   {
     ASSERT_EQ(controller_->params_.gains.dof_names_map[dof_name].p, 0.5);
-    ASSERT_EQ(controller_->params_.gains.dof_names_map[dof_name].feedforward_gain, 1.0);
+    ASSERT_EQ(controller_->params_.gains.dof_names_map[dof_name].feedforward_gain, 0.0);
   }
   ASSERT_EQ(controller_->params_.command_interface, command_interface_);
   EXPECT_THAT(
@@ -664,16 +532,12 @@ TEST_F(PidControllerTest, test_update_chained_feedforward_off_with_gain)
   // setup executor
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
 
   controller_->set_chained_mode(true);
 
   // activate controller
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(controller_->is_in_chained_mode());
-
-  // feedforward by default is OFF
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), false);
 
   // send a message to update reference interface
   controller_->set_reference({target_value});
@@ -688,7 +552,31 @@ TEST_F(PidControllerTest, test_update_chained_feedforward_off_with_gain)
     controller_interface::return_type::OK);
 
   // check on result from update
-  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), expected_command_value);
+  ASSERT_EQ(
+    controller_->command_interfaces_[0].get_optional().value(), first_expected_command_value);
+
+  // turn on feedforward gain
+  for (const auto & dof_name : dof_names_)
+  {
+    ASSERT_TRUE(controller_->get_node()
+                  ->set_parameter(rclcpp::Parameter("gains." + dof_name + ".feedforward_gain", 1.0))
+                  .successful);
+  }
+
+  // run update
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // check on result from update
+  ASSERT_EQ(
+    controller_->command_interfaces_[0].get_optional().value(), second_expected_command_value);
+
+  // Check updated parameters
+  for (const auto & dof_name : dof_names_)
+  {
+    ASSERT_EQ(controller_->params_.gains.dof_names_map[dof_name].feedforward_gain, 1.0);
+  }
 }
 
 /**
@@ -701,7 +589,6 @@ TEST_F(PidControllerTest, test_save_i_term_off)
   SetUpController("test_save_i_term_off");
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   controller_->set_chained_mode(false);
@@ -724,7 +611,8 @@ TEST_F(PidControllerTest, test_save_i_term_off)
   // feedforward OFF -> cmd = p_term + i_term + d_term = 30102.3
   const double expected_command_value = 30102.30102;
 
-  double actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
+  double actual_value =
+    std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
   EXPECT_NEAR(actual_value, expected_command_value, 1e-5);
 
   // deactivate the controller and set command=state
@@ -737,7 +625,7 @@ TEST_F(PidControllerTest, test_save_i_term_off)
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
-  actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
+  actual_value = std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
   EXPECT_NEAR(actual_value, 0.0, 1e-5);
 }
 
@@ -751,7 +639,6 @@ TEST_F(PidControllerTest, test_save_i_term_on)
   SetUpController("test_save_i_term_on");
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   for (const auto & dof_name : dof_names_)
@@ -774,7 +661,8 @@ TEST_F(PidControllerTest, test_save_i_term_on)
   // feedforward OFF -> cmd = p_term + i_term + d_term = 30102.3
   const double expected_command_value = 30102.30102;
 
-  double actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
+  double actual_value =
+    std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
   EXPECT_NEAR(actual_value, expected_command_value, 1e-5);
 
   // deactivate the controller and set command=state
@@ -787,7 +675,7 @@ TEST_F(PidControllerTest, test_save_i_term_on)
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
-  actual_value = std::round(controller_->command_interfaces_[0].get_value() * 1e5) / 1e5;
+  actual_value = std::round(controller_->command_interfaces_[0].get_optional().value() * 1e5) / 1e5;
   EXPECT_NEAR(actual_value, 2.00002, 1e-5);  // i_term from above
 }
 

--- a/pid_controller/test/test_pid_controller.hpp
+++ b/pid_controller/test/test_pid_controller.hpp
@@ -53,17 +53,14 @@ class TestablePidController : public pid_controller::PidController
   FRIEND_TEST(PidControllerTest, all_parameters_set_configure_success);
   FRIEND_TEST(PidControllerTest, activate_success);
   FRIEND_TEST(PidControllerTest, reactivate_success);
-  FRIEND_TEST(PidControllerTest, test_feedforward_mode_service);
-  FRIEND_TEST(PidControllerTest, test_feedforward_mode_parameter);
-  FRIEND_TEST(PidControllerTest, test_update_logic_feedforward_off);
-  FRIEND_TEST(PidControllerTest, test_update_logic_feedforward_on_with_zero_feedforward_gain);
+  FRIEND_TEST(PidControllerTest, test_update_logic_zero_feedforward_gain);
+  FRIEND_TEST(PidControllerTest, test_update_chained_non_zero_feedforward_gain);
+  FRIEND_TEST(PidControllerTest, test_update_chained_changing_feedforward_gain);
   FRIEND_TEST(PidControllerTest, test_update_logic_chainable_not_use_subscriber_update);
   FRIEND_TEST(PidControllerTest, test_update_logic_angle_wraparound_off);
   FRIEND_TEST(PidControllerTest, test_update_logic_angle_wraparound_on);
   FRIEND_TEST(PidControllerTest, subscribe_and_get_messages_success);
   FRIEND_TEST(PidControllerTest, receive_message_and_publish_updated_status);
-  FRIEND_TEST(PidControllerTest, test_update_chained_feedforward_with_gain);
-  FRIEND_TEST(PidControllerTest, test_update_chained_feedforward_off_with_gain);
   FRIEND_TEST(PidControllerDualInterfaceTest, test_chained_feedforward_with_gain_dual_interface);
   FRIEND_TEST(PidControllerTest, test_save_i_term_on);
   FRIEND_TEST(PidControllerTest, test_save_i_term_off);
@@ -143,10 +140,6 @@ public:
     command_publisher_node_ = std::make_shared<rclcpp::Node>("command_publisher");
     command_publisher_ = command_publisher_node_->create_publisher<ControllerCommandMsg>(
       "/test_pid_controller/reference", rclcpp::SystemDefaultsQoS());
-
-    service_caller_node_ = std::make_shared<rclcpp::Node>("service_caller");
-    feedforward_service_client_ = service_caller_node_->create_client<ControllerModeSrvType>(
-      "/test_pid_controller/set_feedforward_control");
   }
 
   static void TearDownTestCase() { rclcpp::shutdown(); }
@@ -261,25 +254,6 @@ protected:
     command_publisher_->publish(msg);
   }
 
-  std::shared_ptr<ControllerModeSrvType::Response> call_service(
-    const bool feedforward, rclcpp::Executor & executor)
-  {
-    auto request = std::make_shared<ControllerModeSrvType::Request>();
-    request->data = feedforward;
-
-    bool wait_for_service_ret =
-      feedforward_service_client_->wait_for_service(std::chrono::milliseconds(500));
-    EXPECT_TRUE(wait_for_service_ret);
-    if (!wait_for_service_ret)
-    {
-      throw std::runtime_error("Service is not available!");
-    }
-    auto result = feedforward_service_client_->async_send_request(request);
-    EXPECT_EQ(executor.spin_until_future_complete(result), rclcpp::FutureReturnCode::SUCCESS);
-
-    return result.get();
-  }
-
 protected:
   // TODO(anyone): adjust the members as needed
 
@@ -298,8 +272,6 @@ protected:
   std::unique_ptr<TestablePidController> controller_;
   rclcpp::Node::SharedPtr command_publisher_node_;
   rclcpp::Publisher<ControllerCommandMsg>::SharedPtr command_publisher_;
-  rclcpp::Node::SharedPtr service_caller_node_;
-  rclcpp::Client<ControllerModeSrvType>::SharedPtr feedforward_service_client_;
 };
 
 #endif  // TEST_PID_CONTROLLER_HPP_

--- a/pid_controller/test/test_pid_controller_dual_interface.cpp
+++ b/pid_controller/test/test_pid_controller_dual_interface.cpp
@@ -56,7 +56,6 @@ public:
 TEST_F(PidControllerDualInterfaceTest, test_chained_feedforward_with_gain_dual_interface)
 {
   SetUpController("test_pid_controller_with_feedforward_gain_dual_interface");
-  controller_->get_node()->set_parameter(rclcpp::Parameter("enable_feedforward", true));
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
   // check on interfaces & pid gain parameters
@@ -78,10 +77,6 @@ TEST_F(PidControllerDualInterfaceTest, test_chained_feedforward_with_gain_dual_i
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_TRUE(controller_->is_in_chained_mode());
 
-  // turn on feedforward
-  controller_->feedforward_mode_enabled_.writeFromNonRT(true);
-  ASSERT_EQ(*(controller_->feedforward_mode_enabled_.readFromRT()), true);
-
   // set up the reference interface,
   controller_->reference_interfaces_ = {
     get_joint1_reference_position(), get_joint2_reference_position(),
@@ -95,8 +90,8 @@ TEST_F(PidControllerDualInterfaceTest, test_chained_feedforward_with_gain_dual_i
   // check the commands
   const double joint1_expected_cmd = 8.915;
   const double joint2_expected_cmd = 9.915;
-  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), joint1_expected_cmd);
-  ASSERT_EQ(controller_->command_interfaces_[1].get_value(), joint2_expected_cmd);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), joint1_expected_cmd);
+  ASSERT_EQ(controller_->command_interfaces_[1].get_optional().value(), joint2_expected_cmd);
 }
 
 int main(int argc, char ** argv)

--- a/pid_controller/test/test_pid_controller_dual_interface.cpp
+++ b/pid_controller/test/test_pid_controller_dual_interface.cpp
@@ -90,8 +90,8 @@ TEST_F(PidControllerDualInterfaceTest, test_chained_feedforward_with_gain_dual_i
   // check the commands
   const double joint1_expected_cmd = 8.915;
   const double joint2_expected_cmd = 9.915;
-  ASSERT_EQ(controller_->command_interfaces_[0].get_optional().value(), joint1_expected_cmd);
-  ASSERT_EQ(controller_->command_interfaces_[1].get_optional().value(), joint2_expected_cmd);
+  ASSERT_EQ(controller_->command_interfaces_[0].get_value(), joint1_expected_cmd);
+  ASSERT_EQ(controller_->command_interfaces_[1].get_value(), joint2_expected_cmd);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Deprecates the marked service and parameter from https://github.com/ros-controls/ros2_controllers/pull/1553. Also adopts tests and fixes compiler warning of the package due to optionals.
