### PR TITLE
Fix docs for motion_primitive_controllers

### DIFF
--- a/motion_primitives_controllers/README.md
+++ b/motion_primitives_controllers/README.md
@@ -46,12 +46,6 @@ These interfaces are used to communicate the internal status of the hardware int
   - `STOPPED`: The robot was stopped using the `STOP_MOTION` command and must be reset with the `RESET_STOP` command before executing new commands.
 - `ready_for_new_primitive`: Boolean flag indicating whether the interface is ready to receive a new motion primitive
 
-
- ## Parameters
- This controller uses the [`generate_parameter_library`](https://github.com/PickNikRobotics/generate_parameter_library) to handle its parameters. The parameter [definition file located in the src folder](https://github.com/ros-controls/ros2_controllers/blob/master/motion_primitives_controllers/src/motion_primitives_forward_controller_parameter.yaml) contains descriptions for all the parameters used by the controller.
- An example parameter file for this controller can be found in [the test directory](https://github.com/ros-controls/ros2_controllers/blob/master/motion_primitives_controllers/test/motion_primitives_forward_controller_params.yaml).
-
-
 # Architecture Overview
 Architecture for a UR robot with [`Universal_Robots_ROS2_Driver` in motion primitives mode](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver).
 

--- a/motion_primitives_controllers/src/motion_primitives_forward_controller_parameter.yaml
+++ b/motion_primitives_controllers/src/motion_primitives_forward_controller_parameter.yaml
@@ -2,6 +2,6 @@ motion_primitives_forward_controller:
   tf_prefix: {
     type: string,
     default_value: "",
-    description: "tf_prefix",
+    description: "All interfaces use the naming scheme `tf_prefix_ + motion_primitive/<interface name>`",
     read_only: true,
   }

--- a/motion_primitives_controllers/userdoc.rst
+++ b/motion_primitives_controllers/userdoc.rst
@@ -3,5 +3,5 @@
 .. _motion_primitives_controllers_userdoc:
 
 
-.. include:: ../README.md
+.. include:: README.md
    :parser: myst_parser.sphinx_

--- a/motion_primitives_controllers/userdoc.rst
+++ b/motion_primitives_controllers/userdoc.rst
@@ -5,3 +5,15 @@
 
 .. include:: README.md
    :parser: myst_parser.sphinx_
+
+Parameters
+,,,,,,,,,,,
+
+This controller uses the `generate_parameter_library <https://github.com/PickNikRobotics/generate_parameter_library>`_ to handle its parameters. The parameter `definition file located in the src folder <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/motion_primitives_controllers/src/motion_primitives_forward_controller_parameter.yaml>`_ contains descriptions for all the parameters used by the controller.
+
+.. generate_parameter_library_details:: src/motion_primitives_forward_controller_parameter.yaml
+
+An example parameter file for this controller can be found in `the test directory <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/motion_primitives_controllers/test/motion_primitives_forward_controller_params.yaml>`_:
+
+.. literalinclude:: test/motion_primitives_forward_controller_params.yaml
+   :language: yaml


### PR DESCRIPTION
The path to the readme was wrong, rendering the repository readme instead.

I also moved the parameter section to the rst for rendering the yaml files.

fyi @mathias31415 