### PR TITLE
Fix #2035: Initialize previous_publish_timestamp_ in on_configure

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -238,16 +238,10 @@ controller_interface::return_type DiffDriveController::update_and_write_commands
     tf2::Quaternion orientation;
     orientation.setRPY(0.0, 0.0, odometry_.getHeading());
 
-    bool should_publish = false;
-
     if (previous_publish_timestamp_ + publish_period_ <= time)
     {
       previous_publish_timestamp_ += publish_period_;
-      should_publish = true;
-    }
 
-    if (should_publish)
-    {
       if (realtime_odometry_publisher_)
       {
         odometry_message_.header.stamp = time;


### PR DESCRIPTION
## Description
This PR addresses issue #2035 by moving the initialization of `previous_publish_timestamp_` into the `on_configure()` lifecycle method.

Previously, this variable was initialized inside a `catch` block within the update loop, effectively using exception handling for normal control flow. Moving it to `on_configure` aligns it with how `previous_update_timestamp_` is handled and ensures the timestamp is valid before the update loop begins.

## Related Issues
Closes #2035

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
