### PR TITLE
Silence -Wdeprecated-declarations in diff_drive_controller

### DIFF
--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -68,7 +68,11 @@ bool Odometry::update(double left_pos, double right_pos, const rclcpp::Time & ti
   left_wheel_old_pos_ = left_wheel_cur_pos;
   right_wheel_old_pos_ = right_wheel_cur_pos;
 
+// Disable deprecated warnings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   updateFromVelocity(left_wheel_est_vel, right_wheel_est_vel, time);
+#pragma GCC diagnostic pop
 
   return true;
 }
@@ -105,7 +109,11 @@ bool Odometry::updateFromVelocity(double left_vel, double right_vel, const rclcp
   const double angular = (right_vel - left_vel) / wheel_separation_;
 
   // Integrate odometry:
+// Disable deprecated warnings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   integrateExact(linear, angular);
+#pragma GCC diagnostic pop
 
   timestamp_ = time;
 
@@ -152,7 +160,11 @@ void Odometry::updateOpenLoop(double linear, double angular, const rclcpp::Time 
   /// Integrate odometry:
   const double dt = time.seconds() - timestamp_.seconds();
   timestamp_ = time;
+// Disable deprecated warnings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   integrateExact(linear * dt, angular * dt);
+#pragma GCC diagnostic pop
 }
 
 bool Odometry::try_update_open_loop(double linear_vel, double angular_vel, double dt)
@@ -203,7 +215,11 @@ void Odometry::integrateExact(double linear, double angular)
 {
   if (fabs(angular) < 1e-6)
   {
+// Disable deprecated warnings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     integrateRungeKutta2(linear, angular);
+#pragma GCC diagnostic pop
   }
   else
   {


### PR DESCRIPTION
Silence warnings from deprecated methods being called in deprecated methods which have been introduced with #1854

```
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp: In member function ‘bool diff_drive_controller::Odometry::update(double, double, const rclcpp::Time&)’:
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp:71:21: warning: ‘bool diff_drive_controller::Odometry::updateFromVelocity(double, double, const rclcpp::Time&)’ is deprecated: Replaced by bool update_from_vel(double left_vel, double right_vel, double dt). [-Wdeprecated-declarations]
   71 |   updateFromVelocity(left_wheel_est_vel, right_wheel_est_vel, time);
      |   ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp:21:
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/include/diff_drive_controller/odometry.hpp:49:8: note: declared here
   49 |   bool updateFromVelocity(double left_vel, double right_vel, const rclcpp::Time & time);
      |        ^~~~~~~~~~~~~~~~~~
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp: In member function ‘bool diff_drive_controller::Odometry::updateFromVelocity(double, double, const rclcpp::Time&)’:
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp:108:17: warning: ‘void diff_drive_controller::Odometry::integrateExact(double, double)’ is deprecated: Replaced by void integrate(double linear_vel, double angular_vel, double dt). [-Wdeprecated-declarations]
  108 |   integrateExact(linear, angular);
      |   ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/include/diff_drive_controller/odometry.hpp:80:8: note: declared here
   80 |   void integrateExact(double linear, double angular);
      |        ^~~~~~~~~~~~~~
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp: In member function ‘void diff_drive_controller::Odometry::updateOpenLoop(double, double, const rclcpp::Time&)’:
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp:155:17: warning: ‘void diff_drive_controller::Odometry::integrateExact(double, double)’ is deprecated: Replaced by void integrate(double linear_vel, double angular_vel, double dt). [-Wdeprecated-declarations]
  155 |   integrateExact(linear * dt, angular * dt);
      |   ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/include/diff_drive_controller/odometry.hpp:80:8: note: declared here
   80 |   void integrateExact(double linear, double angular);
      |        ^~~~~~~~~~~~~~
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp: In member function ‘void diff_drive_controller::Odometry::integrateExact(double, double)’:
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp:206:25: warning: ‘void diff_drive_controller::Odometry::integrateRungeKutta2(double, double)’ is deprecated: Replaced by void integrate(double linear_vel, double angular_vel, double dt). [-Wdeprecated-declarations]
  206 |     integrateRungeKutta2(linear, angular);
      |     ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/workspaces/ros2_rolling_ws/src/ros2_controllers/diff_drive_controller/src/odometry.cpp:192:6: note: declared here
  192 | void Odometry::integrateRungeKutta2(double linear, double angular)
      |      ^~~~~~~~
```