### PR TITLE
Fix `-Wunused-result` warnings in JTC

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -319,7 +319,15 @@ private:
   {
     for (size_t index = 0; index < num_cmd_joints_; ++index)
     {
-      joint_interface[index].get().set_value(trajectory_point_interface[map_cmd_to_joints_[index]]);
+      if (!joint_interface[index].get().set_value(
+            trajectory_point_interface[map_cmd_to_joints_[index]]))
+      {
+        RCLCPP_ERROR(
+          get_node()->get_logger(),
+          "Failed to set value for joint '%s' in command interface '%s'. ",
+          command_joint_names_[index].c_str(), joint_interface[index].get().get_name().c_str());
+        return;
+      }
     }
   }
 };

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -387,15 +387,15 @@ public:
           joint_names_[i], hardware_interface::HW_IF_ACCELERATION,
           separate_cmd_and_state_values ? &joint_state_acc_[i] : &joint_acc_[i]));
 
-      // Add to export lists and set initial values
+      // Add to export lists and set initial values (explicitly discarding return value)
       cmd_interfaces.emplace_back(pos_cmd_interfaces_.back());
-      cmd_interfaces.back().set_value(initial_pos_joints[i]);
+      (void)cmd_interfaces.back().set_value(initial_pos_joints[i]);
       cmd_interfaces.emplace_back(vel_cmd_interfaces_.back());
-      cmd_interfaces.back().set_value(initial_vel_joints[i]);
+      (void)cmd_interfaces.back().set_value(initial_vel_joints[i]);
       cmd_interfaces.emplace_back(acc_cmd_interfaces_.back());
-      cmd_interfaces.back().set_value(initial_acc_joints[i]);
+      (void)cmd_interfaces.back().set_value(initial_acc_joints[i]);
       cmd_interfaces.emplace_back(eff_cmd_interfaces_.back());
-      cmd_interfaces.back().set_value(initial_eff_joints[i]);
+      (void)cmd_interfaces.back().set_value(initial_eff_joints[i]);
       if (separate_cmd_and_state_values)
       {
         joint_state_pos_[i] = INITIAL_POS_JOINTS[i];


### PR DESCRIPTION
We haven't fixed this with #1566