### PR TITLE
Fix SteeringOdometry calculation error

### DIFF
--- a/steering_controllers_library/src/steering_odometry.cpp
+++ b/steering_controllers_library/src/steering_odometry.cpp
@@ -180,7 +180,7 @@ bool SteeringOdometry::update_from_velocity(
 
   double linear_velocity = get_linear_velocity_double_traction_axle(
     right_traction_wheel_vel, left_traction_wheel_vel, steer_pos_);
-  const double angular_velocity = steer_pos_ * linear_velocity / wheel_base_;
+  const double angular_velocity = std::tan(steer_pos_) * linear_velocity / wheel_base_;
 
   return update_odometry(linear_velocity, angular_velocity, dt);
 }


### PR DESCRIPTION
From https://github.com/ros-controls/gz_ros2_control/issues/595

The current calculation method is an approximation for small angles, which can lead to significant errors. In fact, the exact algorithm is used in the other two implementations of `update_from_velocity`, and should be used here as well.

https://github.com/ros-controls/ros2_controllers/blob/a88bf0af29308448424d0112cba2b0560d1a7305/steering_controllers_library/src/steering_odometry.cpp#L129

https://github.com/ros-controls/ros2_controllers/blob/a88bf0af29308448424d0112cba2b0560d1a7305/steering_controllers_library/src/steering_odometry.cpp#L163

https://github.com/ros-controls/ros2_controllers/blob/a88bf0af29308448424d0112cba2b0560d1a7305/steering_controllers_library/src/steering_odometry.cpp#L183

---

Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. Don’t be afraid to request reviews from maintainers.
5. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [ ] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
