### PR TITLE
Deprecate forward_command_controller specializations

### DIFF
--- a/effort_controllers/doc/userdoc.rst
+++ b/effort_controllers/doc/userdoc.rst
@@ -12,6 +12,10 @@ The package contains the following controllers:
 effort_controllers/JointGroupEffortController
 -------------------------------------------------
 
+.. warning::
+
+  ``effort_controllers/JointGroupEffortController`` is deprecated. Use :ref:`forward_command_controller <forward_command_controller_userdoc>` instead by adding the ``interface_name`` parameter and set it to ``effort``.
+
 This is specialization of the :ref:`forward_command_controller <forward_command_controller_userdoc>` that works using the "effort" joint interface.
 
 

--- a/effort_controllers/src/joint_group_effort_controller.cpp
+++ b/effort_controllers/src/joint_group_effort_controller.cpp
@@ -29,6 +29,11 @@ JointGroupEffortController::JointGroupEffortController()
 
 controller_interface::CallbackReturn JointGroupEffortController::on_init()
 {
+  RCLCPP_WARN(
+    get_node()->get_logger(),
+    "'effort_controllers/JointGroupEffortController' is deprecated. "
+    "Use 'forward_command_controller/ForwardCommandController' instead by adding the "
+    "'interface_name' parameter and set it to 'effort'.");
   try
   {
     // Explicitly set the interface parameter declared by the forward_command_controller

--- a/forward_command_controller/doc/userdoc.rst
+++ b/forward_command_controller/doc/userdoc.rst
@@ -5,16 +5,16 @@
 forward_command_controller
 ==========================
 
-This is a base class implementing a feedforward controller. Specific implementations of this base class can be found in:
+A selection of controllers that forward commands of different types.
 
-* :ref:`position_controllers_userdoc`
-* :ref:`velocity_controllers_userdoc`
-* :ref:`effort_controllers_userdoc`
+forward_command_controller and multi_interface_forward_command_controller
+#########################################################################
+Both controllers forward ``std_msgs::msg::Float64MultiArray`` to a set of interfaces, which can be parameterized as follows: While ``forward_command_controller/ForwardCommandController`` only claims a single interface type per joint (``joint[i] + "/" + interface_name``), the ``forward_command_controller/MultiInterfaceForwardCommandController`` claims the combination of all interfaces specified in the ``interface_names`` parameter (``joint[i] + "/" + interface_names[j]``).
 
 Hardware interface type
 -----------------------
 
-This controller can be used for every type of command interface.
+This controller can be used for every type of command interface, not only limited to joints.
 
 
 ROS 2 interface of the controller

--- a/forward_command_controller/src/forward_command_controller_parameters.yaml
+++ b/forward_command_controller/src/forward_command_controller_parameters.yaml
@@ -9,7 +9,7 @@ forward_command_controller:
   }
   interface_name: {
     type: string,
-    description: "Name of the interface to command",
+    description: "Name of the interface of the joint",
     validation: {
       not_empty<>: []
     },

--- a/forward_command_controller/src/multi_interface_forward_command_controller_parameters.yaml
+++ b/forward_command_controller/src/multi_interface_forward_command_controller_parameters.yaml
@@ -9,7 +9,7 @@ multi_interface_forward_command_controller:
   }
   interface_names: {
     type: string_array,
-    description: "Names of the interfaces to command",
+    description: "Names of the interfaces per joint to claim",
     validation: {
       not_empty<>: []
     },

--- a/position_controllers/doc/userdoc.rst
+++ b/position_controllers/doc/userdoc.rst
@@ -12,6 +12,10 @@ The package contains the following controllers:
 position_controllers/JointGroupPositionController
 -------------------------------------------------
 
+.. warning::
+
+  ``position_controllers/JointGroupPositionController`` is deprecated. Use :ref:`forward_command_controller <forward_command_controller_userdoc>` instead by adding the ``interface_name`` parameter and set it to ``position``.
+
 This is specialization of the :ref:`forward_command_controller <forward_command_controller_userdoc>` that works using the "position" joint interface.
 
 

--- a/position_controllers/src/joint_group_position_controller.cpp
+++ b/position_controllers/src/joint_group_position_controller.cpp
@@ -29,6 +29,11 @@ JointGroupPositionController::JointGroupPositionController()
 
 controller_interface::CallbackReturn JointGroupPositionController::on_init()
 {
+  RCLCPP_WARN(
+    get_node()->get_logger(),
+    "'position_controllers/JointGroupPositionController' is deprecated. "
+    "Use 'forward_command_controller/ForwardCommandController' instead by adding the "
+    "'interface_name' parameter and set it to 'position'.");
   try
   {
     // Explicitly set the interface parameter declared by the forward_command_controller

--- a/velocity_controllers/doc/userdoc.rst
+++ b/velocity_controllers/doc/userdoc.rst
@@ -12,6 +12,10 @@ The package contains the following controllers:
 velocity_controllers/JointGroupVelocityController
 -------------------------------------------------
 
+.. warning::
+
+  ``velocity_controllers/JointGroupVelocityController`` is deprecated. Use :ref:`forward_command_controller <forward_command_controller_userdoc>` instead by adding the ``interface_name`` parameter and set it to ``velocity``.
+
 This is specialization of the :ref:`forward_command_controller <forward_command_controller_userdoc>` that works using the "velocity" joint interface.
 
 

--- a/velocity_controllers/src/joint_group_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_group_velocity_controller.cpp
@@ -29,6 +29,11 @@ JointGroupVelocityController::JointGroupVelocityController()
 
 controller_interface::CallbackReturn JointGroupVelocityController::on_init()
 {
+  RCLCPP_WARN(
+    get_node()->get_logger(),
+    "'velocity_controllers/JointGroupVelocityController' is deprecated. "
+    "Use 'forward_command_controller/ForwardCommandController' instead by adding the "
+    "'interface_name' parameter and set it to 'velocity'.");
   try
   {
     // Explicitly set the interface parameter declared by the forward_command_controller


### PR DESCRIPTION
We decided to deprecate the specializations for the sake of reducing duplicate code here in the repository.