### PR TITLE
Remove legacy and deprecated PID parameters

### DIFF
--- a/pid_controller/src/pid_controller.yaml
+++ b/pid_controller/src/pid_controller.yaml
@@ -70,35 +70,26 @@ pid_controller:
         default_value: -.inf,
         description: "Lower output clamp."
       }
-      antiwindup: {
-        type: bool,
-        default_value: false,
-        description: "[Deprecated, see antiwindup_strategy] Anti-windup functionality. When set to true, limits
-        the integral error to prevent windup; otherwise, constrains the
-        integral contribution to the control output. i_clamp_max and
-        i_clamp_min are applied in both scenarios."
-      }
       i_clamp_max: {
         type: double,
-        default_value: 0.0,
-        description: "[Deprecated, see antiwindup_strategy] Upper integral clamp."
+        default_value: .inf,
+        description: "Upper integral clamp."
       }
       i_clamp_min: {
         type: double,
-        default_value: 0.0,
-        description: "[Deprecated, see antiwindup_strategy] Lower integral clamp."
+        default_value: -.inf,
+        description: "Lower integral clamp."
       }
       antiwindup_strategy: {
         type: string,
         default_value: "legacy",
         description: "Specifies the anti-windup strategy. Options: 'back_calculation',
-        'conditional_integration', 'legacy' or 'none'. Note that the 'back_calculation' strategy use the
+        'conditional_integration' or 'none'. Note that the 'back_calculation' strategy use the
         tracking_time_constant parameter to tune the anti-windup behavior.",
         validation: {
           one_of<>: [[
             "back_calculation",
             "conditional_integration",
-            "legacy",
             "none"
           ]]
         }


### PR DESCRIPTION
### **Overview**

Remove legacy and deprecated PID parameters from the pid_controller package. Also update the expected command values in the tests to reflect the correct calculations based on the current PID implementation. 

### **What was added/changed in this PR**

- Removed legacy and deprecated PID parameters from the pid_controller package
- Updated the expected command values in the tests to reflect the correct calculations based on the current PID implementation. 

### **About tests**

The packages compile correctly and have passed the *pre‑commit* and *colcon* tests.

### **About change in tests**

Three test files were modified. In addition to the updates required by the removal of the legacy anti-windup strategy, some tests now include integral action with forward calculation.

### **Related PR's**

- https://github.com/ros-controls/control_toolbox/pull/436

### **Final notes**

I'm very open to any recommendations to improve this code.

