### PR TITLE
rqt_jtc: Check for interface type when adding joint names

### DIFF
--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -467,7 +467,7 @@ def _jtc_joint_names(jtc_info):
         name = "/".join(interface.split("/")[:-1])
         interface_type = interface.split("/")[-1]
         if name not in joint_names:
-            if interface_type == "position" or interface_type == "velocity":
+            if interface_type == "position":
                 joint_names.append(name)
 
     return joint_names


### PR DESCRIPTION
The JTC RQT gui extracts joint names from the required state interfaces of a controller matching the JTC name pattern. If that controller doesn't contain limits for all joints, that controller will be ignored. Therefore, of the controller has setup a speed scaling state interface, that will show up in the list of joints, while there are no limits configured.

Thus, the GUI cannot be used if the controller is setup with a speed scaling state interface.

This commit only adds state interfaces which are of type "position" or "velocity" to the list of joints.