### PR TITLE
Fix JTC crashing when shutdown while executing

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -183,7 +183,7 @@ protected:
   using RealtimeGoalHandlePtr = std::shared_ptr<RealtimeGoalHandle>;
   using RealtimeGoalHandleBuffer = realtime_tools::RealtimeBuffer<RealtimeGoalHandlePtr>;
 
-  RealtimeGoalHandleBuffer rt_active_goal_;       ///< Currently active action goal, if any.
+  RealtimeGoalHandleBuffer rt_active_goal_;  ///< Currently active action goal, if any.
   rclcpp_action::Server<FollowJTrajAction>::SharedPtr action_server_;
   std::atomic<bool> rt_has_pending_goal_{false};  ///< Is there a pending action goal?
   rclcpp::TimerBase::SharedPtr goal_handle_timer_;


### PR DESCRIPTION
When the JTC is executing a trajectory and the system is asked to shutdown it crashes with the error
`Asked to publish result for goal that does not exist`


```
[taskset-2] [controller_manager 1760024502.380843902]: Shutting down the controller manager.

[taskset-2] terminate called after throwing an instance of 'std::runtime_error'
[taskset-2]   what():  Asked to publish result for goal that does not exist

[taskset-2] Stack trace (most recent call last):
[taskset-2] #25   Object "", at 0xffffffffffffffff, in 
[taskset-2] #24   Object "/opt/ros/jazzy/lib/controller_manager/ros2_control_node", at 0x561f369ae934, in _start
[taskset-2] #23   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4d5cd5328a, in __libc_start_main
[taskset-2] #22   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4d5cd531c9, in 
[taskset-2] #21   Object "/opt/ros/jazzy/lib/controller_manager/ros2_control_node", at 0x561f369adeb8, in main
[taskset-2] #20   Object "/opt/ros/jazzy/lib/controller_manager/ros2_control_node", at 0x561f369aea91, in 
[taskset-2] #19   Object "/opt/ros/jazzy/lib/libcontroller_manager.so", at 0x7f4d5d532881, in controller_manager::ControllerManager::~ControllerManager()
[taskset-2] #18   Object "/opt/ros/jazzy/lib/libcontroller_manager.so", at 0x7f4d5d5bd335, in 
[taskset-2] #17   Object "/opt/ros/jazzy/lib/libcontroller_manager.so", at 0x7f4d5d58e389, in void class_loader::ClassLoader::onPluginDeletion<controller_interface::ControllerInterface>(controller_interface::ControllerInterface*)
[taskset-2] #16   Object "/opt/ros/jazzy/lib/libjoint_trajectory_controller.so", at 0x7f4d543ba784, in 
[taskset-2] #15   Object "/opt/ros/jazzy/lib/libjoint_trajectory_controller.so", at 0x7f4d543ba3eb, in 
[taskset-2] #14   Object "/opt/ros/jazzy/lib/libjoint_trajectory_controller.so", at 0x7f4d5436f869, in 
[taskset-2] #13   Object "/opt/ros/jazzy/lib/libjoint_trajectory_controller.so", at 0x7f4d543bccc0, in 
[taskset-2] #12   Object "/opt/ros/jazzy/lib/libjoint_trajectory_controller.so", at 0x7f4d5439d175, in 
[taskset-2] #11   Object "/opt/ros/jazzy/lib/libjoint_trajectory_controller.so", at 0x7f4d543c7d30, in 
[taskset-2] #10   Object "/opt/ros/jazzy/lib/libjoint_trajectory_controller.so", at 0x7f4d543c6fb4, in 
[taskset-2] #9    Object "/opt/ros/jazzy/lib/libjoint_trajectory_controller.so", at 0x7f4d5436b462, in 
[taskset-2] #8    Object "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1", at 0x7f4d5cf5e5cc, in _Unwind_Resume
[taskset-2] #7    Object "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1", at 0x7f4d5cf5db05, in 
[taskset-2] #6    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f4d5d0238b9, in __gxx_personality_v0
[taskset-2] #5    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f4d5d00e8e5, in __cxa_call_terminate
[taskset-2] #4    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f4d5d0240d9, in 
[taskset-2] #3    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f4d5d00eff4, in 
[taskset-2] #2    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4d5cd518fe, in abort
[taskset-2] #1    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4d5cd6e27d, in raise
[taskset-2] #0    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4d5cdc7b2c, in pthread_kill
[taskset-2] Aborted (Signal sent by tkill() 931710 0)
```

When the JTC is being destroyed, destruction of the objects is in reverse order of declaration. Previously in the header the `rt_active_goal_` was before the `action_server_`.  I'm guessing the action server is attempting to clean up its list of active goals and tries to finalize by publishing a result but the active goal handle had already been destroyed causing the exception `Asked to publish result for goal that does not exist`.

I spent a little time to modify the `test_trajectory_actions` but was not successful. If I get some time to learn more about how that test works I will to add a unit test for this.