### PR TITLE
Reset JTC PID's to zero on_activate()

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1167,6 +1167,11 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
     read_state_from_state_interfaces(state_current_);
     read_state_from_state_interfaces(last_commanded_state_);
   }
+  // reset/zero out all of the PID's (The integral term is not retained and reset to zero)
+  for (auto & pid : pids_)
+  {
+    pid->reset();
+  }
   last_commanded_time_ = rclcpp::Time();
 
   // The controller should start by holding position at the beginning of active state


### PR DESCRIPTION
When running the JTC in velocity control mode I noticed that the joints receive an impulse on reactivation after is has thrown a previous fault in motion. In the below example you can see this joint gets an impulse of -4 rad/sec down to zero as I reactivate the JTC. The impulse causes my hardware to throw another fault.
<img width="1830" height="1001" alt="image" src="https://github.com/user-attachments/assets/62fffbee-3c96-4537-9f31-2b30a4a71719" />

This change adds a `reset()` call to each joints PID controller so that the old command values are zero'd out when (re)activating.
<img width="1590" height="416" alt="image" src="https://github.com/user-attachments/assets/512f8609-e58d-41c2-9b59-27a35b507ee8" />
