### PR TITLE
Refactor: Rename joint_reference_interfaces_ to reference_interface_n…

### DIFF
--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
@@ -303,7 +303,7 @@ protected:
 
   std::array<double, 4> joint_state_values_ = {{0.5, 0.5, 0.0, 0.0}};
   std::array<double, 4> joint_command_values_ = {{1.1, 3.3, 2.2, 4.4}};
-  std::array<std::string, 2> joint_reference_interfaces_ = {{"linear", "angular"}};
+  std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
   std::string steering_interface_name_ = "position";
   // defined in setup
   std::string traction_interface_name_ = "";

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -272,7 +272,7 @@ protected:
 
   std::array<double, 2> joint_state_values_ = {{3.3, 0.5}};
   std::array<double, 2> joint_command_values_ = {{1.1, 2.2}};
-  std::array<std::string, 2> joint_reference_interfaces_ = {{"linear", "angular"}};
+  std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
   std::string steering_interface_name_ = "position";
 
   // defined in setup

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -320,7 +320,7 @@ protected:
   std::array<double, 4> joint_state_values_ = {{0.5, 0.5, 0.0, 0.0}};
   std::array<double, 4> joint_command_values_ = {{1.1, 3.3, 2.2, 4.4}};
 
-  std::array<std::string, 2> joint_reference_interfaces_ = {{"linear", "angular"}};
+  std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
   std::string steering_interface_name_ = "position";
   // defined in setup
   std::string traction_interface_name_ = "";


### PR DESCRIPTION
Hello, ros_controllers maintainers. This is indeed, my first contribution. 

Here I changed the following files,
1. ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
2. bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
3. steering_controllers_library/test/test_steering_controllers_library.hpp

I renamed every instance of joint_reference_interfaces_
to reference_interface_names_.

Regards,
TheDevMystic (Surya)