### PR TITLE
broadcaster for magnetic field values from a magnetometer

### DIFF
--- a/doc/controllers_index.rst
+++ b/doc/controllers_index.rst
@@ -63,6 +63,7 @@ In the sense of ros2_control, broadcasters are still controllers using the same 
    Pose Broadcaster <../pose_broadcaster/doc/userdoc.rst>
    GPS Sensor Broadcaster <../gps_sensor_broadcaster/doc/userdoc.rst>
    State Interfaces Broadcaster <../state_interfaces_broadcaster/doc/userdoc.rst>
+   Magnetometer Broadcaster <../magnetometer_broadcaster/doc/userdoc.rst>
 
 Filters
 **********************

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -57,3 +57,7 @@ steering_controllers_library
 *****************************
 * Parameter ``tf_frame_prefix`` added with the similar functionality to other controllers. (`#2080 <https://github.com/ros-controls/ros2_controllers/pull/2080>`_).
 * Set odometry service added to be used at runtime. (`#2244 <https://github.com/ros-controls/ros2_controllers/pull/2244>`_).
+
+magnetometer_broadcaster
+************************
+New package to broadcast ``sensor_msgs/msg/MagneticField`` from state interfaces defined by the ``semantic_components::MagneticFieldSensor``.

--- a/magnetometer_broadcaster/CMakeLists.txt
+++ b/magnetometer_broadcaster/CMakeLists.txt
@@ -43,6 +43,29 @@ target_link_libraries(magnetometer_broadcaster PUBLIC
 pluginlib_export_plugin_description_file(
   controller_interface magnetometer_broadcaster.xml)
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gmock REQUIRED)
+  find_package(controller_manager REQUIRED)
+  find_package(hardware_interface REQUIRED)
+  find_package(ros2_control_test_assets REQUIRED)
+
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+  ament_add_gmock(test_load_magnetometer_broadcaster test/test_load_magnetometer_broadcaster.cpp)
+  target_link_libraries(test_load_magnetometer_broadcaster
+    magnetometer_broadcaster
+    controller_manager::controller_manager
+    ros2_control_test_assets::ros2_control_test_assets
+  )
+
+  ament_add_gmock(test_magnetometer_broadcaster
+    test/test_magnetometer_broadcaster.cpp
+  )
+  target_link_libraries(test_magnetometer_broadcaster
+    magnetometer_broadcaster
+    ros2_control_test_assets::ros2_control_test_assets
+  )
+endif()
+
 install(
   TARGETS
     magnetometer_broadcaster

--- a/magnetometer_broadcaster/CMakeLists.txt
+++ b/magnetometer_broadcaster/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.16)
+project(magnetometer_broadcaster)
+
+find_package(ros2_control_cmake REQUIRED)
+set_compiler_options()
+export_windows_symbols()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  controller_interface
+  generate_parameter_library
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+  realtime_tools
+  sensor_msgs
+)
+
+find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
+
+generate_parameter_library(magnetometer_broadcaster_parameters
+  src/magnetometer_broadcaster_parameters.yaml
+)
+
+add_library(magnetometer_broadcaster SHARED
+  src/magnetometer_broadcaster.cpp
+)
+target_compile_features(magnetometer_broadcaster PUBLIC cxx_std_20)
+target_link_libraries(magnetometer_broadcaster PUBLIC
+                      magnetometer_broadcaster_parameters
+                      controller_interface::controller_interface
+                      hardware_interface::hardware_interface
+                      pluginlib::pluginlib
+                      rclcpp::rclcpp
+                      rclcpp_lifecycle::rclcpp_lifecycle
+                      realtime_tools::realtime_tools
+                      ${sensor_msgs_TARGETS})
+
+pluginlib_export_plugin_description_file(
+  controller_interface magnetometer_broadcaster.xml)
+
+install(
+  TARGETS
+    magnetometer_broadcaster
+    magnetometer_broadcaster_parameters
+  EXPORT export_magnetometer_broadcaster
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
+
+ament_export_targets(export_magnetometer_broadcaster HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/magnetometer_broadcaster/doc/userdoc.rst
+++ b/magnetometer_broadcaster/doc/userdoc.rst
@@ -1,0 +1,24 @@
+:github_url: https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/magnetometer_broadcaster/doc/userdoc.rst
+
+.. _magnetometer_broadcaster_userdoc:
+
+Magnetometer Broadcaster
+--------------------------------
+Broadcaster for magnetometer messages (type: ``sensor_msgs/msg/MagneticField``), using the ``semantic_components::MagneticFieldSensor``.
+
+Parameters
+^^^^^^^^^^^
+This controller uses the `generate_parameter_library <https://github.com/PickNikRobotics/generate_parameter_library>`_ to handle its parameters. The parameter `definition file located in the src folder <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/magnetometer_broadcaster/src/magnetometer_broadcaster_parameters.yaml>`_ contains descriptions for all the parameters used by the controller.
+
+List of parameters
+=========================
+.. generate_parameter_library_details:: ../src/magnetometer_broadcaster_parameters.yaml
+
+
+An example parameter file
+=========================
+
+An example parameter file for this controller can be found in `the test directory <https://github.com/ros-controls/ros2_controllers/blob/{REPOS_FILE_BRANCH}/magnetometer_broadcaster/test/magnetometer_broadcaster_params.yaml>`_:
+
+.. literalinclude:: ../test/magnetometer_broadcaster_params.yaml
+   :language: yaml

--- a/magnetometer_broadcaster/magnetometer_broadcaster.xml
+++ b/magnetometer_broadcaster/magnetometer_broadcaster.xml
@@ -1,0 +1,10 @@
+<library path="magnetometer_broadcaster">
+  <class name="magnetometer_broadcaster/MagnetometerBroadcaster"
+         type="magnetometer_broadcaster::MagnetometerBroadcaster"
+         base_class_type="controller_interface::ControllerInterface"
+>
+  <description>
+      This controller publishes the readings of a magnetometer as sensor_msgs/msg/MagneticField message.
+  </description>
+  </class>
+</library>

--- a/magnetometer_broadcaster/package.xml
+++ b/magnetometer_broadcaster/package.xml
@@ -35,6 +35,10 @@
   <depend>realtime_tools</depend>
   <depend>sensor_msgs</depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>controller_manager</test_depend>
+  <test_depend>ros2_control_test_assets</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/magnetometer_broadcaster/package.xml
+++ b/magnetometer_broadcaster/package.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd"
+            schematypens="http://www.w3.org/2001/XMLSchema"
+?>
+<package format="3">
+  <name>magnetometer_broadcaster</name>
+  <version>6.4.0</version>
+  <description>Controller to publish readings of a magnetometer.</description>
+
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="denis@stoglrobotics.de">Denis Štogl</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <url type="website">https://control.ros.org</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros2_controllers/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros2_controllers/</url>
+
+  <author email="Rauch.Christian@gmx.de">Christian Rauch</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>ros2_control_cmake</build_depend>
+
+  <depend>backward_ros</depend>
+  <depend>controller_interface</depend>
+  <depend>eigen</depend>
+  <depend>generate_parameter_library</depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>realtime_tools</depend>
+  <depend>sensor_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/magnetometer_broadcaster/package.xml
+++ b/magnetometer_broadcaster/package.xml
@@ -4,7 +4,7 @@
 ?>
 <package format="3">
   <name>magnetometer_broadcaster</name>
-  <version>6.4.0</version>
+  <version>6.7.0</version>
   <description>Controller to publish readings of a magnetometer.</description>
 
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>

--- a/magnetometer_broadcaster/src/magnetometer_broadcaster.cpp
+++ b/magnetometer_broadcaster/src/magnetometer_broadcaster.cpp
@@ -1,0 +1,147 @@
+// Copyright 2026 Christian Rauch
+// Copyright 2021 PAL Robotics SL.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Authors: Christian Rauch, Subhas Das, Denis Stogl, Victor Lopez
+ */
+
+#include <memory>
+#include <vector>
+
+#include <controller_interface/controller_interface.hpp>
+#include <magnetometer_broadcaster/magnetometer_broadcaster_parameters.hpp>
+#include <pluginlib/class_list_macros.hpp>
+#include <rclcpp_lifecycle/state.hpp>
+#include <realtime_tools/realtime_publisher.hpp>
+#include <semantic_components/magnetic_field_sensor.hpp>
+#include <sensor_msgs/msg/magnetic_field.hpp>
+
+namespace magnetometer_broadcaster
+{
+
+class MagnetometerBroadcaster : public controller_interface::ControllerInterface
+{
+public:
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override
+  {
+    return {};
+  }
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override
+  {
+    return {
+      .type = controller_interface::interface_configuration_type::INDIVIDUAL,
+      .names = magnetometer_->get_state_interface_names(),
+    };
+  }
+
+  controller_interface::CallbackReturn on_init() override
+  {
+    try
+    {
+      param_listener_ = std::make_shared<ParamListener>(get_node());
+    }
+    catch (const std::exception & e)
+    {
+      RCLCPP_ERROR_STREAM(
+        get_node()->get_logger(), "Exception thrown during init stage with message: " << e.what());
+      return CallbackReturn::ERROR;
+    }
+
+    return CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & /*previous_state*/) override
+  {
+    try
+    {
+      params_ = param_listener_->get_params();
+    }
+    catch (const std::exception & e)
+    {
+      RCLCPP_ERROR_STREAM(
+        get_node()->get_logger(),
+        "Exception thrown during config stage with message: " << e.what());
+      return CallbackReturn::ERROR;
+    }
+
+    magnetometer_ = std::make_unique<semantic_components::MagneticFieldSensor>(params_.sensor_name);
+    try
+    {
+      sensor_state_publisher_ = get_node()->create_publisher<sensor_msgs::msg::MagneticField>(
+        "~/magnetic_field", rclcpp::SystemDefaultsQoS());
+      realtime_publisher_ = std::make_unique<StatePublisher>(sensor_state_publisher_);
+    }
+    catch (const std::exception & e)
+    {
+      RCLCPP_ERROR_STREAM(
+        get_node()->get_logger(),
+        "Exception thrown during publisher creation at configure stage with message: " << e.what());
+      return CallbackReturn::ERROR;
+    }
+
+    state_message_.header.frame_id = params_.frame_id;
+    std::copy(
+      params_.static_covariance.begin(), params_.static_covariance.end(),
+      state_message_.magnetic_field_covariance.begin());
+
+    return CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State & /*previous_state*/) override
+  {
+    magnetometer_->assign_loaned_state_interfaces(state_interfaces_);
+    return CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::CallbackReturn on_deactivate(
+    const rclcpp_lifecycle::State & /*previous_state*/) override
+  {
+    magnetometer_->release_interfaces();
+    return CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::return_type update(
+    const rclcpp::Time & time, const rclcpp::Duration & /*period*/) override
+  {
+    magnetometer_->get_values_as_message(state_message_);
+
+    if (realtime_publisher_)
+    {
+      state_message_.header.stamp = time;
+      realtime_publisher_->try_publish(state_message_);
+    }
+
+    return controller_interface::return_type::OK;
+  }
+
+protected:
+  std::shared_ptr<ParamListener> param_listener_;
+  Params params_;
+
+  std::unique_ptr<semantic_components::MagneticFieldSensor> magnetometer_;
+
+  using StatePublisher = realtime_tools::RealtimePublisher<sensor_msgs::msg::MagneticField>;
+  rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr sensor_state_publisher_;
+  std::unique_ptr<StatePublisher> realtime_publisher_;
+  sensor_msgs::msg::MagneticField state_message_;
+};
+
+}  // namespace magnetometer_broadcaster
+
+PLUGINLIB_EXPORT_CLASS(
+  magnetometer_broadcaster::MagnetometerBroadcaster, controller_interface::ControllerInterface)

--- a/magnetometer_broadcaster/src/magnetometer_broadcaster_parameters.yaml
+++ b/magnetometer_broadcaster/src/magnetometer_broadcaster_parameters.yaml
@@ -1,0 +1,29 @@
+magnetometer_broadcaster:
+  sensor_name: {
+    type: string,
+    default_value: "",
+    read_only: true,
+    description: "Defines sensor name used as prefix for its interfaces.
+    Interface names are: ``<sensor_name>/magnetic_field.x, <sensor_name>/magnetic_field.x, <sensor_name>/magnetic_field.z.``",
+    validation: {
+      not_empty<>: null
+    }
+  }
+  frame_id: {
+    type: string,
+    default_value: "",
+    read_only: true,
+    description: "Sensor's frame_id in which values are published.",
+    validation: {
+      not_empty<>: null
+    }
+  }
+  static_covariance: {
+    type: double_array,
+    default_value: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    read_only: true,
+    description: "Static covariance. Row major about x, y, z axes",
+    validation: {
+      fixed_size<>: [9],
+    }
+  }

--- a/magnetometer_broadcaster/test/magnetometer_broadcaster_params.yaml
+++ b/magnetometer_broadcaster/test/magnetometer_broadcaster_params.yaml
@@ -1,0 +1,4 @@
+test_magnetometer_broadcaster:
+  ros__parameters:
+    sensor_name: magnetometer
+    frame_id: magnetometer_frame

--- a/magnetometer_broadcaster/test/test_load_magnetometer_broadcaster.cpp
+++ b/magnetometer_broadcaster/test/test_load_magnetometer_broadcaster.cpp
@@ -1,0 +1,46 @@
+// Copyright 2026 ros2_control development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Authors: Christian Rauch, Wiktor Bajor, Jakub Delicat
+ */
+
+#include <gmock/gmock.h>
+#include <memory>
+
+#include <controller_manager/controller_manager.hpp>
+#include <hardware_interface/resource_manager.hpp>
+#include <rclcpp/executor.hpp>
+#include <rclcpp/executors/single_threaded_executor.hpp>
+#include <rclcpp/utilities.hpp>
+#include <ros2_control_test_assets/descriptions.hpp>
+
+TEST(TestLoadMagnetometerBroadcaster, load_controller)
+{
+  rclcpp::init(0, nullptr);
+  std::shared_ptr<rclcpp::Executor> executor =
+    std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+  controller_manager::ControllerManager cm(
+    executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/magnetometer_broadcaster_params.yaml";
+
+  cm.set_parameter({"test_magnetometer_broadcaster.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_magnetometer_broadcaster.type", "magnetometer_broadcaster/MagnetometerBroadcaster"});
+
+  ASSERT_NE(cm.load_controller("test_magnetometer_broadcaster"), nullptr);
+  rclcpp::shutdown();
+}

--- a/magnetometer_broadcaster/test/test_magnetometer_broadcaster.cpp
+++ b/magnetometer_broadcaster/test/test_magnetometer_broadcaster.cpp
@@ -1,0 +1,209 @@
+// Copyright 2026 ros2_control development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Authors: Christian Rauch, Wiktor Bajor, Jakub Delicat
+ */
+
+#include <gmock/gmock.h>
+#include <utility>
+
+#include <class_loader/class_loader.hpp>
+#include <controller_interface/controller_interface.hpp>
+#include <hardware_interface/loaned_state_interface.hpp>
+#include <hardware_interface/types/hardware_interface_return_values.hpp>
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
+#include <magnetometer_broadcaster/magnetometer_broadcaster_parameters.hpp>
+#include <rclcpp/node.hpp>
+#include <rclcpp/wait_result_kind.hpp>
+#include <rclcpp/wait_set.hpp>
+#include <rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp>
+#include <ros2_control_test_assets/descriptions.hpp>
+#include <sensor_msgs/msg/magnetic_field.hpp>
+
+using callback_return_type =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+namespace
+{
+rclcpp::WaitResultKind wait_for(std::shared_ptr<rclcpp::SubscriptionBase> subscription)
+{
+  rclcpp::WaitSet wait_set;
+  wait_set.add_subscription(subscription);
+  return wait_set.wait().kind();
+}
+
+rclcpp::NodeOptions create_node_options_with_overriden_parameters(
+  std::vector<rclcpp::Parameter> parameters)
+{
+  auto node_options = rclcpp::NodeOptions();
+  node_options.parameter_overrides(parameters);
+  return node_options;
+}
+}  // namespace
+
+class MagnetometerBroadcasterTest : public ::testing::Test
+{
+public:
+  void SetUp()
+  {
+    broadcaster = loader->createInstance<controller_interface::ControllerInterface>(
+      "magnetometer_broadcaster::MagnetometerBroadcaster");
+  }
+
+  void TearDown() { broadcaster.reset(); }
+
+  void setup_broadcaster()
+  {
+    std::vector<hardware_interface::LoanedStateInterface> state_ifs;
+    state_ifs.emplace_back(magnetic_field_x, nullptr);
+    state_ifs.emplace_back(magnetic_field_y, nullptr);
+    state_ifs.emplace_back(magnetic_field_z, nullptr);
+
+    broadcaster->assign_interfaces({}, std::move(state_ifs));
+  }
+
+  sensor_msgs::msg::MagneticField subscribe_and_get_message()
+  {
+    rclcpp::Node test_subscription_node("test_subscription_node");
+    auto subscription = test_subscription_node.create_subscription<sensor_msgs::msg::MagneticField>(
+      "/test_magnetometer_broadcaster/magnetic_field", 10,
+      [](const sensor_msgs::msg::MagneticField::SharedPtr) {});
+    broadcaster->update(rclcpp::Time{}, rclcpp::Duration::from_seconds(0));
+    wait_for(subscription);
+
+    rclcpp::MessageInfo msg_info;
+    sensor_msgs::msg::MagneticField msg;
+    subscription->take(msg, msg_info);
+    return msg;
+  }
+
+  controller_interface::ControllerInterfaceParams create_ctrl_params(
+    const rclcpp::NodeOptions & node_options, const std::string & robot_description = "")
+  {
+    controller_interface::ControllerInterfaceParams params;
+    params.controller_name = "test_magnetometer_broadcaster";
+    params.robot_description = robot_description;
+    params.update_rate = 0;
+    params.node_namespace = "";
+    params.node_options = node_options;
+    return params;
+  }
+
+protected:
+  const std::string sensor_name_ = "magnetometer";
+  const rclcpp::Parameter sensor_name_param_ = rclcpp::Parameter("sensor_name", sensor_name_);
+  const std::string frame_id_ = "magnetometer_frame";
+  const rclcpp::Parameter frame_id_param_ = rclcpp::Parameter("frame_id", frame_id_);
+
+  std::array<double, 3> sensor_values_ = {{20e-6, 30e-6, 40e-6}};
+  hardware_interface::StateInterface::SharedPtr magnetic_field_x =
+    std::make_shared<hardware_interface::StateInterface>(
+      sensor_name_, "magnetic_field.x", &sensor_values_[0]);
+  hardware_interface::StateInterface::SharedPtr magnetic_field_y =
+    std::make_shared<hardware_interface::StateInterface>(
+      sensor_name_, "magnetic_field.y", &sensor_values_[1]);
+  hardware_interface::StateInterface::SharedPtr magnetic_field_z =
+    std::make_shared<hardware_interface::StateInterface>(
+      sensor_name_, "magnetic_field.z", &sensor_values_[2]);
+
+  std::unique_ptr<class_loader::ClassLoader> loader =
+    std::make_unique<class_loader::ClassLoader>(std::string{});
+
+  controller_interface::ControllerInterfaceSharedPtr broadcaster = nullptr;
+};
+
+TEST_F(MagnetometerBroadcasterTest, whenNoParamsAreSetThenInitShouldFail)
+{
+  const auto result = broadcaster->init(create_ctrl_params(
+    broadcaster->define_custom_node_options(), ros2_control_test_assets::minimal_robot_urdf));
+  ASSERT_EQ(result, controller_interface::return_type::ERROR);
+}
+
+TEST_F(MagnetometerBroadcasterTest, whenOnlySensorNameIsSetThenInitShouldFail)
+{
+  const auto node_options = create_node_options_with_overriden_parameters({sensor_name_param_});
+  const auto result = broadcaster->init(
+    create_ctrl_params(node_options, ros2_control_test_assets::minimal_robot_urdf));
+  ASSERT_EQ(result, controller_interface::return_type::ERROR);
+}
+
+TEST_F(
+  MagnetometerBroadcasterTest,
+  whenAllRequiredArgumentsAreSetThenInitConfigureAndActivationShouldSucceed)
+{
+  const auto node_options =
+    create_node_options_with_overriden_parameters({sensor_name_param_, frame_id_param_});
+  const auto result = broadcaster->init(
+    create_ctrl_params(node_options, ros2_control_test_assets::minimal_robot_urdf));
+  ASSERT_EQ(result, controller_interface::return_type::OK);
+  ASSERT_EQ(broadcaster->on_configure(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+  ASSERT_EQ(broadcaster->on_activate(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+}
+
+TEST_F(MagnetometerBroadcasterTest, whenBroadcasterIsActiveShouldPublishWithCovarianceSetToZero)
+{
+  const auto node_options =
+    create_node_options_with_overriden_parameters({sensor_name_param_, frame_id_param_});
+  const auto result = broadcaster->init(
+    create_ctrl_params(node_options, ros2_control_test_assets::minimal_robot_urdf));
+  ASSERT_EQ(result, controller_interface::return_type::OK);
+  ASSERT_EQ(broadcaster->on_configure(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+  setup_broadcaster();
+  ASSERT_EQ(broadcaster->on_activate(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+
+  const auto msg = subscribe_and_get_message();
+  EXPECT_EQ(msg.header.frame_id, frame_id_);
+  EXPECT_EQ(msg.magnetic_field.x, sensor_values_[0]);
+  EXPECT_EQ(msg.magnetic_field.y, sensor_values_[1]);
+  EXPECT_EQ(msg.magnetic_field.z, sensor_values_[2]);
+
+  const std::array<double, 9> expected_covariance = {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
+  ASSERT_THAT(msg.magnetic_field_covariance, ::testing::ElementsAreArray(expected_covariance));
+}
+
+TEST_F(
+  MagnetometerBroadcasterTest,
+  whenBroadcasterIsActiveAndStaticCovarianceShouldPublishWithStaticCovariance)
+{
+  const std::array<double, 9> static_covariance = {{1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}};
+  const auto node_options = create_node_options_with_overriden_parameters(
+    {sensor_name_param_,
+     frame_id_param_,
+     {"static_covariance",
+      std::vector<double>{static_covariance.begin(), static_covariance.end()}}});
+  const auto result = broadcaster->init(
+    create_ctrl_params(node_options, ros2_control_test_assets::minimal_robot_urdf));
+  ASSERT_EQ(result, controller_interface::return_type::OK);
+  ASSERT_EQ(broadcaster->on_configure(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+  setup_broadcaster();
+  ASSERT_EQ(broadcaster->on_activate(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+
+  const auto msg = subscribe_and_get_message();
+  EXPECT_EQ(msg.header.frame_id, frame_id_);
+  EXPECT_EQ(msg.magnetic_field.x, sensor_values_[0]);
+  EXPECT_EQ(msg.magnetic_field.y, sensor_values_[1]);
+  EXPECT_EQ(msg.magnetic_field.z, sensor_values_[2]);
+
+  ASSERT_THAT(msg.magnetic_field_covariance, ::testing::ElementsAreArray(static_covariance));
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleMock(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/ros2_controllers/package.xml
+++ b/ros2_controllers/package.xml
@@ -29,6 +29,7 @@
   <exec_depend>imu_sensor_broadcaster</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>magnetometer_broadcaster</exec_depend>
   <exec_depend>mecanum_drive_controller</exec_depend>
   <exec_depend>motion_primitives_controllers</exec_depend>
   <exec_depend>omni_wheel_drive_controller</exec_depend>


### PR DESCRIPTION
This PR adds a broadcaster for magnetometers via the `semantic_components::MagneticFieldSensor`, similar to how this is done for other semantic components (`semantic_components::IMUSensor`, `semantic_components::ForceTorqueSensor`).

---

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
