### PR TITLE
Add cmake package dependency to moprim controller

### DIFF
--- a/motion_primitives_controllers/package.xml
+++ b/motion_primitives_controllers/package.xml
@@ -21,6 +21,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>generate_parameter_library</build_depend>
+  <build_depend>ros2_control_cmake</build_depend>
 
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>


### PR DESCRIPTION
Fixes https://build.ros2.org/job/Kbin_uN64__motion_primitives_controllers__ubuntu_noble_amd64__binary/1/console

fyi @mathias31415 I haven't seen this earlier :see_no_evil: 