### PR TITLE
Remove unused `get_state_msg` method

### DIFF
--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -202,11 +202,6 @@ public:
   trajectory_msgs::msg::JointTrajectoryPoint get_state_error() { return state_error_; }
   trajectory_msgs::msg::JointTrajectoryPoint get_current_command() { return command_current_; }
 
-  control_msgs::msg::JointTrajectoryControllerState get_state_msg()
-  {
-    return state_publisher_->get_msg();
-  }
-
   /**
    * a copy of the private member function
    */


### PR DESCRIPTION
The get_msg will be removed upstream
https://github.com/ros-controls/realtime_tools/pull/422