### PR TITLE
Fix: Remove deprecated `rclcpp::spin_some(node)`

### DIFF
--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -130,7 +130,7 @@ protected:
   }
 
   /// \brief wait for the subscriber and publisher to completely setup
-  void waitForSetup()
+  void waitForSetup(rclcpp::Executor & executor)
   {
     constexpr std::chrono::seconds TIMEOUT{2};
     auto clock = pub_node->get_clock();
@@ -141,7 +141,8 @@ protected:
       {
         FAIL();
       }
-      rclcpp::spin_some(pub_node);
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
   }
 
@@ -532,7 +533,7 @@ TEST_F(TestDiffDriveController, test_speed_limiter)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // send msg
   publish(0.0, 0.0);
@@ -773,7 +774,7 @@ TEST_F(TestDiffDriveController, cleanup)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // send msg
   const double linear = 1.0;
@@ -894,7 +895,7 @@ TEST_F(TestDiffDriveController, chainable_controller_unchained_mode)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   // (Note: reference_interfaces_ is protected, but this is
@@ -990,7 +991,7 @@ TEST_F(TestDiffDriveController, chainable_controller_chained_mode)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   for (const auto & interface : controller_->reference_interfaces_)
@@ -1094,7 +1095,7 @@ TEST_F(TestDiffDriveController, deactivate_then_activate)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   // (Note: reference_interfaces_ is protected, but this is
@@ -1138,7 +1139,7 @@ TEST_F(TestDiffDriveController, deactivate_then_activate)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // (Note: reference_interfaces_ is protected, but this is
   // a FRIEND_TEST so we can use it)
@@ -1192,7 +1193,7 @@ TEST_F(TestDiffDriveController, command_with_zero_timestamp_is_accepted_with_war
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // published command message with zero timestamp sets the command interfaces to the correct values
   const double linear = 1.0;

--- a/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.cpp
+++ b/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.cpp
@@ -322,7 +322,7 @@ TEST_F(OmniWheelDriveControllerTest, chainable_controller_unchained_mode)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   for (const auto & interface : controller_->reference_interfaces_)
@@ -410,7 +410,7 @@ TEST_F(OmniWheelDriveControllerTest, chainable_controller_chained_mode)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   for (const auto & interface : controller_->reference_interfaces_)
@@ -478,7 +478,7 @@ TEST_F(OmniWheelDriveControllerTest, deactivate_then_activate)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   for (const auto & interface : controller_->reference_interfaces_)
@@ -523,7 +523,7 @@ TEST_F(OmniWheelDriveControllerTest, deactivate_then_activate)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   for (const auto & interface : controller_->reference_interfaces_)
   {
@@ -572,7 +572,7 @@ TEST_F(OmniWheelDriveControllerTest, command_with_zero_timestamp_is_accepted_wit
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // published command message with zero timestamp sets the command interfaces to the correct values
   publish_twist_timestamped(rclcpp::Time(0, 0, RCL_ROS_TIME));
@@ -615,7 +615,7 @@ TEST_F(OmniWheelDriveControllerTest, 3_wheel_test)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   for (const auto & interface : controller_->reference_interfaces_)
@@ -683,7 +683,7 @@ TEST_F(OmniWheelDriveControllerTest, 3_wheel_rot_test)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   for (const auto & interface : controller_->reference_interfaces_)
@@ -751,7 +751,7 @@ TEST_F(OmniWheelDriveControllerTest, 4_wheel_rot_test)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   for (const auto & interface : controller_->reference_interfaces_)
@@ -819,7 +819,7 @@ TEST_F(OmniWheelDriveControllerTest, 5_wheel_test)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // Reference interfaces should be NaN on initialization
   for (const auto & interface : controller_->reference_interfaces_)

--- a/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.hpp
+++ b/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.hpp
@@ -139,7 +139,7 @@ protected:
   }
 
   /// \brief wait for the subscriber and publisher to completely setup
-  void waitForSetup()
+  void waitForSetup(rclcpp::Executor & executor)
   {
     constexpr std::chrono::seconds TIMEOUT{2};
     auto clock = cmd_vel_publisher_node_->get_clock();
@@ -150,7 +150,8 @@ protected:
       {
         FAIL();
       }
-      rclcpp::spin_some(cmd_vel_publisher_node_);
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
   }
 

--- a/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
+++ b/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
@@ -80,9 +80,11 @@ TEST_F(GripperControllerTest, ConfigureParamsSuccess)
 {
   this->SetUpController();
 
-  this->controller_->get_node()->set_parameter({"joint", "joint1"});
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  rclcpp::spin_some(this->controller_->get_node()->get_node_base_interface());
+  this->controller_->get_node()->set_parameter({"joint", "joint1"});
+  executor.spin_some();
 
   // configure successful
   ASSERT_EQ(

--- a/tricycle_controller/test/test_tricycle_controller.cpp
+++ b/tricycle_controller/test/test_tricycle_controller.cpp
@@ -120,7 +120,7 @@ protected:
   }
 
   /// \brief wait for the subscriber and publisher to completely setup
-  void waitForSetup()
+  void waitForSetup(rclcpp::Executor & executor)
   {
     constexpr std::chrono::seconds TIMEOUT{2};
     auto clock = pub_node->get_clock();
@@ -131,7 +131,8 @@ protected:
       {
         FAIL();
       }
-      rclcpp::spin_some(pub_node);
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
   }
 
@@ -268,7 +269,7 @@ TEST_F(TestTricycleController, cleanup)
   state = controller_->get_node()->activate();
   ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
 
-  waitForSetup();
+  waitForSetup(executor);
 
   // send msg
   const double linear = 1.0;


### PR DESCRIPTION
# Summary
Fixes: #1925
Colcon Tests: Passing
Colcon Build: Passing

The following only the tests in the following packages will be affected:
1. diff_drive_controller
2. omni_wheel_drive_controller
3. parallel_gripper_controller
4. tricycle_controller

The common `waitForSetup` sub-routine now follows `wait_for_twist` style, i.e. the executor object (already existing in the TEST FIXTURE) is passed by reference into the function.