### PR TITLE
Fix deprecation warning in diff_drive_controller

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -604,7 +604,7 @@ void DiffDriveController::set_odometry(
 
 bool DiffDriveController::reset()
 {
-  odometry_.resetOdometry();
+  odometry_.setOdometry(0.0, 0.0, 0.0);
 
   reset_buffers();
 

--- a/diff_drive_controller/test/test_odometry.cpp
+++ b/diff_drive_controller/test/test_odometry.cpp
@@ -146,7 +146,7 @@ TEST_F(OdometryTest, TestReset)
   EXPECT_NE(odometry_.getX(), 0.0);
 
   // 2. Reset
-  odometry_.resetOdometry();
+  odometry_.setOdometry(0.0, 0.0, 0.0);
 
   // 3. Verify position is cleared
   EXPECT_DOUBLE_EQ(odometry_.getX(), 0.0);


### PR DESCRIPTION
## Description
This PR fixes a deprecation warning in `diff_drive_controller` by replacing the deprecated
`Odometry::resetOdometry()` call with `setOdometry(0.0, 0.0, 0.0)`.

The change is limited in scope and does not introduce any functional behavior changes.

## Related Issue
Fixes #2172 