### PR TITLE
Remove unneccessary usage of `get_ordered_interfaces`

### DIFF
--- a/admittance_controller/include/admittance_controller/admittance_controller.hpp
+++ b/admittance_controller/include/admittance_controller/admittance_controller.hpp
@@ -82,15 +82,6 @@ protected:
   size_t num_joints_ = 0;
   std::vector<std::string> command_joint_names_;
 
-  // The interfaces are defined as the types in 'allowed_interface_types_' member.
-  // For convenience, for each type the interfaces are ordered so that i-th position
-  // matches i-th index in joint_names_
-  template <typename T>
-  using InterfaceReferences = std::vector<std::vector<std::reference_wrapper<T>>>;
-
-  InterfaceReferences<hardware_interface::LoanedCommandInterface> joint_command_interface_;
-  InterfaceReferences<hardware_interface::LoanedStateInterface> joint_state_interface_;
-
   bool has_position_state_interface_ = false;
   bool has_velocity_state_interface_ = false;
   bool has_acceleration_state_interface_ = false;

--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -226,8 +226,7 @@ controller_interface::CallbackReturn AdmittanceController::on_configure(
     }
   }
 
-  // Check if only allowed interface types are used and initialize storage to avoid memory
-  // allocation during activation
+  // Check if only allowed interface types are used
   auto contains_interface_type =
     [](const std::vector<std::string> & interface_type_list, const std::string & interface_type)
   {
@@ -235,7 +234,6 @@ controller_interface::CallbackReturn AdmittanceController::on_configure(
            interface_type_list.end();
   };
 
-  joint_command_interface_.resize(allowed_interface_types_.size());
   for (const auto & interface : admittance_->parameters_.command_interfaces)
   {
     auto it =
@@ -257,9 +255,7 @@ controller_interface::CallbackReturn AdmittanceController::on_configure(
   has_effort_command_interface_ = contains_interface_type(
     admittance_->parameters_.command_interfaces, hardware_interface::HW_IF_EFFORT);
 
-  // Check if only allowed interface types are used and initialize storage to avoid memory
-  // allocation during activation
-  joint_state_interface_.resize(allowed_interface_types_.size());
+  // Check if only allowed interface types are used
   for (const auto & interface : admittance_->parameters_.state_interfaces)
   {
     auto it =
@@ -362,37 +358,6 @@ controller_interface::CallbackReturn AdmittanceController::on_activate(
   if (!admittance_)
   {
     return controller_interface::CallbackReturn::ERROR;
-  }
-
-  // order all joints in the storage
-  for (const auto & interface : admittance_->parameters_.state_interfaces)
-  {
-    auto it =
-      std::find(allowed_interface_types_.begin(), allowed_interface_types_.end(), interface);
-    auto index = static_cast<size_t>(std::distance(allowed_interface_types_.begin(), it));
-    if (!controller_interface::get_ordered_interfaces(
-          state_interfaces_, admittance_->parameters_.joints, interface,
-          joint_state_interface_[index]))
-    {
-      RCLCPP_ERROR(
-        get_node()->get_logger(), "Expected %zu '%s' state interfaces, got %zu.", num_joints_,
-        interface.c_str(), joint_state_interface_[index].size());
-      return CallbackReturn::ERROR;
-    }
-  }
-  for (const auto & interface : admittance_->parameters_.command_interfaces)
-  {
-    auto it =
-      std::find(allowed_interface_types_.begin(), allowed_interface_types_.end(), interface);
-    auto index = static_cast<size_t>(std::distance(allowed_interface_types_.begin(), it));
-    if (!controller_interface::get_ordered_interfaces(
-          command_interfaces_, command_joint_names_, interface, joint_command_interface_[index]))
-    {
-      RCLCPP_ERROR(
-        get_node()->get_logger(), "Expected %zu '%s' command interfaces, got %zu.", num_joints_,
-        interface.c_str(), joint_command_interface_[index].size());
-      return CallbackReturn::ERROR;
-    }
   }
 
   // update parameters if any have changed
@@ -522,11 +487,6 @@ controller_interface::CallbackReturn AdmittanceController::on_deactivate(
     }
   }
 
-  for (size_t index = 0; index < allowed_interface_types_.size(); ++index)
-  {
-    joint_command_interface_[index].clear();
-    joint_state_interface_[index].clear();
-  }
   release_interfaces();
   admittance_->reset(num_joints_);
 

--- a/forward_command_controller/src/forward_command_controller_parameters.yaml
+++ b/forward_command_controller/src/forward_command_controller_parameters.yaml
@@ -3,9 +3,11 @@ forward_command_controller:
     type: string_array,
     default_value: [],
     description: "Name of the joints to control",
+    read_only: true
   }
   interface_name: {
     type: string,
     default_value: "",
     description: "Name of the interface to command",
+    read_only: true
   }

--- a/forward_command_controller/src/forward_controllers_base.cpp
+++ b/forward_command_controller/src/forward_controllers_base.cpp
@@ -98,22 +98,6 @@ controller_interface::InterfaceConfiguration ForwardControllersBase::state_inter
 controller_interface::CallbackReturn ForwardControllersBase::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  //  check if we have all resources defined in the "points" parameter
-  //  also verify that we *only* have the resources defined in the "points" parameter
-  // ATTENTION(destogl): Shouldn't we use ordered interface all the time?
-  std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
-    ordered_interfaces;
-  if (
-    !controller_interface::get_ordered_interfaces(
-      command_interfaces_, command_interface_types_, std::string(""), ordered_interfaces) ||
-    command_interface_types_.size() != ordered_interfaces.size())
-  {
-    RCLCPP_ERROR(
-      get_node()->get_logger(), "Expected %zu command interfaces, got %zu",
-      command_interface_types_.size(), ordered_interfaces.size());
-    return controller_interface::CallbackReturn::ERROR;
-  }
-
   // reset command buffer if a command came through callback when controller was inactive
   // Try to set default value in command.
   // If this fails, then another command will be received soon anyways.

--- a/forward_command_controller/src/multi_interface_forward_command_controller_parameters.yaml
+++ b/forward_command_controller/src/multi_interface_forward_command_controller_parameters.yaml
@@ -3,9 +3,11 @@ multi_interface_forward_command_controller:
     type: string,
     default_value: "",
     description: "Name of the joint to control",
+    read_only: true
   }
   interface_names: {
     type: string_array,
     default_value: [],
     description: "Names of the interfaces to command",
+    read_only: true
   }

--- a/forward_command_controller/test/test_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_forward_command_controller.hpp
@@ -57,7 +57,7 @@ public:
   void SetUp();
   void TearDown();
 
-  void SetUpController();
+  void SetUpController(const std::vector<rclcpp::Parameter> & parameters = {});
   void SetUpHandles();
 
 protected:

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
@@ -51,11 +51,22 @@ void MultiInterfaceForwardCommandControllerTest::SetUp()
 
 void MultiInterfaceForwardCommandControllerTest::TearDown() { controller_.reset(nullptr); }
 
-void MultiInterfaceForwardCommandControllerTest::SetUpController(bool set_params_and_activate)
+void MultiInterfaceForwardCommandControllerTest::SetUpController(
+  bool set_default_params_and_activate, const std::vector<rclcpp::Parameter> & parameters)
 {
-  const auto result = controller_->init(
-    "multi_interface_forward_command_controller", "", 0, "",
-    controller_->define_custom_node_options());
+  std::vector<rclcpp::Parameter> parameter_overrides;
+  if (set_default_params_and_activate)
+  {
+    parameter_overrides.push_back({"joint", "joint1"});
+    parameter_overrides.push_back(
+      {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+  }
+  parameter_overrides.insert(parameter_overrides.end(), parameters.begin(), parameters.end());
+  auto node_options = controller_->define_custom_node_options();
+  node_options.parameter_overrides(parameter_overrides);
+
+  const auto result =
+    controller_->init("multi_interface_forward_command_controller", "", 0, "", node_options);
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
@@ -65,28 +76,18 @@ void MultiInterfaceForwardCommandControllerTest::SetUpController(bool set_params
   controller_->assign_interfaces(std::move(command_ifs), {});
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  if (set_params_and_activate)
+  if (set_default_params_and_activate)
   {
-    SetParametersAndActivateController();
+    auto node_state = controller_->configure();
+    ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+    node_state = controller_->get_node()->activate();
+    ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
   }
-}
-
-void MultiInterfaceForwardCommandControllerTest::SetParametersAndActivateController()
-{
-  controller_->get_node()->set_parameter({"joint", "joint1"});
-  controller_->get_node()->set_parameter(
-    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
-
-  auto node_state = controller_->configure();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
-  node_state = controller_->get_node()->activate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 }
 
 TEST_F(MultiInterfaceForwardCommandControllerTest, JointsParameterNotSet)
 {
-  SetUpController();
-  controller_->get_node()->set_parameter({"interface_names", std::vector<std::string>()});
+  SetUpController(false, {rclcpp::Parameter("interface_names", std::vector<std::string>())});
 
   // configure failed, 'joint' parameter not set
   ASSERT_EQ(
@@ -96,8 +97,7 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, JointsParameterNotSet)
 
 TEST_F(MultiInterfaceForwardCommandControllerTest, InterfaceParameterNotSet)
 {
-  SetUpController();
-  controller_->get_node()->set_parameter({"joint", ""});
+  SetUpController(false, {rclcpp::Parameter("joint", "")});
 
   // configure failed, 'interface_names' parameter not set
   ASSERT_EQ(
@@ -107,10 +107,9 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, InterfaceParameterNotSet)
 
 TEST_F(MultiInterfaceForwardCommandControllerTest, JointsParameterIsEmpty)
 {
-  SetUpController();
-
-  controller_->get_node()->set_parameter({"joint", ""});
-  controller_->get_node()->set_parameter({"interface_names", std::vector<std::string>()});
+  SetUpController(
+    false, {rclcpp::Parameter("joint", ""),
+            rclcpp::Parameter("interface_names", std::vector<std::string>())});
 
   // configure failed, 'joint' is empty
   ASSERT_EQ(
@@ -120,9 +119,9 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, JointsParameterIsEmpty)
 
 TEST_F(MultiInterfaceForwardCommandControllerTest, InterfaceParameterEmpty)
 {
-  SetUpController();
-  controller_->get_node()->set_parameter({"joint", "joint1"});
-  controller_->get_node()->set_parameter({"interface_names", std::vector<std::string>()});
+  SetUpController(
+    false, {rclcpp::Parameter("joint", "joint1"),
+            rclcpp::Parameter("interface_names", std::vector<std::string>())});
 
   // configure failed, 'interface_name' is empty
   ASSERT_EQ(
@@ -132,11 +131,10 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, InterfaceParameterEmpty)
 
 TEST_F(MultiInterfaceForwardCommandControllerTest, ConfigureParamsSuccess)
 {
-  SetUpController();
-
-  controller_->get_node()->set_parameter({"joint", "joint1"});
-  controller_->get_node()->set_parameter(
-    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
+  SetUpController(
+    false, {rclcpp::Parameter("joint", "joint1"),
+            rclcpp::Parameter(
+              "interface_names", std::vector<std::string>{"position", "velocity", "effort"})});
 
   // configure successful
   ASSERT_EQ(
@@ -149,40 +147,6 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, ConfigureParamsSuccess)
   EXPECT_EQ(cmd_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
   auto state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, IsEmpty());
-}
-
-TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateWithWrongJointsNamesFails)
-{
-  SetUpController();
-
-  controller_->get_node()->set_parameter({"joint", "joint2"});
-  controller_->get_node()->set_parameter(
-    {"interface_names", std::vector<std::string>{"position", "velocity", "effort"}});
-
-  // activate failed, 'joint2' is not a valid joint name for the hardware
-  ASSERT_EQ(
-    controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
-  ASSERT_EQ(
-    controller_->on_activate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::ERROR);
-}
-
-TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateWithWrongInterfaceNameFails)
-{
-  SetUpController();
-
-  controller_->get_node()->set_parameter({"joint", "joint1"});
-  controller_->get_node()->set_parameter(
-    {"interface_names", std::vector<std::string>{"position", "velocity", "acceleration"}});
-
-  // activate failed, 'acceleration' is not a registered interface for `joint1`
-  ASSERT_EQ(
-    controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
-  ASSERT_EQ(
-    controller_->on_activate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::ERROR);
 }
 
 TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateSuccess)

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
@@ -62,8 +62,8 @@ public:
   void SetUp();
   void TearDown();
 
-  void SetUpController(bool set_params_and_activate = false);
-  void SetParametersAndActivateController();
+  void SetUpController(
+    bool set_params_and_activate = false, const std::vector<rclcpp::Parameter> & parameters = {});
 
 protected:
   std::unique_ptr<FriendMultiInterfaceForwardCommandController> controller_;


### PR DESCRIPTION
Fixes #116

Admittance_controller: There were some copies of the interface names without ever using them again.
forward_command_controller:  I changed the joint and interface parameters to be read_only, then we don't need the ordering there at all. This might be a breaking change, but I don't think that dynamically changing that would have worked without notifying the CM?