### PR TITLE
Don't call `release_interfaces` from controllers

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1273,7 +1273,6 @@ controller_interface::CallbackReturn JointTrajectoryController::on_deactivate(
     joint_command_interface_[index].clear();
     joint_state_interface_[index].clear();
   }
-  release_interfaces();
 
   subscriber_is_active_ = false;
 

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -163,10 +163,9 @@ TEST_P(TrajectoryControllerTestParameterized, cleanup)
   traj_controller_->update(
     rclcpp::Time(static_cast<uint64_t>(0.5 * 1e9)), rclcpp::Duration::from_seconds(0.5));
 
-  auto state = traj_controller_->get_node()->deactivate();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  DeactivateTrajectoryController();
 
-  state = traj_controller_->get_node()->cleanup();
+  auto state = traj_controller_->get_node()->cleanup();
   ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
 
   executor.cancel();
@@ -237,8 +236,7 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
 
   // deactivate
   std::vector<double> deactivated_positions{joint_pos_[0], joint_pos_[1], joint_pos_[2]};
-  state = traj_controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  DeactivateTrajectoryController();
 
   // it should be holding the current point
   expectHoldingPointDeactivated(deactivated_positions);

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -434,6 +434,7 @@ public:
         EXPECT_EQ(
           traj_controller_->get_node()->deactivate().id(),
           lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+        traj_controller_->release_interfaces();
       }
     }
   }

--- a/parallel_gripper_controller/include/parallel_gripper_controller/parallel_gripper_action_controller_impl.hpp
+++ b/parallel_gripper_controller/include/parallel_gripper_controller/parallel_gripper_action_controller_impl.hpp
@@ -404,7 +404,6 @@ controller_interface::CallbackReturn GripperActionController::on_deactivate(
   joint_command_interface_ = std::nullopt;
   joint_position_state_interface_ = std::nullopt;
   joint_velocity_state_interface_ = std::nullopt;
-  release_interfaces();
   return controller_interface::CallbackReturn::SUCCESS;
 }
 

--- a/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
+++ b/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
@@ -132,6 +132,7 @@ TEST_F(GripperControllerTest, ActivateDeactivateActivateSuccess)
   ASSERT_EQ(
     this->controller_->on_deactivate(rclcpp_lifecycle::State()),
     controller_interface::CallbackReturn::SUCCESS);
+  this->controller_->release_interfaces();
 
   // re-assign interfaces
   std::vector<LoanedCommandInterface> command_ifs;


### PR DESCRIPTION
@saikishor 

> The controllers are not supposed to call them at all. 

https://github.com/ros-controls/ros2_control/blob/0d2d78139da58e49992c6dc8ac7552a07e64e397/controller_interface/include/controller_interface/controller_interface_base.hpp#L148-L152