### PR TITLE
mecanum_drive_controller: Don't require std_srvs

### DIFF
--- a/mecanum_drive_controller/CMakeLists.txt
+++ b/mecanum_drive_controller/CMakeLists.txt
@@ -16,7 +16,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   rclcpp_lifecycle
   realtime_tools
-  std_srvs
   tf2
   tf2_geometry_msgs
   tf2_msgs


### PR DESCRIPTION
PR #2110 removed `std_srvs` from `package.xml` and C++ code, but CMake still requires it. Remove it from there to not fail in environments where `std_srvs` is not available (e.g. with the Nix package manager).
