### PR TITLE
Fix links to diff_drive_controller doc file.

### DIFF
--- a/diff_drive_controller/doc/userdoc.rst
+++ b/diff_drive_controller/doc/userdoc.rst
@@ -74,12 +74,12 @@ Publishers
 Parameters
 ,,,,,,,,,,,,
 
-This controller uses the `generate_parameter_library <https://github.com/PickNikRobotics/generate_parameter_library>`_ to handle its parameters. The parameter `definition file located in the src folder <../../src/diff_drive_controller_parameter.yaml>`_ contains descriptions for all the parameters used by the controller.
+This controller uses the `generate_parameter_library <https://github.com/PickNikRobotics/generate_parameter_library>`_ to handle its parameters. The parameter `definition file located in the src folder <../src/diff_drive_controller_parameter.yaml>`_ contains descriptions for all the parameters used by the controller.
 
 .. generate_parameter_library_details:: ../src/diff_drive_controller_parameter.yaml
   parameters_context.yaml
 
-An example parameter file for this controller can be found in `the test directory <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/diff_drive_controller/test/config/test_diff_drive_controller.yaml>`_:
+An example parameter file for this controller can be found in `the test directory <../test/config/test_diff_drive_controller.yaml>`_:
 
 .. literalinclude:: ../test/config/test_diff_drive_controller.yaml
    :language: yaml


### PR DESCRIPTION
Reading the repo I just found these links not working in the doc for the diff_drive_controller. With relative paths they also should remain specific for the branch.
