### PR TITLE
Refactor: Renamed joint_reference_interfaces_ to reference_interface_…

### DIFF
--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.cpp
@@ -82,11 +82,11 @@ TEST_F(AckermannSteeringControllerTest, check_exported_interfaces)
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
-  for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)
+  ASSERT_EQ(reference_interfaces.size(), reference_interface_names_.size());
+  for (size_t i = 0; i < reference_interface_names_.size(); ++i)
   {
     const std::string ref_itf_prefix_name =
-      std::string(controller_->get_node()->get_name()) + "/" + joint_reference_interfaces_[i];
+      std::string(controller_->get_node()->get_name()) + "/" + reference_interface_names_[i];
     EXPECT_EQ(
       reference_interfaces[i]->get_name(),
       ref_itf_prefix_name + "/" + hardware_interface::HW_IF_VELOCITY);
@@ -186,7 +186,7 @@ TEST_F(AckermannSteeringControllerTest, test_update_logic)
     1.4179821977774734, COMMON_THRESHOLD);
 
   EXPECT_FALSE(std::isnan(controller_->input_ref_.get().twist.linear.x));
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_reference_interfaces_.size());
+  EXPECT_EQ(controller_->reference_interfaces_.size(), reference_interface_names_.size());
   for (const auto & interface : controller_->reference_interfaces_)
   {
     EXPECT_TRUE(std::isnan(interface));
@@ -226,7 +226,7 @@ TEST_F(AckermannSteeringControllerTest, test_update_logic_chained)
     1.4179821977774734, COMMON_THRESHOLD);
 
   EXPECT_TRUE(std::isnan(controller_->input_ref_.get().twist.linear.x));
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_reference_interfaces_.size());
+  EXPECT_EQ(controller_->reference_interfaces_.size(), reference_interface_names_.size());
   for (const auto & interface : controller_->reference_interfaces_)
   {
     EXPECT_TRUE(std::isnan(interface));

--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
@@ -303,7 +303,7 @@ protected:
 
   std::array<double, 4> joint_state_values_ = {{0.5, 0.5, 0.0, 0.0}};
   std::array<double, 4> joint_command_values_ = {{1.1, 3.3, 2.2, 4.4}};
-  std::array<std::string, 2> joint_reference_interfaces_ = {{"linear", "angular"}};
+  std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
   std::string steering_interface_name_ = "position";
   // defined in setup
   std::string traction_interface_name_ = "";

--- a/ackermann_steering_controller/test/test_ackermann_steering_controller_preceding.cpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller_preceding.cpp
@@ -84,11 +84,11 @@ TEST_F(AckermannSteeringControllerTest, check_exported_interfaces)
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
-  for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)
+  ASSERT_EQ(reference_interfaces.size(), reference_interface_names_.size());
+  for (size_t i = 0; i < reference_interface_names_.size(); ++i)
   {
     const std::string ref_itf_prefix_name =
-      std::string(controller_->get_node()->get_name()) + "/" + joint_reference_interfaces_[i];
+      std::string(controller_->get_node()->get_name()) + "/" + reference_interface_names_[i];
     EXPECT_EQ(
       reference_interfaces[i]->get_name(),
       ref_itf_prefix_name + "/" + hardware_interface::HW_IF_VELOCITY);

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
@@ -68,11 +68,11 @@ TEST_F(BicycleSteeringControllerTest, check_exported_interfaces)
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
-  for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)
+  ASSERT_EQ(reference_interfaces.size(), reference_interface_names_.size());
+  for (size_t i = 0; i < reference_interface_names_.size(); ++i)
   {
     const std::string ref_itf_prefix_name =
-      std::string(controller_->get_node()->get_name()) + "/" + joint_reference_interfaces_[i];
+      std::string(controller_->get_node()->get_name()) + "/" + reference_interface_names_[i];
     EXPECT_EQ(
       reference_interfaces[i]->get_name(),
       ref_itf_prefix_name + "/" + hardware_interface::HW_IF_VELOCITY);
@@ -165,7 +165,7 @@ TEST_F(BicycleSteeringControllerTest, test_update_logic)
     COMMON_THRESHOLD);
 
   EXPECT_FALSE(std::isnan(controller_->input_ref_.get().twist.linear.x));
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_reference_interfaces_.size());
+  EXPECT_EQ(controller_->reference_interfaces_.size(), reference_interface_names_.size());
   for (const auto & interface : controller_->reference_interfaces_)
   {
     EXPECT_TRUE(std::isnan(interface));
@@ -198,7 +198,7 @@ TEST_F(BicycleSteeringControllerTest, test_update_logic_chained)
     COMMON_THRESHOLD);
 
   EXPECT_TRUE(std::isnan(controller_->input_ref_.get().twist.linear.x));
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_reference_interfaces_.size());
+  EXPECT_EQ(controller_->reference_interfaces_.size(), reference_interface_names_.size());
   for (const auto & interface : controller_->reference_interfaces_)
   {
     EXPECT_TRUE(std::isnan(interface));

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -272,7 +272,7 @@ protected:
 
   std::array<double, 2> joint_state_values_ = {{3.3, 0.5}};
   std::array<double, 2> joint_command_values_ = {{1.1, 2.2}};
-  std::array<std::string, 2> joint_reference_interfaces_ = {{"linear", "angular"}};
+  std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
   std::string steering_interface_name_ = "position";
 
   // defined in setup

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller_preceding.cpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller_preceding.cpp
@@ -71,11 +71,11 @@ TEST_F(BicycleSteeringControllerTest, check_exported_interfaces)
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
-  for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)
+  ASSERT_EQ(reference_interfaces.size(), reference_interface_names_.size());
+  for (size_t i = 0; i < reference_interface_names_.size(); ++i)
   {
     const std::string ref_itf_prefix_name =
-      std::string(controller_->get_node()->get_name()) + "/" + joint_reference_interfaces_[i];
+      std::string(controller_->get_node()->get_name()) + "/" + reference_interface_names_[i];
     EXPECT_EQ(
       reference_interfaces[i]->get_name(),
       ref_itf_prefix_name + "/" + hardware_interface::HW_IF_VELOCITY);

--- a/steering_controllers_library/test/test_steering_controllers_library.cpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.cpp
@@ -66,11 +66,11 @@ TEST_F(SteeringControllersLibraryTest, check_exported_interfaces)
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
-  for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)
+  ASSERT_EQ(reference_interfaces.size(), reference_interface_names_.size());
+  for (size_t i = 0; i < reference_interface_names_.size(); ++i)
   {
     const std::string ref_itf_prefix_name =
-      std::string(controller_->get_node()->get_name()) + "/" + joint_reference_interfaces_[i];
+      std::string(controller_->get_node()->get_name()) + "/" + reference_interface_names_[i];
     EXPECT_EQ(reference_interfaces[i]->get_prefix_name(), ref_itf_prefix_name);
     EXPECT_EQ(
       reference_interfaces[i]->get_name(),

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -320,7 +320,7 @@ protected:
   std::array<double, 4> joint_state_values_ = {{0.5, 0.5, 0.0, 0.0}};
   std::array<double, 4> joint_command_values_ = {{1.1, 3.3, 2.2, 4.4}};
 
-  std::array<std::string, 2> joint_reference_interfaces_ = {{"linear", "angular"}};
+  std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
   std::string steering_interface_name_ = "position";
   // defined in setup
   std::string traction_interface_name_ = "";

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.cpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.cpp
@@ -75,11 +75,11 @@ TEST_F(TricycleSteeringControllerTest, check_exported_interfaces)
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
-  for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)
+  ASSERT_EQ(reference_interfaces.size(), reference_interface_names_.size());
+  for (size_t i = 0; i < reference_interface_names_.size(); ++i)
   {
     const std::string ref_itf_prefix_name =
-      std::string(controller_->get_node()->get_name()) + "/" + joint_reference_interfaces_[i];
+      std::string(controller_->get_node()->get_name()) + "/" + reference_interface_names_[i];
     EXPECT_EQ(reference_interfaces[i]->get_prefix_name(), ref_itf_prefix_name);
     EXPECT_EQ(
       reference_interfaces[i]->get_name(),
@@ -175,7 +175,7 @@ TEST_F(TricycleSteeringControllerTest, test_update_logic)
     COMMON_THRESHOLD);
 
   EXPECT_FALSE(std::isnan(controller_->input_ref_.get().twist.linear.x));
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_reference_interfaces_.size());
+  EXPECT_EQ(controller_->reference_interfaces_.size(), reference_interface_names_.size());
   for (const auto & interface : controller_->reference_interfaces_)
   {
     EXPECT_TRUE(std::isnan(interface));
@@ -212,7 +212,7 @@ TEST_F(TricycleSteeringControllerTest, test_update_logic_chained)
     COMMON_THRESHOLD);
 
   EXPECT_TRUE(std::isnan(controller_->input_ref_.get().twist.linear.x));
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_reference_interfaces_.size());
+  EXPECT_EQ(controller_->reference_interfaces_.size(), reference_interface_names_.size());
   for (const auto & interface : controller_->reference_interfaces_)
   {
     EXPECT_TRUE(std::isnan(interface));

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
@@ -288,7 +288,7 @@ protected:
 
   std::array<double, 3> joint_state_values_{{0.5, 0.5, 0.0}};
   std::array<double, 3> joint_command_values_{{1.1, 3.3, 2.2}};
-  std::array<std::string, 2> joint_reference_interfaces_{{"linear", "angular"}};
+  std::array<std::string, 2> reference_interface_names_{{"linear", "angular"}};
   std::string steering_interface_name_ = "position";
   // defined in setup
   std::string traction_interface_name_ = "";

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller_preceding.cpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller_preceding.cpp
@@ -77,11 +77,11 @@ TEST_F(TricycleSteeringControllerTest, check_exported_interfaces)
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_reference_interfaces_.size());
-  for (size_t i = 0; i < joint_reference_interfaces_.size(); ++i)
+  ASSERT_EQ(reference_interfaces.size(), reference_interface_names_.size());
+  for (size_t i = 0; i < reference_interface_names_.size(); ++i)
   {
     const std::string ref_itf_prefix_name =
-      std::string(controller_->get_node()->get_name()) + "/" + joint_reference_interfaces_[i];
+      std::string(controller_->get_node()->get_name()) + "/" + reference_interface_names_[i];
     EXPECT_EQ(reference_interfaces[i]->get_prefix_name(), ref_itf_prefix_name);
     EXPECT_EQ(
       reference_interfaces[i]->get_name(),


### PR DESCRIPTION
Dear ros2_controllers maintainers, my previous pull request was taken down due to some issues. Because of the that issue I have to open a second pull request. I am deeply sorry for the inconvenience due to my error.

Furthermore, information related to this pull request are as following,
1. Changed joint_reference_interfaces_ to reference_interface_name_ in 11 files with  31 additions and 31 deletions.

It passed following workflows,
1. Check rolling compatibility on Jazzy
2. Check rolling compatibility on Humble
3. Check rolling compatibility on Kilted.

Again, I am extremely sorry for second pull request and your inconvenience.
