### PR TITLE
fix rqt_joint_trajectory_controller namespace for robots with namespace

### DIFF
--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -464,7 +464,7 @@ def _jtc_joint_names(jtc_info):
 
     joint_names = []
     for interface in jtc_info.required_state_interfaces:
-        name = interface.split("/")[-2]
+        name = "/".join(interface.split("/")[:-1])
         if name not in joint_names:
             joint_names.append(name)
 


### PR DESCRIPTION
rqt_joint_trajectory_controller does not work if your robot has a namespace. This PR fixes that, to test do:

`ros2 run rqt_joint_trajectory_controller rqt_joint_trajectory_controller --ros-args -r __ns:=/my_robot_ns`

behavior: arm cannot be moved, because in fact not even the drop-down menu from the right combo box (jtc_combo) is filled with data.

I have tested these changes with robots with namespace and without namespace and works fine, so it does not break things for others.