### PR TITLE
Fix link to REP103

### DIFF
--- a/doc/mobile_robot_kinematics.rst
+++ b/doc/mobile_robot_kinematics.rst
@@ -200,7 +200,7 @@ Nonholonomic Wheeled Mobile Robots
 Unicycle model
 ,,,,,,,,,,,,,,,,
 
-To define the coordinate systems (`ROS coordinate frame conventions <https://reps.openrobotics.org/rep-0103/#id19>`__, the coordinate systems follow the right-hand rule), consider the following simple unicycle model
+To define the coordinate systems (`ROS coordinate frame conventions <https://reps.openrobotics.org/rep-0103/#coordinate-frame-conventions>`__, the coordinate systems follow the right-hand rule), consider the following simple unicycle model
 
 .. image:: images/unicycle.svg
    :width: 550


### PR DESCRIPTION
`(doc/ros2_controllers/doc/mobile_robot_kinematics: line  203) broken    https://reps.openrobotics.org/rep-0103/#id19 - Anchor 'id19' not found`