### PR TITLE
fix: reset header stamps to zero in reset methods to prevent timeout

### DIFF
--- a/admittance_controller/src/admittance_controller.cpp
+++ b/admittance_controller/src/admittance_controller.cpp
@@ -41,7 +41,7 @@ void reset_wrench_msg(
   geometry_msgs::msg::WrenchStamped & msg,
   const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node)
 {
-  msg.header.stamp = node->now();
+  msg.header.stamp = rclcpp::Time(0, 0, node->get_clock()->get_clock_type());
   msg.wrench = geometry_msgs::msg::Wrench();
 }
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -654,7 +654,7 @@ void DiffDriveController::reset_buffers()
 
   // Fill RealtimeBox with NaNs so it will contain a known value
   // but still indicate that no command has yet been sent.
-  command_msg_.header.stamp = get_node()->now();
+  command_msg_.header.stamp = rclcpp::Time(0, 0, get_node()->get_clock()->get_clock_type());
   command_msg_.twist.linear.x = std::numeric_limits<double>::quiet_NaN();
   command_msg_.twist.linear.y = std::numeric_limits<double>::quiet_NaN();
   command_msg_.twist.linear.z = std::numeric_limits<double>::quiet_NaN();

--- a/gpio_controllers/src/gpio_command_controller.cpp
+++ b/gpio_controllers/src/gpio_command_controller.cpp
@@ -37,7 +37,7 @@ void print_interface(const rclcpp::Logger & logger, const T & command_interfaces
 void reset_controller_reference_msg(
   gpio_controllers::CmdType & msg, const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node)
 {
-  msg.header.stamp = node->now();
+  msg.header.stamp = rclcpp::Time(0, 0, node->get_clock()->get_clock_type());
   msg.interface_groups.clear();
   msg.interface_values.clear();
 }

--- a/mecanum_drive_controller/src/mecanum_drive_controller.cpp
+++ b/mecanum_drive_controller/src/mecanum_drive_controller.cpp
@@ -37,7 +37,7 @@ using ControllerReferenceMsg =
 void reset_controller_reference_msg(
   ControllerReferenceMsg & msg, const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node)
 {
-  msg.header.stamp = node->now();
+  msg.header.stamp = rclcpp::Time(0, 0, node->get_clock()->get_clock_type());
   msg.twist.linear.x = std::numeric_limits<double>::quiet_NaN();
   msg.twist.linear.y = std::numeric_limits<double>::quiet_NaN();
   msg.twist.linear.z = std::numeric_limits<double>::quiet_NaN();

--- a/mecanum_drive_controller/test/test_mecanum_drive_controller.cpp
+++ b/mecanum_drive_controller/test/test_mecanum_drive_controller.cpp
@@ -445,7 +445,7 @@ TEST_F(
   controller_->wait_for_commands(executor);
   reference = controller_->input_ref_.get();
 
-  ASSERT_EQ(old_timestamp.sec, reference.header.stamp.sec);
+  EXPECT_GT(reference.header.stamp.sec, old_timestamp.sec);
   EXPECT_FALSE(std::isnan(reference.twist.linear.x));
   EXPECT_FALSE(std::isnan(reference.twist.angular.z));
   EXPECT_EQ(reference.twist.linear.x, 1.5);

--- a/omni_wheel_drive_controller/src/omni_wheel_drive_controller.cpp
+++ b/omni_wheel_drive_controller/src/omni_wheel_drive_controller.cpp
@@ -575,7 +575,7 @@ void OmniWheelDriveController::reset_buffers()
 
   // Fill RealtimeBox with NaNs so it will contain a known value
   // but still indicate that no command has yet been sent.
-  command_msg_.header.stamp = get_node()->now();
+  command_msg_.header.stamp = rclcpp::Time(0, 0, get_node()->get_clock()->get_clock_type());
   command_msg_.twist.linear.x = std::numeric_limits<double>::quiet_NaN();
   command_msg_.twist.linear.y = std::numeric_limits<double>::quiet_NaN();
   command_msg_.twist.linear.z = std::numeric_limits<double>::quiet_NaN();

--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -14,6 +14,7 @@
 
 #include "steering_controllers_library/steering_controllers_library.hpp"
 
+#include <cmath>
 #include <limits>
 #include <memory>
 #include <string>
@@ -34,7 +35,7 @@ using ControllerTwistReferenceMsg =
 void reset_controller_reference_msg(
   ControllerTwistReferenceMsg & msg, const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node)
 {
-  msg.header.stamp = node->now();
+  msg.header.stamp = rclcpp::Time(0, 0, node->get_clock()->get_clock_type());
   msg.twist.linear.x = std::numeric_limits<double>::quiet_NaN();
   msg.twist.linear.y = std::numeric_limits<double>::quiet_NaN();
   msg.twist.linear.z = std::numeric_limits<double>::quiet_NaN();
@@ -733,7 +734,6 @@ controller_interface::return_type SteeringControllersLibrary::update_and_write_c
         controller_state_msg_.steering_angle_command.push_back(command_interface_value_op.value());
       }
     }
-
     controller_state_publisher_->try_publish(controller_state_msg_);
   }
 

--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -769,7 +769,7 @@ bool SteeringControllersLibrary::reset()
 {
   odometry_.set_odometry(0.0, 0.0, 0.0);
 
-  reset_controller_reference_msg(current_ref_, get_node());
+  reset_controller_reference_msg(current_ref_);
   input_ref_.set(current_ref_);
 
   last_linear_velocity_ = std::numeric_limits<double>::quiet_NaN();

--- a/steering_controllers_library/test/test_steering_controllers_library.cpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.cpp
@@ -431,6 +431,8 @@ TEST_F(SteeringControllersLibraryTest, odometry_set_service)
   for (int i = 0; i < 10; ++i) move_robot(1.0, 0.0);
   ASSERT_GT(controller_->odometry_.get_x(), 0.0);
 
+  move_robot(0.0, 0.0, 0.0);
+
   // 2. Call the odometry set service
   auto set_request = std::make_shared<control_msgs::srv::SetOdometry::Request>();
   auto set_response = std::make_shared<control_msgs::srv::SetOdometry::Response>();

--- a/steering_controllers_library/test/test_steering_controllers_library.cpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.cpp
@@ -431,7 +431,7 @@ TEST_F(SteeringControllersLibraryTest, odometry_set_service)
   for (int i = 0; i < 10; ++i) move_robot(1.0, 0.0);
   ASSERT_GT(controller_->odometry_.get_x(), 0.0);
 
-  move_robot(0.0, 0.0, 0.0);
+  move_robot(0.0, 0.0);
 
   // 2. Call the odometry set service
   auto set_request = std::make_shared<control_msgs::srv::SetOdometry::Request>();


### PR DESCRIPTION
**Problem**: When controllers reset their internal reference messages, the initialization functions assigned the current time (now()) to the new empty message's timestamp. This caused the message 'age' calculation to yield 0 seconds, which allowed the _empty message to bypass safety timeout checks_.

Solution:

- Modified the reset functions across the affected controllers to set the timestamp to **rclcpp::Time(0)** instead of the current time. This explicitly marks the reset message as an old/invalid command, ensuring the safety timeout logic halts the robot.
- Applied **(void)node**; cast to silence -Werror=unused-parameter compiler warnings without altering existing function signatures. I was unsure to remove this _const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node_ as I might break ABI, but I guess this might not, as it completely separate. 
- Updated **EXPECT_EQ** to **EXPECT_GT** in t_est_mecanum_drive_controller.cpp_ to correctly test the timestamp update against the new 0 baseline. The old EXPECT_EQ tested against an incorrect now() baseline; EXPECT_GT correctly ensures the timestamp advanced from 0.

**Affected Controllers:**
- admittance_controller
- diff_drive_controller
- gpio_controllers
- mecanum_drive_controller
-  omni_wheel_drive_controller
- steering_controllers_library

fix #1774 