### PR TITLE
Shutdown context properly

### DIFF
--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_forward_position_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_forward_position_controller.py
@@ -66,14 +66,18 @@ class PublisherForwardPosition(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    publisher_forward_position = PublisherForwardPosition()
+    node = PublisherForwardPosition()
 
     try:
-        rclpy.spin(publisher_forward_position)
+        rclpy.spin(node)
     except (KeyboardInterrupt, rclpy.executors.ExternalShutdownException):
         print("Keyboard interrupt received. Shutting down node.")
     except Exception as e:
         print(f"Unhandled exception: {e}")
+    finally:
+        if node:
+            node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_controllers_test_nodes/ros2_controllers_test_nodes/publisher_joint_trajectory_controller.py
@@ -182,14 +182,18 @@ class PublisherJointTrajectory(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    publisher_joint_trajectory = PublisherJointTrajectory()
+    node = PublisherJointTrajectory()
 
     try:
-        rclpy.spin(publisher_joint_trajectory)
+        rclpy.spin(node)
     except (KeyboardInterrupt, rclpy.executors.ExternalShutdownException):
         print("Keyboard interrupt received. Shutting down node.")
     except Exception as e:
         print(f"Unhandled exception: {e}")
+    finally:
+        if node:
+            node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sometime the shutdown fails with a segfault:
```
[INFO] [publisher_forward_position_controller-9]: sending signal 'SIGINT' to process[publisher_forward_position_controller-9]
Error: ROR] [publisher_forward_position_controller-9]: process has died [pid 37985, exit code -11, cmd '/home/runner/work/ros2_control_ci/ros2_control_ci/.work/target_ws/install/ros2_controllers_test_nodes/lib/ros2_controllers_test_nodes/publisher_forward_position_controller --ros-args -r __node:=threedofbot_position_command_publisher --params-file /home/runner/work/ros2_control_ci/ros2_control_ci/.work/target_ws/install/ros2_control_demo_example_13/share/ros2_control_demo_example_13/config/three_robots_position_command_publishers.yaml'].
```
https://github.com/ros-controls/ros2_control_ci/issues/477