### PR TITLE
mecanum_drive_controller: Declare missing backward_ros dependency

### DIFF
--- a/mecanum_drive_controller/package.xml
+++ b/mecanum_drive_controller/package.xml
@@ -25,6 +25,7 @@
   <build_depend>generate_parameter_library</build_depend>
   <build_depend>ros2_control_cmake</build_depend>
 
+  <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
Since CMakeLists.txt contains "find_package(backward_ros REQUIRED)", without this change, compilation can fail with the following error:

    CMake Error at CMakeLists.txt:25 (find_package):
      By not providing "Findbackward_ros.cmake" in CMAKE_MODULE_PATH this project
      has asked CMake to find a package configuration file provided by
      "backward_ros", but CMake did not find one.

This change fixes that.