### PR TITLE
Fix use of M_PI in omni_wheel_driver_controller on MSVC

### DIFF
--- a/omni_wheel_drive_controller/src/odometry.cpp
+++ b/omni_wheel_drive_controller/src/odometry.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define _USE_MATH_DEFINES
+
 #include "omni_wheel_drive_controller/odometry.hpp"
 
 #include <cmath>


### PR DESCRIPTION
Similar to https://github.com/ros-controls/ros2_controllers/pull/1536, new code that uses `M_PI` that does not work out of the box in Windows unless `_USE_MATH_DEFINES` is defined. I can't wait for C++20 and `std::numbers::pi`.


To send us a pull request, please:

- [ ] Fork the repository.
- [ ] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [ ] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [ ] Commit to your fork using clear commit messages.
- [ ] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
