### PR TITLE
Use UnorderedElementsAreArray for JSB tests

### DIFF
--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -37,9 +37,9 @@ using hardware_interface::HW_IF_VELOCITY;
 using hardware_interface::LoanedStateInterface;
 using std::placeholders::_1;
 using testing::Each;
-using testing::ElementsAreArray;
 using testing::IsEmpty;
 using testing::SizeIs;
+using testing::UnorderedElementsAreArray;
 
 namespace
 {
@@ -193,7 +193,7 @@ TEST_F(JointStateBroadcasterTest, ActivateEmptyTest)
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(joint_names_));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(joint_names_));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));
@@ -204,16 +204,16 @@ TEST_F(JointStateBroadcasterTest, ActivateEmptyTest)
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(joint_names_));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(joint_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[0].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[1].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[2].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
 }
 
 TEST_F(JointStateBroadcasterTest, ReactivateTheControllerWithDifferentInterfacesTest)
@@ -245,7 +245,7 @@ TEST_F(JointStateBroadcasterTest, ReactivateTheControllerWithDifferentInterfaces
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(joint_names_));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(joint_names_));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));
@@ -256,16 +256,16 @@ TEST_F(JointStateBroadcasterTest, ReactivateTheControllerWithDifferentInterfaces
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(joint_names_));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(joint_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[0].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[1].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[2].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
 
   // Now deactivate and activate with only 2 set of joints and interfaces (to create as in one of
   // the interface is unavailable)
@@ -292,7 +292,7 @@ TEST_F(JointStateBroadcasterTest, ReactivateTheControllerWithDifferentInterfaces
   // joint state initialized
   const auto & new_joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(new_joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(new_joint_state_msg.name, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(new_joint_state_msg.name, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(new_joint_state_msg.position, SizeIs(NUM_JOINTS_WITH_ONE_DEACTIVATED));
   ASSERT_THAT(new_joint_state_msg.velocity, SizeIs(NUM_JOINTS_WITH_ONE_DEACTIVATED));
   ASSERT_THAT(new_joint_state_msg.effort, SizeIs(NUM_JOINTS_WITH_ONE_DEACTIVATED));
@@ -304,16 +304,16 @@ TEST_F(JointStateBroadcasterTest, ReactivateTheControllerWithDifferentInterfaces
   ASSERT_THAT(new_dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS_WITH_ONE_DEACTIVATED));
   ASSERT_THAT(
     new_dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS_WITH_ONE_DEACTIVATED));
-  ASSERT_THAT(new_dynamic_joint_state_msg.joint_names, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(new_dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(
     new_dynamic_joint_state_msg.interface_values[0].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     new_dynamic_joint_state_msg.interface_values[1].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     new_dynamic_joint_state_msg.interface_values[2].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
 }
 
 TEST_F(JointStateBroadcasterTest, ActivateTestWithoutJointsParameter)
@@ -344,7 +344,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutJointsParameter)
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(joint_names_));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(joint_names_));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));
@@ -355,16 +355,16 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutJointsParameter)
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(joint_names_));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(joint_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[0].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[1].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[2].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
 }
 
 TEST_F(JointStateBroadcasterTest, ActivateTestWithoutInterfacesParameter)
@@ -395,7 +395,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutInterfacesParameter)
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(joint_names_));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(joint_names_));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));
@@ -406,16 +406,16 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutInterfacesParameter)
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(joint_names_));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(joint_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[0].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[1].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[2].interface_names,
-    ElementsAreArray(interface_names_));
+    UnorderedElementsAreArray(interface_names_));
 }
 
 TEST_F(JointStateBroadcasterTest, ActivateDeactivateTestTwoJointsOneInterface)
@@ -446,7 +446,7 @@ TEST_F(JointStateBroadcasterTest, ActivateDeactivateTestTwoJointsOneInterface)
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
   for (auto i = 0ul; i < NUM_JOINTS; ++i)
@@ -465,11 +465,13 @@ TEST_F(JointStateBroadcasterTest, ActivateDeactivateTestTwoJointsOneInterface)
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(
-    dynamic_joint_state_msg.interface_values[0].interface_names, ElementsAreArray(IF_NAMES));
+    dynamic_joint_state_msg.interface_values[0].interface_names,
+    UnorderedElementsAreArray(IF_NAMES));
   ASSERT_THAT(
-    dynamic_joint_state_msg.interface_values[1].interface_names, ElementsAreArray(IF_NAMES));
+    dynamic_joint_state_msg.interface_values[1].interface_names,
+    UnorderedElementsAreArray(IF_NAMES));
 
   // deactivate
   ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
@@ -512,7 +514,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces)
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));
@@ -527,9 +529,10 @@ TEST_F(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces)
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(
-    dynamic_joint_state_msg.interface_values[0].interface_names, ElementsAreArray(IF_NAMES));
+    dynamic_joint_state_msg.interface_values[0].interface_names,
+    UnorderedElementsAreArray(IF_NAMES));
 }
 
 TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesAllMissing)
@@ -590,7 +593,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing)
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));
@@ -607,12 +610,13 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing)
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[0].interface_names,
-    ElementsAreArray({IF_NAMES[0]}));  // joint 1 has only pos interface
+    UnorderedElementsAreArray({IF_NAMES[0]}));  // joint 1 has only pos interface
   ASSERT_THAT(
-    dynamic_joint_state_msg.interface_values[1].interface_names, ElementsAreArray(IF_NAMES));
+    dynamic_joint_state_msg.interface_values[1].interface_names,
+    UnorderedElementsAreArray(IF_NAMES));
 }
 
 TEST_F(JointStateBroadcasterTest, TestCustomInterfaceWithoutMapping)
@@ -650,9 +654,10 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceWithoutMapping)
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(
-    dynamic_joint_state_msg.interface_values[0].interface_names, ElementsAreArray(IF_NAMES));
+    dynamic_joint_state_msg.interface_values[0].interface_names,
+    UnorderedElementsAreArray(IF_NAMES));
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->joint_state_publisher_);
@@ -686,7 +691,7 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceMapping)
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
   for (auto i = 0ul; i < NUM_JOINTS; ++i)
@@ -705,10 +710,10 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceMapping)
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[0].interface_names,
-    ElementsAreArray({HW_IF_POSITION}));  // mapping to this value
+    UnorderedElementsAreArray({HW_IF_POSITION}));  // mapping to this value
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->joint_state_publisher_);
@@ -731,7 +736,7 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceMappingUpdate)
 
   // joint state initialized
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_EQ(joint_state_msg.position[0], custom_joint_value_);
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
@@ -751,10 +756,10 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceMappingUpdate)
   ASSERT_EQ(dynamic_joint_state_msg.header.frame_id, frame_id_);
   ASSERT_THAT(dynamic_joint_state_msg.joint_names, SizeIs(NUM_JOINTS));
   ASSERT_THAT(dynamic_joint_state_msg.interface_values, SizeIs(NUM_JOINTS));
-  ASSERT_THAT(dynamic_joint_state_msg.joint_names, ElementsAreArray(JOINT_NAMES));
+  ASSERT_THAT(dynamic_joint_state_msg.joint_names, UnorderedElementsAreArray(JOINT_NAMES));
   ASSERT_THAT(
     dynamic_joint_state_msg.interface_values[0].interface_names,
-    ElementsAreArray({HW_IF_POSITION}));
+    UnorderedElementsAreArray({HW_IF_POSITION}));
 
   // publishers initialized
   ASSERT_TRUE(state_broadcaster_->joint_state_publisher_);
@@ -831,9 +836,9 @@ void JointStateBroadcasterTest::test_published_joint_state_message(const std::st
   // we only check that all values in this test are present in the message
   // and that it is the same across the interfaces
   // for test purposes they are mapped to the same doubles
-  ASSERT_THAT(joint_state_msg.position, ElementsAreArray(joint_values_));
-  ASSERT_THAT(joint_state_msg.velocity, ElementsAreArray(joint_state_msg.position));
-  ASSERT_THAT(joint_state_msg.effort, ElementsAreArray(joint_state_msg.position));
+  ASSERT_THAT(joint_state_msg.position, UnorderedElementsAreArray(joint_values_));
+  ASSERT_THAT(joint_state_msg.velocity, UnorderedElementsAreArray(joint_state_msg.position));
+  ASSERT_THAT(joint_state_msg.effort, UnorderedElementsAreArray(joint_state_msg.position));
 }
 
 TEST_F(JointStateBroadcasterTest, JointStatePublishTest)
@@ -906,7 +911,7 @@ void JointStateBroadcasterTest::test_published_dynamic_joint_state_message(
   {
     ASSERT_THAT(
       dynamic_joint_state_msg->interface_values[i].interface_names,
-      ElementsAreArray(INTERFACE_NAMES));
+      UnorderedElementsAreArray(INTERFACE_NAMES));
     const auto index_in_original_order = static_cast<size_t>(std::distance(
       joint_names_.cbegin(),
       std::find(
@@ -956,7 +961,7 @@ TEST_F(JointStateBroadcasterTest, ExtraJointStatePublishTest)
   // joint state initialized
   const auto & joint_state_msg = state_broadcaster_->realtime_joint_state_publisher_->msg_;
   ASSERT_EQ(joint_state_msg.header.frame_id, frame_id_);
-  ASSERT_THAT(joint_state_msg.name, ElementsAreArray(all_joint_names));
+  ASSERT_THAT(joint_state_msg.name, UnorderedElementsAreArray(all_joint_names));
   ASSERT_THAT(joint_state_msg.position, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.velocity, SizeIs(NUM_JOINTS));
   ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));


### PR DESCRIPTION
Sames fix as in https://github.com/ros-controls/ros2_control/pull/730

Closes #1123

I'm not sure if we should apply this patch to newer distros, because we never had this problem an newer RHEL versions.