### PR TITLE
docs: diff_drive_controller - complete wheel_separation_multiplier description and fix then→than typo

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller_parameter.yaml
+++ b/diff_drive_controller/src/diff_drive_controller_parameter.yaml
@@ -26,7 +26,7 @@ diff_drive_controller:
   wheel_radius: {
     type: double,
     default_value: 0.0,
-    description: "Radius of a wheel, i.e., wheels size, used for transformation of linear velocity into wheel rotations. If this parameter is wrong the robot will move faster or slower then expected.",
+    description: "Radius of a wheel, i.e., wheels size, used for transformation of linear velocity into wheel rotations. If this parameter is wrong the robot will move faster or slower than expected.",
     validation: {
       gt<>: [0.0]
     }
@@ -34,8 +34,8 @@ diff_drive_controller:
   wheel_separation_multiplier: {
     type: double,
     default_value: 1.0,
-    description: "Correction factor for wheel separation (TODO(destogl): Please help me describe this correctly)",
-  }
+    description: "Correction factor when the actual wheel separation differs from the nominal value in the ``wheel_separation`` parameter.",
+  } 
   left_wheel_radius_multiplier: {
     type: double,
     default_value: 1.0,


### PR DESCRIPTION
## Change Description
This PR focuses on two minor improvements to the `diff_drive_controller_parameter.yaml` file (no functional changes, only document optimization):
1. Complete the description of `wheel_separation_multiplier` parameter, remove the leftover TODO comment, and align the description style with other `multiplier` parameters (e.g., `left_wheel_radius_multiplier`).
2. Fix the typo in `wheel_radius` parameter description: replace "then" with "than" (a common grammatical error in comparison sentences).