### PR TITLE
Fix open_loop odometry of steering controllers

### DIFF
--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -517,8 +517,12 @@ controller_interface::return_type SteeringControllersLibrary::update_reference_f
 controller_interface::return_type SteeringControllersLibrary::update_and_write_commands(
   const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-  update_odometry(period);
   auto logger = get_node()->get_logger();
+
+  // store current ref (for open loop odometry) and update odometry
+  last_linear_velocity_ = reference_interfaces_[0];
+  last_angular_velocity_ = reference_interfaces_[1];
+  update_odometry(period);
 
   // MOVE ROBOT
 


### PR DESCRIPTION
It seems that I accidentally removed that with #1721

This still has some issues if we hit the timeout, as the odometry will be updated from NaNs. This should be fixed with #2083 and proper tests to be added.