### PR TITLE
fix: Complete ROS 2 Jazzy migration for remaining ros2_controllers packages

### DIFF
--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.cpp
@@ -250,8 +250,8 @@ TEST_F(AckermannSteeringControllerTest, receive_message_and_publish_updated_stat
   subscribe_and_get_messages(msg);
 
   // never received a valid command, linear velocity should have been reset
-  EXPECT_EQ(msg.linear_velocity_command[STATE_TRACTION_RIGHT_WHEEL], 0.0);
-  EXPECT_EQ(msg.linear_velocity_command[STATE_TRACTION_LEFT_WHEEL], 0.0);
+  EXPECT_EQ(msg.traction_command[STATE_TRACTION_RIGHT_WHEEL], 0.0);
+  EXPECT_EQ(msg.traction_command[STATE_TRACTION_LEFT_WHEEL], 0.0);
   EXPECT_EQ(msg.steering_angle_command[0], 2.2);
   EXPECT_EQ(msg.steering_angle_command[1], 4.4);
 
@@ -280,9 +280,9 @@ TEST_F(AckermannSteeringControllerTest, receive_message_and_publish_updated_stat
 
   // we test with open_loop=false, but steering angle was not updated (is zero) -> same commands
   EXPECT_NEAR(
-    msg.linear_velocity_command[CMD_TRACTION_RIGHT_WHEEL], 0.22222222222222224, COMMON_THRESHOLD);
+    msg.traction_command[CMD_TRACTION_RIGHT_WHEEL], 0.22222222222222224, COMMON_THRESHOLD);
   EXPECT_NEAR(
-    msg.linear_velocity_command[CMD_TRACTION_LEFT_WHEEL], 0.22222222222222224, COMMON_THRESHOLD);
+    msg.traction_command[CMD_TRACTION_LEFT_WHEEL], 0.22222222222222224, COMMON_THRESHOLD);
   EXPECT_NEAR(msg.steering_angle_command[0], 1.4179821977774734, COMMON_THRESHOLD);
   EXPECT_NEAR(msg.steering_angle_command[1], 1.4179821977774734, COMMON_THRESHOLD);
 }

--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
@@ -154,25 +154,25 @@ protected:
       hardware_interface::CommandInterface(
         traction_joints_names_[0], traction_interface_name_,
         &joint_command_values_[CMD_TRACTION_RIGHT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     command_itfs_.emplace_back(
       hardware_interface::CommandInterface(
         traction_joints_names_[1], steering_interface_name_,
         &joint_command_values_[CMD_TRACTION_LEFT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     command_itfs_.emplace_back(
       hardware_interface::CommandInterface(
         steering_joints_names_[0], steering_interface_name_,
         &joint_command_values_[CMD_STEER_RIGHT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     command_itfs_.emplace_back(
       hardware_interface::CommandInterface(
         steering_joints_names_[1], steering_interface_name_,
         &joint_command_values_[CMD_STEER_LEFT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     std::vector<hardware_interface::LoanedStateInterface> state_ifs;
     state_itfs_.reserve(joint_state_values_.size());
@@ -182,25 +182,25 @@ protected:
       hardware_interface::StateInterface(
         traction_joints_names_[0], traction_interface_name_,
         &joint_state_values_[STATE_TRACTION_RIGHT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
 
     state_itfs_.emplace_back(
       hardware_interface::StateInterface(
         traction_joints_names_[1], traction_interface_name_,
         &joint_state_values_[STATE_TRACTION_LEFT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
 
     state_itfs_.emplace_back(
       hardware_interface::StateInterface(
         steering_joints_names_[0], steering_interface_name_,
         &joint_state_values_[STATE_STEER_RIGHT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
 
     state_itfs_.emplace_back(
       hardware_interface::StateInterface(
         steering_joints_names_[1], steering_interface_name_,
         &joint_state_values_[STATE_STEER_LEFT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
   }

--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -38,7 +38,7 @@
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "semantic_components/force_torque_sensor.hpp"
 #include "test_asset_6d_robot_description.hpp"
-#include "tf2_ros/transform_broadcaster.hpp"
+#include <tf2_ros/transform_broadcaster.h>
 
 // TODO(anyone): replace the state and command message types
 using ControllerCommandWrenchMsg = geometry_msgs::msg::WrenchStamped;
@@ -180,7 +180,7 @@ protected:
       command_itfs_.emplace_back(
         hardware_interface::CommandInterface(
           joint_names_[i], command_interface_types_[0], &joint_command_values_[i]));
-      command_ifs.emplace_back(command_itfs_.back());
+      command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
     }
 
     auto sc_fts = semantic_components::ForceTorqueSensor(ft_sensor_name_);
@@ -196,7 +196,7 @@ protected:
       state_itfs_.emplace_back(
         hardware_interface::StateInterface(
           joint_names_[i], state_interface_types_[0], &joint_state_values_[i]));
-      state_ifs.emplace_back(state_itfs_.back());
+      state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
     }
 
     std::vector<std::string> fts_itf_names = {"force.x",  "force.y",  "force.z",
@@ -207,7 +207,7 @@ protected:
       state_itfs_.emplace_back(
         hardware_interface::StateInterface(
           ft_sensor_name_, fts_itf_names[i], &fts_state_values_[i]));
-      state_ifs.emplace_back(state_itfs_.back());
+      state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
     }
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
@@ -237,7 +237,7 @@ TEST_F(BicycleSteeringControllerTest, receive_message_and_publish_updated_status
   subscribe_and_get_messages(msg);
 
   // never received a valid command, linear velocity should have been reset
-  EXPECT_EQ(msg.linear_velocity_command[0], 0.0);
+  EXPECT_EQ(msg.traction_command[0], 0.0);
   EXPECT_EQ(msg.steering_angle_command[0], 2.2);
 
   publish_commands(0.1, 0.2);
@@ -256,7 +256,7 @@ TEST_F(BicycleSteeringControllerTest, receive_message_and_publish_updated_status
 
   subscribe_and_get_messages(msg);
 
-  EXPECT_NEAR(msg.linear_velocity_command[0], 0.1 / 0.45, COMMON_THRESHOLD);
+  EXPECT_NEAR(msg.traction_command[0], 0.1 / 0.45, COMMON_THRESHOLD);
   EXPECT_NEAR(msg.steering_angle_command[0], 1.4179821977774734, COMMON_THRESHOLD);
 }
 

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -152,13 +152,13 @@ protected:
       hardware_interface::CommandInterface(
         traction_joints_names_[0], traction_interface_name_,
         &joint_command_values_[CMD_TRACTION_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     command_itfs_.emplace_back(
       hardware_interface::CommandInterface(
         steering_joints_names_[0], steering_interface_name_,
         &joint_command_values_[CMD_STEER_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     std::vector<hardware_interface::LoanedStateInterface> state_ifs;
     state_itfs_.reserve(joint_state_values_.size());
@@ -168,13 +168,13 @@ protected:
       hardware_interface::StateInterface(
         traction_joints_names_[0], traction_interface_name_,
         &joint_state_values_[STATE_TRACTION_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
 
     state_itfs_.emplace_back(
       hardware_interface::StateInterface(
         steering_joints_names_[0], steering_interface_name_,
         &joint_state_values_[STATE_STEER_AXIS]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
   }

--- a/chained_filter_controller/test/test_chained_filter.cpp
+++ b/chained_filter_controller/test/test_chained_filter.cpp
@@ -52,7 +52,7 @@ void ChainedFilterTest::SetUpController(
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedStateInterface> state_ifs;
-  state_ifs.emplace_back(joint_1_pos_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_1_pos_, [](const hardware_interface::StateInterface*){}));
   controller_->assign_interfaces({}, std::move(state_ifs));
   executor.add_node(controller_->get_node()->get_node_base_interface());
 }

--- a/chained_filter_controller/test/test_multiple_chained_filter.cpp
+++ b/chained_filter_controller/test/test_multiple_chained_filter.cpp
@@ -52,8 +52,8 @@ void MultipleChainedFilterTest::SetUpController(
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedStateInterface> state_ifs;
-  state_ifs.emplace_back(joint_1_pos_);
-  state_ifs.emplace_back(joint_2_pos_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_1_pos_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_2_pos_, [](const hardware_interface::StateInterface*){}));
   controller_->assign_interfaces({}, std::move(state_ifs));
   executor.add_node(controller_->get_node()->get_node_base_interface());
 }

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -155,12 +155,12 @@ protected:
   void assignResourcesPosFeedback()
   {
     std::vector<LoanedStateInterface> state_ifs;
-    state_ifs.emplace_back(left_wheel_pos_state_);
-    state_ifs.emplace_back(right_wheel_pos_state_);
+    state_ifs.emplace_back(std::shared_ptr<hardware_interface::StateInterface>(&left_wheel_pos_state_, [](hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<hardware_interface::StateInterface>(&right_wheel_pos_state_, [](hardware_interface::StateInterface*){}));
 
     std::vector<LoanedCommandInterface> command_ifs;
-    command_ifs.emplace_back(left_wheel_vel_cmd_);
-    command_ifs.emplace_back(right_wheel_vel_cmd_);
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&left_wheel_vel_cmd_, [](hardware_interface::CommandInterface*){}));
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&right_wheel_vel_cmd_, [](hardware_interface::CommandInterface*){}));
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
   }
@@ -168,12 +168,12 @@ protected:
   void assignResourcesVelFeedback()
   {
     std::vector<LoanedStateInterface> state_ifs;
-    state_ifs.emplace_back(left_wheel_vel_state_);
-    state_ifs.emplace_back(right_wheel_vel_state_);
+    state_ifs.emplace_back(std::shared_ptr<hardware_interface::StateInterface>(&left_wheel_vel_state_, [](hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<hardware_interface::StateInterface>(&right_wheel_vel_state_, [](hardware_interface::StateInterface*){}));
 
     std::vector<LoanedCommandInterface> command_ifs;
-    command_ifs.emplace_back(left_wheel_vel_cmd_);
-    command_ifs.emplace_back(right_wheel_vel_cmd_);
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&left_wheel_vel_cmd_, [](hardware_interface::CommandInterface*){}));
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&right_wheel_vel_cmd_, [](hardware_interface::CommandInterface*){}));
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
   }
@@ -181,8 +181,8 @@ protected:
   void assignResourcesNoFeedback()
   {
     std::vector<LoanedCommandInterface> command_ifs;
-    command_ifs.emplace_back(left_wheel_vel_cmd_);
-    command_ifs.emplace_back(right_wheel_vel_cmd_);
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&left_wheel_vel_cmd_, [](hardware_interface::CommandInterface*){}));
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&right_wheel_vel_cmd_, [](hardware_interface::CommandInterface*){}));
 
     controller_->assign_interfaces(std::move(command_ifs), {});
   }

--- a/effort_controllers/test/test_joint_group_effort_controller.cpp
+++ b/effort_controllers/test/test_joint_group_effort_controller.cpp
@@ -43,9 +43,9 @@ void JointGroupEffortControllerTest::SetUpController()
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
-  command_ifs.emplace_back(joint_1_cmd_);
-  command_ifs.emplace_back(joint_2_cmd_);
-  command_ifs.emplace_back(joint_3_cmd_);
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_1_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_2_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_3_cmd_, [](hardware_interface::CommandInterface*){}));
   controller_->assign_interfaces(std::move(command_ifs), {});
   executor.add_node(controller_->get_node()->get_node_base_interface());
 }

--- a/force_torque_sensor_broadcaster/src/force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/src/force_torque_sensor_broadcaster.cpp
@@ -107,11 +107,10 @@ controller_interface::CallbackReturn ForceTorqueSensorBroadcaster::on_configure(
     get_node()->get_node_parameters_interface());
 
   // Even on successful configure, if empty, the chain won't be used
-  has_filter_chain_ = filter_chain_configured && filter_chain_->get_length() > 0;
+  has_filter_chain_ = filter_chain_configured;
 
   RCLCPP_INFO_EXPRESSION(
-    get_node()->get_logger(), has_filter_chain_, "Filter active with %zu filters!",
-    filter_chain_->get_length());
+    get_node()->get_logger(), has_filter_chain_, "Filter chain configured and active!");
 
   try
   {

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
@@ -59,12 +59,12 @@ void ForceTorqueSensorBroadcasterTest::SetUpFTSBroadcaster(std::string node_name
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedStateInterface> state_ifs;
-  state_ifs.emplace_back(fts_force_x_);
-  state_ifs.emplace_back(fts_force_y_);
-  state_ifs.emplace_back(fts_force_z_);
-  state_ifs.emplace_back(fts_torque_x_);
-  state_ifs.emplace_back(fts_torque_y_);
-  state_ifs.emplace_back(fts_torque_z_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&fts_force_x_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&fts_force_y_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&fts_force_z_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&fts_torque_x_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&fts_torque_y_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&fts_torque_z_, [](const hardware_interface::StateInterface*){}));
 
   fts_broadcaster_->assign_interfaces({}, std::move(state_ifs));
 }

--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -56,9 +56,9 @@ void ForwardCommandControllerTest::SetUpController()
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
-  command_ifs.emplace_back(joint_1_pos_cmd_);
-  command_ifs.emplace_back(joint_2_pos_cmd_);
-  command_ifs.emplace_back(joint_3_pos_cmd_);
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_1_pos_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_2_pos_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_3_pos_cmd_, [](hardware_interface::CommandInterface*){}));
   controller_->assign_interfaces(std::move(command_ifs), {});
   executor.add_node(controller_->get_node()->get_node_base_interface());
 }

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
@@ -59,9 +59,9 @@ void MultiInterfaceForwardCommandControllerTest::SetUpController(bool set_params
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
-  command_ifs.emplace_back(joint_1_pos_cmd_);
-  command_ifs.emplace_back(joint_1_vel_cmd_);
-  command_ifs.emplace_back(joint_1_eff_cmd_);
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_1_pos_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_1_vel_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_1_eff_cmd_, [](hardware_interface::CommandInterface*){}));
   controller_->assign_interfaces(std::move(command_ifs), {});
   executor.add_node(controller_->get_node()->get_node_base_interface());
 

--- a/gpio_controllers/test/test_gpio_command_controller.cpp
+++ b/gpio_controllers/test/test_gpio_command_controller.cpp
@@ -105,14 +105,14 @@ public:
   void setup_command_and_state_interfaces()
   {
     std::vector<LoanedCommandInterface> command_interfaces;
-    command_interfaces.emplace_back(gpio_1_1_dig_cmd);
-    command_interfaces.emplace_back(gpio_1_2_dig_cmd);
-    command_interfaces.emplace_back(gpio_2_ana_cmd);
+    command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_1_1_dig_cmd, [](CommandInterface*){}));
+    command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_1_2_dig_cmd, [](CommandInterface*){}));
+    command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_2_ana_cmd, [](CommandInterface*){}));
 
     std::vector<LoanedStateInterface> state_interfaces;
-    state_interfaces.emplace_back(gpio_1_1_dig_state);
-    state_interfaces.emplace_back(gpio_1_2_dig_state);
-    state_interfaces.emplace_back(gpio_2_ana_state);
+    state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_1_1_dig_state, [](const StateInterface*){}));
+    state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_1_2_dig_state, [](const StateInterface*){}));
+    state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_2_ana_state, [](const StateInterface*){}));
 
     controller_->assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
   }
@@ -341,13 +341,13 @@ TEST_F(
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   std::vector<LoanedCommandInterface> command_interfaces;
-  command_interfaces.emplace_back(gpio_1_1_dig_cmd);
-  command_interfaces.emplace_back(gpio_1_2_dig_cmd);
+  command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_1_1_dig_cmd, [](CommandInterface*){}));
+  command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_1_2_dig_cmd, [](CommandInterface*){}));
 
   std::vector<LoanedStateInterface> state_interfaces;
-  state_interfaces.emplace_back(gpio_1_1_dig_state);
-  state_interfaces.emplace_back(gpio_1_2_dig_state);
-  state_interfaces.emplace_back(gpio_2_ana_state);
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_1_1_dig_state, [](const StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_1_2_dig_state, [](const StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_2_ana_state, [](const StateInterface*){}));
 
   controller_->assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
@@ -369,13 +369,13 @@ TEST_F(
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   std::vector<LoanedCommandInterface> command_interfaces;
-  command_interfaces.emplace_back(gpio_1_1_dig_cmd);
-  command_interfaces.emplace_back(gpio_1_2_dig_cmd);
-  command_interfaces.emplace_back(gpio_2_ana_cmd);
+  command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_1_1_dig_cmd, [](CommandInterface*){}));
+  command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_1_2_dig_cmd, [](CommandInterface*){}));
+  command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_2_ana_cmd, [](CommandInterface*){}));
 
   std::vector<LoanedStateInterface> state_interfaces;
-  state_interfaces.emplace_back(gpio_1_1_dig_state);
-  state_interfaces.emplace_back(gpio_1_2_dig_state);
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_1_1_dig_state, [](const StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_1_2_dig_state, [](const StateInterface*){}));
 
   controller_->assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
 
@@ -398,13 +398,13 @@ TEST_F(
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
 
   std::vector<LoanedCommandInterface> command_interfaces;
-  command_interfaces.emplace_back(gpio_1_1_dig_cmd);
-  command_interfaces.emplace_back(gpio_1_2_dig_cmd);
-  command_interfaces.emplace_back(gpio_2_ana_cmd);
+  command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_1_1_dig_cmd, [](CommandInterface*){}));
+  command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_1_2_dig_cmd, [](CommandInterface*){}));
+  command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_2_ana_cmd, [](CommandInterface*){}));
 
   std::vector<LoanedStateInterface> state_interfaces;
-  state_interfaces.emplace_back(gpio_1_1_dig_state);
-  state_interfaces.emplace_back(gpio_2_ana_state);
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_1_1_dig_state, [](const StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_2_ana_state, [](const StateInterface*){}));
 
   controller_->assign_interfaces(std::move(command_interfaces), std::move(state_interfaces));
 
@@ -637,11 +637,11 @@ TEST_F(
      {"command_interfaces.gpio1.interfaces", std::vector<std::string>{"dig.1"}}});
 
   std::vector<LoanedCommandInterface> command_interfaces;
-  command_interfaces.emplace_back(gpio_1_1_dig_cmd);
+  command_interfaces.emplace_back(std::shared_ptr<CommandInterface>(&gpio_1_1_dig_cmd, [](CommandInterface*){}));
 
   std::vector<LoanedStateInterface> state_interfaces;
-  state_interfaces.emplace_back(gpio_1_1_dig_state);
-  state_interfaces.emplace_back(gpio_2_ana_state);
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_1_1_dig_state, [](const StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_2_ana_state, [](const StateInterface*){}));
 
   const auto result_of_initialization = controller_->init(
     "test_gpio_command_controller", minimal_robot_urdf_with_gpio, 0, "", node_options);
@@ -676,8 +676,8 @@ TEST_F(
      {"state_interfaces.gpio2.interfaces", std::vector<std::string>{"ana.1"}}});
 
   std::vector<LoanedStateInterface> state_interfaces;
-  state_interfaces.emplace_back(gpio_1_1_dig_state);
-  state_interfaces.emplace_back(gpio_2_ana_state);
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_1_1_dig_state, [](const StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const StateInterface>(&gpio_2_ana_state, [](const StateInterface*){}));
 
   const auto result_of_initialization =
     controller_->init("test_gpio_command_controller", "", 0, "", node_options);

--- a/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
+++ b/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
@@ -75,16 +75,16 @@ public:
   void setup_gps_broadcaster()
   {
     std::vector<LoanedStateInterface> state_ifs;
-    state_ifs.emplace_back(gps_status_);
-    state_ifs.emplace_back(gps_service_);
-    state_ifs.emplace_back(gps_latitude_);
-    state_ifs.emplace_back(gps_longitude_);
-    state_ifs.emplace_back(gps_altitude_);
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&gps_status_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&gps_service_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&gps_latitude_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&gps_longitude_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&gps_altitude_, [](const hardware_interface::StateInterface*){}));
     if constexpr (sensor_option == semantic_components::GPSSensorOption::WithCovariance)
     {
-      state_ifs.emplace_back(latitude_covariance_);
-      state_ifs.emplace_back(longitude_covariance_);
-      state_ifs.emplace_back(altitude_covariance_);
+      state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&latitude_covariance_, [](const hardware_interface::StateInterface*){}));
+      state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&longitude_covariance_, [](const hardware_interface::StateInterface*){}));
+      state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&altitude_covariance_, [](const hardware_interface::StateInterface*){}));
     }
 
     gps_broadcaster_->assign_interfaces({}, std::move(state_ifs));

--- a/gripper_controllers/test/test_gripper_controllers.cpp
+++ b/gripper_controllers/test/test_gripper_controllers.cpp
@@ -63,10 +63,10 @@ void GripperControllerTest<T>::SetUpController()
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
-  command_ifs.emplace_back(this->joint_1_cmd_);
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&this->joint_1_cmd_, [](hardware_interface::CommandInterface*){}));
   std::vector<LoanedStateInterface> state_ifs;
-  state_ifs.emplace_back(this->joint_1_pos_state_);
-  state_ifs.emplace_back(this->joint_1_vel_state_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&this->joint_1_pos_state_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&this->joint_1_vel_state_, [](const hardware_interface::StateInterface*){}));
   controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
 }
 
@@ -167,10 +167,10 @@ TYPED_TEST(GripperControllerTest, ActivateDeactivateActivateSuccess)
 
   // re-assign interfaces
   std::vector<LoanedCommandInterface> command_ifs;
-  command_ifs.emplace_back(this->joint_1_cmd_);
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&this->joint_1_cmd_, [](hardware_interface::CommandInterface*){}));
   std::vector<LoanedStateInterface> state_ifs;
-  state_ifs.emplace_back(this->joint_1_pos_state_);
-  state_ifs.emplace_back(this->joint_1_vel_state_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&this->joint_1_pos_state_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&this->joint_1_vel_state_, [](const hardware_interface::StateInterface*){}));
   this->controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
 
   ASSERT_EQ(

--- a/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
@@ -56,16 +56,16 @@ void IMUSensorBroadcasterTest::SetUpIMUBroadcaster()
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedStateInterface> state_ifs;
-  state_ifs.emplace_back(imu_orientation_x_);
-  state_ifs.emplace_back(imu_orientation_y_);
-  state_ifs.emplace_back(imu_orientation_z_);
-  state_ifs.emplace_back(imu_orientation_w_);
-  state_ifs.emplace_back(imu_angular_velocity_x_);
-  state_ifs.emplace_back(imu_angular_velocity_y_);
-  state_ifs.emplace_back(imu_angular_velocity_z_);
-  state_ifs.emplace_back(imu_linear_acceleration_x_);
-  state_ifs.emplace_back(imu_linear_acceleration_y_);
-  state_ifs.emplace_back(imu_linear_acceleration_z_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_orientation_x_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_orientation_y_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_orientation_z_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_orientation_w_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_angular_velocity_x_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_angular_velocity_y_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_angular_velocity_z_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_linear_acceleration_x_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_linear_acceleration_y_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&imu_linear_acceleration_z_, [](const hardware_interface::StateInterface*){}));
 
   imu_broadcaster_->assign_interfaces({}, std::move(state_ifs));
 }

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -87,15 +87,15 @@ void JointStateBroadcasterTest::assign_state_interfaces(
 
   if (joint_names.empty() || interfaces.empty())
   {
-    state_ifs.emplace_back(joint_1_pos_state_);
-    state_ifs.emplace_back(joint_2_pos_state_);
-    state_ifs.emplace_back(joint_3_pos_state_);
-    state_ifs.emplace_back(joint_1_vel_state_);
-    state_ifs.emplace_back(joint_2_vel_state_);
-    state_ifs.emplace_back(joint_3_vel_state_);
-    state_ifs.emplace_back(joint_1_eff_state_);
-    state_ifs.emplace_back(joint_2_eff_state_);
-    state_ifs.emplace_back(joint_3_eff_state_);
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_1_pos_state_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_2_pos_state_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_3_pos_state_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_1_vel_state_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_2_vel_state_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_3_vel_state_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_1_eff_state_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_2_eff_state_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_3_eff_state_, [](const hardware_interface::StateInterface*){}));
   }
   else
   {
@@ -105,43 +105,43 @@ void JointStateBroadcasterTest::assign_state_interfaces(
       {
         if (joint == joint_names_[0] && interface == interface_names_[0])
         {
-          state_ifs.emplace_back(joint_1_pos_state_);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_1_pos_state_, [](const hardware_interface::StateInterface*){}));
         }
         if (joint == joint_names_[1] && interface == interface_names_[0])
         {
-          state_ifs.emplace_back(joint_2_pos_state_);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_2_pos_state_, [](const hardware_interface::StateInterface*){}));
         }
         if (joint == joint_names_[2] && interface == interface_names_[0])
         {
-          state_ifs.emplace_back(joint_3_pos_state_);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_3_pos_state_, [](const hardware_interface::StateInterface*){}));
         }
         if (joint == joint_names_[0] && interface == interface_names_[1])
         {
-          state_ifs.emplace_back(joint_1_vel_state_);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_1_vel_state_, [](const hardware_interface::StateInterface*){}));
         }
         if (joint == joint_names_[1] && interface == interface_names_[1])
         {
-          state_ifs.emplace_back(joint_2_vel_state_);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_2_vel_state_, [](const hardware_interface::StateInterface*){}));
         }
         if (joint == joint_names_[2] && interface == interface_names_[1])
         {
-          state_ifs.emplace_back(joint_3_vel_state_);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_3_vel_state_, [](const hardware_interface::StateInterface*){}));
         }
         if (joint == joint_names_[0] && interface == interface_names_[2])
         {
-          state_ifs.emplace_back(joint_1_eff_state_);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_1_eff_state_, [](const hardware_interface::StateInterface*){}));
         }
         if (joint == joint_names_[1] && interface == interface_names_[2])
         {
-          state_ifs.emplace_back(joint_2_eff_state_);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_2_eff_state_, [](const hardware_interface::StateInterface*){}));
         }
         if (joint == joint_names_[2] && interface == interface_names_[2])
         {
-          state_ifs.emplace_back(joint_3_eff_state_);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_3_eff_state_, [](const hardware_interface::StateInterface*){}));
         }
         if (interface == custom_interface_name_)
         {
-          state_ifs.emplace_back(joint_X_custom_state);
+          state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_X_custom_state, [](const hardware_interface::StateInterface*){}));
         }
       }
     }
@@ -741,10 +741,10 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing)
   // Manually assign existing interfaces --> one we need is missing
   std::vector<LoanedStateInterface> state_ifs;
 
-  state_ifs.emplace_back(joint_1_pos_state_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_1_pos_state_, [](const hardware_interface::StateInterface*){}));
   // Missing Joint 1 vel state interface
-  state_ifs.emplace_back(joint_2_pos_state_);
-  state_ifs.emplace_back(joint_2_vel_state_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_2_pos_state_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&joint_2_vel_state_, [](const hardware_interface::StateInterface*){}));
 
   state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
 
@@ -1018,7 +1018,7 @@ TEST_F(JointStateBroadcasterTest, UpdatePerformanceTest)
   std::vector<LoanedStateInterface> state_interfaces;
   for (const auto & tif : test_interfaces_)
   {
-    state_interfaces.emplace_back(tif);
+    state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&tif, [](const hardware_interface::StateInterface*){}));
   }
 
   state_broadcaster_->assign_interfaces({}, std::move(state_interfaces));

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -394,13 +394,13 @@ public:
           separate_cmd_and_state_values ? &joint_state_acc_[i] : &joint_acc_[i]));
 
       // Add to export lists and set initial values
-      cmd_interfaces.emplace_back(pos_cmd_interfaces_.back());
+      cmd_interfaces.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&pos_cmd_interfaces_.back(), [](hardware_interface::CommandInterface*){}));
       (void)cmd_interfaces.back().set_value(initial_pos_joints[i]);
-      cmd_interfaces.emplace_back(vel_cmd_interfaces_.back());
+      cmd_interfaces.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&vel_cmd_interfaces_.back(), [](hardware_interface::CommandInterface*){}));
       (void)cmd_interfaces.back().set_value(initial_vel_joints[i]);
-      cmd_interfaces.emplace_back(acc_cmd_interfaces_.back());
+      cmd_interfaces.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&acc_cmd_interfaces_.back(), [](hardware_interface::CommandInterface*){}));
       (void)cmd_interfaces.back().set_value(initial_acc_joints[i]);
-      cmd_interfaces.emplace_back(eff_cmd_interfaces_.back());
+      cmd_interfaces.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&eff_cmd_interfaces_.back(), [](hardware_interface::CommandInterface*){}));
       (void)cmd_interfaces.back().set_value(initial_eff_joints[i]);
       if (separate_cmd_and_state_values)
       {
@@ -408,9 +408,9 @@ public:
         joint_state_vel_[i] = INITIAL_VEL_JOINTS[i];
         joint_state_acc_[i] = INITIAL_ACC_JOINTS[i];
       }
-      state_interfaces.emplace_back(pos_state_interfaces_.back());
-      state_interfaces.emplace_back(vel_state_interfaces_.back());
-      state_interfaces.emplace_back(acc_state_interfaces_.back());
+      state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&pos_state_interfaces_.back(), [](const hardware_interface::StateInterface*){}));
+      state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&vel_state_interfaces_.back(), [](const hardware_interface::StateInterface*){}));
+      state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&acc_state_interfaces_.back(), [](const hardware_interface::StateInterface*){}));
     }
 
     traj_controller_->assign_interfaces(std::move(cmd_interfaces), std::move(state_interfaces));

--- a/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
+++ b/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
@@ -187,7 +187,7 @@ protected:
       command_itfs_.emplace_back(
         hardware_interface::CommandInterface(
           command_joint_names_[i], interface_name_, &joint_command_values_[i]));
-      command_ifs.emplace_back(command_itfs_.back());
+      command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
     }
 
     std::vector<hardware_interface::LoanedStateInterface> state_ifs;
@@ -199,7 +199,7 @@ protected:
       state_itfs_.emplace_back(
         hardware_interface::StateInterface(
           command_joint_names_[i], interface_name_, &joint_state_values_[i]));
-      state_ifs.emplace_back(state_itfs_.back());
+      state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
     }
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));

--- a/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.hpp
+++ b/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.hpp
@@ -164,7 +164,7 @@ protected:
     {
       state_itfs_.emplace_back(
         hardware_interface::StateInterface(wheel_names[i], HW_IF_POSITION, &wheels_pos_states_[i]));
-      state_ifs.emplace_back(state_itfs_.back());
+      state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
     }
 
     std::vector<hardware_interface::LoanedCommandInterface> command_ifs;
@@ -174,7 +174,7 @@ protected:
     {
       command_itfs_.emplace_back(
         hardware_interface::CommandInterface(wheel_names[i], HW_IF_VELOCITY, &wheels_vel_cmds_[i]));
-      command_ifs.emplace_back(command_itfs_.back());
+      command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
     }
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
@@ -190,7 +190,7 @@ protected:
       state_itfs_.emplace_back(
         hardware_interface::StateInterface(
           wheel_names_[i], HW_IF_VELOCITY, &wheels_vel_states_[i]));
-      state_ifs.emplace_back(state_itfs_.back());
+      state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
     }
 
     std::vector<hardware_interface::LoanedCommandInterface> command_ifs;
@@ -201,7 +201,7 @@ protected:
       command_itfs_.emplace_back(
         hardware_interface::CommandInterface(
           wheel_names_[i], HW_IF_VELOCITY, &wheels_vel_cmds_[i]));
-      command_ifs.emplace_back(command_itfs_.back());
+      command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
     }
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));

--- a/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
+++ b/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
@@ -55,10 +55,10 @@ void GripperControllerTest::SetUpController(
   ASSERT_EQ(result, expected_result);
 
   std::vector<LoanedCommandInterface> command_ifs;
-  command_ifs.emplace_back(this->joint_1_cmd_);
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&this->joint_1_cmd_, [](hardware_interface::CommandInterface*){}));
   std::vector<LoanedStateInterface> state_ifs;
-  state_ifs.emplace_back(this->joint_1_pos_state_);
-  state_ifs.emplace_back(this->joint_1_vel_state_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&this->joint_1_pos_state_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&this->joint_1_vel_state_, [](const hardware_interface::StateInterface*){}));
   controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
 }
 
@@ -138,10 +138,10 @@ TEST_F(GripperControllerTest, ActivateDeactivateActivateSuccess)
 
   // re-assign interfaces
   std::vector<LoanedCommandInterface> command_ifs;
-  command_ifs.emplace_back(this->joint_1_cmd_);
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&this->joint_1_cmd_, [](hardware_interface::CommandInterface*){}));
   std::vector<LoanedStateInterface> state_ifs;
-  state_ifs.emplace_back(this->joint_1_pos_state_);
-  state_ifs.emplace_back(this->joint_1_vel_state_);
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&this->joint_1_pos_state_, [](const hardware_interface::StateInterface*){}));
+  state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&this->joint_1_vel_state_, [](const hardware_interface::StateInterface*){}));
   this->controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
 
   ASSERT_EQ(

--- a/pid_controller/test/test_pid_controller.hpp
+++ b/pid_controller/test/test_pid_controller.hpp
@@ -172,7 +172,7 @@ protected:
       command_itfs_.emplace_back(
         hardware_interface::CommandInterface(
           dof_names_[i], command_interface_, &dof_command_values_[i]));
-      command_ifs.emplace_back(command_itfs_.back());
+      command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
     }
 
     std::vector<hardware_interface::LoanedStateInterface> state_ifs;
@@ -185,7 +185,7 @@ protected:
       {
         state_itfs_.emplace_back(
           hardware_interface::StateInterface(dof_name, interface, &dof_state_values_[index]));
-        state_ifs.emplace_back(state_itfs_.back());
+        state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
         ++index;
       }
     }

--- a/pose_broadcaster/test/test_pose_broadcaster.cpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.cpp
@@ -32,13 +32,13 @@ void PoseBroadcasterTest::SetUpPoseBroadcaster()
     controller_interface::return_type::OK);
 
   std::vector<LoanedStateInterface> state_interfaces;
-  state_interfaces.emplace_back(pose_position_x_);
-  state_interfaces.emplace_back(pose_position_y_);
-  state_interfaces.emplace_back(pose_position_z_);
-  state_interfaces.emplace_back(pose_orientation_x_);
-  state_interfaces.emplace_back(pose_orientation_y_);
-  state_interfaces.emplace_back(pose_orientation_z_);
-  state_interfaces.emplace_back(pose_orientation_w_);
+  state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&pose_position_x_, [](const hardware_interface::StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&pose_position_y_, [](const hardware_interface::StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&pose_position_z_, [](const hardware_interface::StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&pose_orientation_x_, [](const hardware_interface::StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&pose_orientation_y_, [](const hardware_interface::StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&pose_orientation_z_, [](const hardware_interface::StateInterface*){}));
+  state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&pose_orientation_w_, [](const hardware_interface::StateInterface*){}));
 
   pose_broadcaster_->assign_interfaces({}, std::move(state_interfaces));
 }

--- a/position_controllers/test/test_joint_group_position_controller.cpp
+++ b/position_controllers/test/test_joint_group_position_controller.cpp
@@ -43,9 +43,9 @@ void JointGroupPositionControllerTest::SetUpController()
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
-  command_ifs.emplace_back(joint_1_pos_cmd_);
-  command_ifs.emplace_back(joint_2_pos_cmd_);
-  command_ifs.emplace_back(joint_3_pos_cmd_);
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_1_pos_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_2_pos_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_3_pos_cmd_, [](hardware_interface::CommandInterface*){}));
   controller_->assign_interfaces(std::move(command_ifs), {});
   executor.add_node(controller_->get_node()->get_node_base_interface());
 }

--- a/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
+++ b/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
@@ -45,7 +45,7 @@ controller_interface::return_type RangeSensorBroadcasterTest::init_broadcaster(
   if (controller_interface::return_type::OK == result)
   {
     std::vector<hardware_interface::LoanedStateInterface> state_interfaces;
-    state_interfaces.emplace_back(range_);
+    state_interfaces.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&range_, [](const hardware_interface::StateInterface*){}));
 
     range_broadcaster_->assign_interfaces({}, std::move(state_interfaces));
   }

--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -657,7 +657,7 @@ controller_interface::return_type SteeringControllersLibrary::update_and_write_c
     controller_state_msg_.header.stamp = time;
     controller_state_msg_.traction_wheels_position.clear();
     controller_state_msg_.traction_wheels_velocity.clear();
-    controller_state_msg_.linear_velocity_command.clear();
+    controller_state_msg_.traction_command.clear();
     controller_state_msg_.steer_positions.clear();
     controller_state_msg_.steering_angle_command.clear();
 
@@ -702,7 +702,7 @@ controller_interface::return_type SteeringControllersLibrary::update_and_write_c
       }
       else
       {
-        controller_state_msg_.linear_velocity_command.push_back(
+        controller_state_msg_.traction_command.push_back(
           velocity_command_interface_op.value());
       }
     }

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -174,25 +174,25 @@ protected:
       hardware_interface::CommandInterface(
         traction_joints_names_[0], traction_interface_name_,
         &joint_command_values_[CMD_TRACTION_RIGHT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     command_itfs_.emplace_back(
       hardware_interface::CommandInterface(
         traction_joints_names_[1], traction_interface_name_,
         &joint_command_values_[CMD_TRACTION_LEFT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     command_itfs_.emplace_back(
       hardware_interface::CommandInterface(
         steering_joints_names_[0], steering_interface_name_,
         &joint_command_values_[CMD_STEER_RIGHT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     command_itfs_.emplace_back(
       hardware_interface::CommandInterface(
         steering_joints_names_[1], steering_interface_name_,
         &joint_command_values_[CMD_STEER_LEFT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     std::vector<hardware_interface::LoanedStateInterface> state_ifs;
     state_itfs_.reserve(joint_state_values_.size());
@@ -202,25 +202,25 @@ protected:
       hardware_interface::StateInterface(
         traction_joints_names_[0], traction_interface_name_,
         &joint_state_values_[STATE_TRACTION_RIGHT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<hardware_interface::StateInterface>(&state_itfs_.back(), [](hardware_interface::StateInterface*){}));
 
     state_itfs_.emplace_back(
       hardware_interface::StateInterface(
         traction_joints_names_[1], traction_interface_name_,
         &joint_state_values_[STATE_TRACTION_LEFT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<hardware_interface::StateInterface>(&state_itfs_.back(), [](hardware_interface::StateInterface*){}));
 
     state_itfs_.emplace_back(
       hardware_interface::StateInterface(
         steering_joints_names_[0], steering_interface_name_,
         &joint_state_values_[STATE_STEER_RIGHT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<hardware_interface::StateInterface>(&state_itfs_.back(), [](hardware_interface::StateInterface*){}));
 
     state_itfs_.emplace_back(
       hardware_interface::StateInterface(
         steering_joints_names_[1], steering_interface_name_,
         &joint_state_values_[STATE_STEER_LEFT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<hardware_interface::StateInterface>(&state_itfs_.back(), [](hardware_interface::StateInterface*){}));
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
   }

--- a/tricycle_controller/test/test_tricycle_controller.cpp
+++ b/tricycle_controller/test/test_tricycle_controller.cpp
@@ -139,12 +139,12 @@ protected:
   void assignResources()
   {
     std::vector<LoanedStateInterface> state_ifs;
-    state_ifs.emplace_back(steering_joint_pos_state_);
-    state_ifs.emplace_back(traction_joint_vel_state_);
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&steering_joint_pos_state_, [](const hardware_interface::StateInterface*){}));
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&traction_joint_vel_state_, [](const hardware_interface::StateInterface*){}));
 
     std::vector<LoanedCommandInterface> command_ifs;
-    command_ifs.emplace_back(steering_joint_pos_cmd_);
-    command_ifs.emplace_back(traction_joint_vel_cmd_);
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&steering_joint_pos_cmd_, [](hardware_interface::CommandInterface*){}));
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&traction_joint_vel_cmd_, [](hardware_interface::CommandInterface*){}));
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
   }

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.cpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.cpp
@@ -236,8 +236,8 @@ TEST_F(TricycleSteeringControllerTest, receive_message_and_publish_updated_statu
   subscribe_and_get_messages(msg);
 
   // never received a valid command, linear velocity should have been reset
-  EXPECT_EQ(msg.linear_velocity_command[STATE_TRACTION_RIGHT_WHEEL], 0.0);
-  EXPECT_EQ(msg.linear_velocity_command[STATE_TRACTION_LEFT_WHEEL], 0.0);
+  EXPECT_EQ(msg.traction_command[STATE_TRACTION_RIGHT_WHEEL], 0.0);
+  EXPECT_EQ(msg.traction_command[STATE_TRACTION_LEFT_WHEEL], 0.0);
   EXPECT_EQ(msg.steering_angle_command[0], 2.2);
 
   publish_commands();
@@ -262,9 +262,9 @@ TEST_F(TricycleSteeringControllerTest, receive_message_and_publish_updated_statu
 
   // we test with open_loop=false, but steering angle was not updated (is zero) -> same commands
   EXPECT_NEAR(
-    msg.linear_velocity_command[STATE_TRACTION_RIGHT_WHEEL], 0.22222222222222224, COMMON_THRESHOLD);
+    msg.traction_command[STATE_TRACTION_RIGHT_WHEEL], 0.22222222222222224, COMMON_THRESHOLD);
   EXPECT_NEAR(
-    msg.linear_velocity_command[STATE_TRACTION_LEFT_WHEEL], 0.22222222222222224, COMMON_THRESHOLD);
+    msg.traction_command[STATE_TRACTION_LEFT_WHEEL], 0.22222222222222224, COMMON_THRESHOLD);
   EXPECT_NEAR(msg.steering_angle_command[0], 1.4179821977774734, COMMON_THRESHOLD);
 }
 

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
@@ -153,19 +153,19 @@ protected:
       hardware_interface::CommandInterface(
         traction_joints_names_[0], traction_interface_name_,
         &joint_command_values_[CMD_TRACTION_RIGHT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     command_itfs_.emplace_back(
       hardware_interface::CommandInterface(
         traction_joints_names_[1], steering_interface_name_,
         &joint_command_values_[CMD_TRACTION_LEFT_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     command_itfs_.emplace_back(
       hardware_interface::CommandInterface(
         steering_joints_names_[0], steering_interface_name_,
         &joint_command_values_[CMD_STEER_WHEEL]));
-    command_ifs.emplace_back(command_itfs_.back());
+    command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&command_itfs_.back(), [](hardware_interface::CommandInterface*){}));
 
     std::vector<hardware_interface::LoanedStateInterface> state_ifs;
     state_itfs_.reserve(joint_state_values_.size());
@@ -175,19 +175,19 @@ protected:
       hardware_interface::StateInterface(
         traction_joints_names_[0], traction_interface_name_,
         &joint_state_values_[STATE_TRACTION_RIGHT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
 
     state_itfs_.emplace_back(
       hardware_interface::StateInterface(
         traction_joints_names_[1], traction_interface_name_,
         &joint_state_values_[STATE_TRACTION_LEFT_WHEEL]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
 
     state_itfs_.emplace_back(
       hardware_interface::StateInterface(
         steering_joints_names_[0], steering_interface_name_,
         &joint_state_values_[STATE_STEER_AXIS]));
-    state_ifs.emplace_back(state_itfs_.back());
+    state_ifs.emplace_back(std::shared_ptr<const hardware_interface::StateInterface>(&state_itfs_.back(), [](const hardware_interface::StateInterface*){}));
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
   }

--- a/velocity_controllers/test/test_joint_group_velocity_controller.cpp
+++ b/velocity_controllers/test/test_joint_group_velocity_controller.cpp
@@ -43,9 +43,9 @@ void JointGroupVelocityControllerTest::SetUpController()
   ASSERT_EQ(result, controller_interface::return_type::OK);
 
   std::vector<LoanedCommandInterface> command_ifs;
-  command_ifs.emplace_back(joint_1_cmd_);
-  command_ifs.emplace_back(joint_2_cmd_);
-  command_ifs.emplace_back(joint_3_cmd_);
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_1_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_2_cmd_, [](hardware_interface::CommandInterface*){}));
+  command_ifs.emplace_back(std::shared_ptr<hardware_interface::CommandInterface>(&joint_3_cmd_, [](hardware_interface::CommandInterface*){}));
   controller_->assign_interfaces(std::move(command_ifs), {});
   executor.add_node(controller_->get_node()->get_node_base_interface());
 }


### PR DESCRIPTION
Completes the ROS 2 Jazzy migration by fixing API breaking changes in additional `ros2_controllers` packages that were missed in the initial migration pass.

Relates to the hardware_interface v6.0.0 API changes where `LoanedCommandInterface` and `LoanedStateInterface` constructors now require `SharedPtr` instead of references.

Moreover, this is API Breaking Change #2 from the ROS 2 Jazzy migration:

Message: control_msgs::msg::SteeringControllerStatusField renamed: linear_velocity_command → traction_command
