### PR TITLE
Fix integer literal in logging macro

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -319,7 +319,7 @@ inline bool check_state_tolerance_per_joint(
   if (show_errors)
   {
     const auto logger = rclcpp::get_logger("tolerances");
-    RCLCPP_ERROR(logger, "State tolerances failed for joint %lu:", joint_idx);
+    RCLCPP_ERROR(logger, "State tolerances failed for joint %zu:", joint_idx);
 
     if (state_tolerance.position > 0.0 && abs(error_position) > state_tolerance.position)
     {


### PR DESCRIPTION
Similar to
https://github.com/ros-controls/ros2_controllers/blob/a496412c5a51eda9bf9552f7a8e3a8fd9815f9e1/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp#L319