### PR TITLE
[RQT_JTC] add unit tests for parse_joint_limits

### DIFF
--- a/rqt_joint_trajectory_controller/package.xml
+++ b/rqt_joint_trajectory_controller/package.xml
@@ -30,6 +30,7 @@
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>qt_gui</exec_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_limits_urdf.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_limits_urdf.py
@@ -155,9 +155,6 @@ def parse_joint_limits(urdf_string, joints_names, use_smallest_joint_limits=True
                 dependent_joints[name] = entry
                 continue
 
-            if name in dependent_joints:
-                continue
-
             joint = {"min_position": minval, "max_position": maxval}
             joint["has_position_limits"] = jtype != "continuous"
             joint["max_velocity"] = maxvel

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_limits_urdf.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_limits_urdf.py
@@ -45,81 +45,142 @@ def subscribe_to_robot_description(node, key="robot_description"):
     node.create_subscription(String, key, callback, qos_profile)
 
 
-def get_joint_limits(node, joints_names, use_smallest_joint_limits=True):
+def parse_joint_limits(urdf_string, joints_names, use_smallest_joint_limits=True):
+    """
+    Parse joint position and velocity limits from a URDF XML string.
+
+    This function contains all the real parsing logic and has no dependency
+    on ROS, global variables, or any running infrastructure. It accepts the
+    URDF as a plain Python string, which makes it directly unit-testable
+    without needing a ROS node or a robot_description topic.
+
+    Parameters
+    ----------
+    urdf_string : str
+        A complete URDF XML document as a string.
+    joints_names : list[str]
+        The joints that the active controller manages. A joint in this list
+        that is missing its <limit> element will raise an Exception. Joints
+        NOT in this list that are missing limits are silently skipped.
+    use_smallest_joint_limits : bool
+        When True, safety_controller soft limits narrow the reported range.
+
+    Returns
+    -------
+    dict
+        Maps joint name to a dict with keys:
+        min_position, max_position, has_position_limits, max_velocity.
+
+    """
     use_small = use_smallest_joint_limits
     use_mimic = True
 
+    free_joints = {}
+    dependent_joints = {}
+
+    # minidom raises xml.parsers.expat.ExpatError for completely invalid XML.
+    # We let that propagate naturally — the caller (get_joint_limits) can
+    # decide how to handle it. For unit tests, we test our own logic only.
+    robot = xml.dom.minidom.parseString(urdf_string).getElementsByTagName("robot")[0]
+
+    # Walk every direct child of the <robot> element.
+    # Non-joint tags like <link>, <ros2_control>, <gazebo> are naturally
+    # skipped because we only act when localName == "joint".
+    for child in robot.childNodes:
+        # minidom includes whitespace text nodes between elements — skip them
+        if child.nodeType is child.TEXT_NODE:
+            continue
+        if child.localName == "joint":
+            jtype = child.getAttribute("type")
+            if jtype == "fixed":
+                # Fixed joints have no DOF — no slider needed in the GUI
+                continue
+            name = child.getAttribute("name")
+
+            try:
+                limit = child.getElementsByTagName("limit")[0]
+
+                # minidom returns "" for absent attributes.
+                # float("") raises ValueError, which we catch below.
+                try:
+                    minval = float(limit.getAttribute("lower"))
+                    maxval = float(limit.getAttribute("upper"))
+                except ValueError:
+                    if jtype == "continuous":
+                        # Continuous joints have no position bounds by definition
+                        minval = -pi
+                        maxval = pi
+                    else:
+                        raise Exception(
+                            f"Missing lower/upper position limits for the joint"
+                            f" : {name} of type : {jtype} in the robot_description!"
+                        )
+
+                try:
+                    maxvel = float(limit.getAttribute("velocity"))
+                except ValueError:
+                    raise Exception(
+                        f"Missing velocity limits for the joint"
+                        f" : {name} of type : {jtype} in the robot_description!"
+                    )
+
+            except IndexError:
+                # No <limit> element found at all for this joint
+                if name in joints_names:
+                    raise Exception(
+                        f"Missing limits tag for the joint" f" : {name} in the robot_description!"
+                    )
+                # Joint is not managed by this controller — skip silently
+                continue
+
+            # Optionally narrow the range with safety controller soft limits
+            safety_tags = child.getElementsByTagName("safety_controller")
+            if use_small and len(safety_tags) == 1:
+                tag = safety_tags[0]
+                if tag.hasAttribute("soft_lower_limit"):
+                    minval = max(minval, float(tag.getAttribute("soft_lower_limit")))
+                if tag.hasAttribute("soft_upper_limit"):
+                    maxval = min(maxval, float(tag.getAttribute("soft_upper_limit")))
+
+            # Mimic joints follow another joint — exclude from free_joints
+            mimic_tags = child.getElementsByTagName("mimic")
+            if use_mimic and len(mimic_tags) == 1:
+                tag = mimic_tags[0]
+                entry = {"parent": tag.getAttribute("joint")}
+                if tag.hasAttribute("multiplier"):
+                    entry["factor"] = float(tag.getAttribute("multiplier"))
+                if tag.hasAttribute("offset"):
+                    entry["offset"] = float(tag.getAttribute("offset"))
+
+                dependent_joints[name] = entry
+                continue
+
+            if name in dependent_joints:
+                continue
+
+            joint = {"min_position": minval, "max_position": maxval}
+            joint["has_position_limits"] = jtype != "continuous"
+            joint["max_velocity"] = maxvel
+            free_joints[name] = joint
+
+    return free_joints
+
+
+def get_joint_limits(node, joints_names, use_smallest_joint_limits=True):
+    """
+    ROS-aware wrapper around parse_joint_limits.
+
+    Waits for the robot_description topic to publish, then delegates all
+    real parsing work to parse_joint_limits(). This separation means
+    parse_joint_limits() can be tested without any ROS infrastructure.
+    """
     count = 0
     while description == "" and count < 10:
         print("Waiting for the robot_description!")
         count += 1
         rclpy.spin_once(node, timeout_sec=1.0)
 
-    free_joints = {}
-    dependent_joints = {}
+    if description == "":
+        return {}
 
-    if description != "":
-        robot = xml.dom.minidom.parseString(description).getElementsByTagName("robot")[0]
-
-        # Find all non-fixed joints
-        for child in robot.childNodes:
-            if child.nodeType is child.TEXT_NODE:
-                continue
-            if child.localName == "joint":
-                jtype = child.getAttribute("type")
-                if jtype == "fixed":
-                    continue
-                name = child.getAttribute("name")
-
-                try:
-                    limit = child.getElementsByTagName("limit")[0]
-                    try:
-                        minval = float(limit.getAttribute("lower"))
-                        maxval = float(limit.getAttribute("upper"))
-                    except ValueError:
-                        if jtype == "continuous":
-                            minval = -pi
-                            maxval = pi
-                        else:
-                            raise Exception(
-                                f"Missing lower/upper position limits for the joint : {name} of type : {jtype} in the robot_description!"
-                            )
-                    try:
-                        maxvel = float(limit.getAttribute("velocity"))
-                    except ValueError:
-                        raise Exception(
-                            f"Missing velocity limits for the joint : {name} of type : {jtype} in the robot_description!"
-                        )
-                except IndexError:
-                    if name in joints_names:
-                        raise Exception(
-                            f"Missing limits tag for the joint : {name} in the robot_description!"
-                        )
-                safety_tags = child.getElementsByTagName("safety_controller")
-                if use_small and len(safety_tags) == 1:
-                    tag = safety_tags[0]
-                    if tag.hasAttribute("soft_lower_limit"):
-                        minval = max(minval, float(tag.getAttribute("soft_lower_limit")))
-                    if tag.hasAttribute("soft_upper_limit"):
-                        maxval = min(maxval, float(tag.getAttribute("soft_upper_limit")))
-
-                mimic_tags = child.getElementsByTagName("mimic")
-                if use_mimic and len(mimic_tags) == 1:
-                    tag = mimic_tags[0]
-                    entry = {"parent": tag.getAttribute("joint")}
-                    if tag.hasAttribute("multiplier"):
-                        entry["factor"] = float(tag.getAttribute("multiplier"))
-                    if tag.hasAttribute("offset"):
-                        entry["offset"] = float(tag.getAttribute("offset"))
-
-                    dependent_joints[name] = entry
-                    continue
-
-                if name in dependent_joints:
-                    continue
-
-                joint = {"min_position": minval, "max_position": maxval}
-                joint["has_position_limits"] = jtype != "continuous"
-                joint["max_velocity"] = maxvel
-                free_joints[name] = joint
-    return free_joints
+    return parse_joint_limits(description, joints_names, use_smallest_joint_limits)

--- a/rqt_joint_trajectory_controller/test/test_joint_limits_urdf.py
+++ b/rqt_joint_trajectory_controller/test/test_joint_limits_urdf.py
@@ -1,4 +1,4 @@
-# Copyright 2024 ros2_control Development Team
+# Copyright 2026 ros2_control Development Team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -143,11 +143,6 @@ def test_continuous_joint_velocity_is_preserved():
 # ---------------------------------------------------------------------------
 # Group 3: Fixed joints — they have no DOF and must be completely ignored.
 # ---------------------------------------------------------------------------
-
-
-def test_fixed_joint_not_in_result():
-    result = parse_joint_limits(_robot(_fixed("camera_mount")), [])
-    assert "camera_mount" not in result
 
 
 def test_urdf_with_only_fixed_joints_returns_empty_dict():

--- a/rqt_joint_trajectory_controller/test/test_joint_limits_urdf.py
+++ b/rqt_joint_trajectory_controller/test/test_joint_limits_urdf.py
@@ -1,0 +1,339 @@
+# Copyright 2024 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for parse_joint_limits() in joint_limits_urdf.py.
+
+All tests are ROS-free. They call parse_joint_limits() directly with
+URDF strings and assert on the returned dict. No node, no topic, no
+robot_description publisher is needed.
+
+Run with:
+    pytest rqt_joint_trajectory_controller/test/test_joint_limits_urdf.py -v
+"""
+
+import math
+import pytest
+
+from rqt_joint_trajectory_controller.joint_limits_urdf import parse_joint_limits
+
+# ---------------------------------------------------------------------------
+# Small URDF builder helpers
+#
+# Real robot URDFs are hundreds of lines long, but for testing we only need
+# the minimum valid XML that exercises one specific behaviour. These helpers
+# let each test build exactly what it needs in two or three lines.
+# ---------------------------------------------------------------------------
+
+
+def _robot(*joint_snippets):
+    """Wrap joint snippets inside a minimal valid <robot> element."""
+    body = "\n".join(joint_snippets)
+    return f'<?xml version="1.0"?><robot name="r"><link name="base"/>{body}</robot>'
+
+
+def _revolute(name, lower, upper, velocity):
+    """A revolute joint with explicit position and velocity limits."""
+    return (
+        f'<link name="{name}_link"/>'
+        f'<joint name="{name}" type="revolute">'
+        f'<parent link="base"/><child link="{name}_link"/>'
+        f'<limit lower="{lower}" upper="{upper}" velocity="{velocity}" effort="10"/>'
+        f"</joint>"
+    )
+
+
+def _continuous(name, velocity):
+    """A continuous joint — no lower/upper attributes."""
+    return (
+        f'<link name="{name}_link"/>'
+        f'<joint name="{name}" type="continuous">'
+        f'<parent link="base"/><child link="{name}_link"/>'
+        f'<limit velocity="{velocity}" effort="10"/>'
+        f"</joint>"
+    )
+
+
+def _fixed(name):
+    """A fixed joint — no limits element at all."""
+    return (
+        f'<link name="{name}_link"/>'
+        f'<joint name="{name}" type="fixed">'
+        f'<parent link="base"/><child link="{name}_link"/>'
+        f"</joint>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group 1: Revolute joint — the most common joint type in a robot arm.
+# The function must return exactly the values written in the URDF.
+# ---------------------------------------------------------------------------
+
+
+def test_revolute_joint_appears_in_result():
+    result = parse_joint_limits(_robot(_revolute("j1", -1.5, 1.5, 2.0)), ["j1"])
+    assert "j1" in result
+
+
+def test_revolute_joint_min_position():
+    result = parse_joint_limits(_robot(_revolute("j1", -1.5, 1.5, 2.0)), ["j1"])
+    assert result["j1"]["min_position"] == pytest.approx(-1.5)
+
+
+def test_revolute_joint_max_position():
+    result = parse_joint_limits(_robot(_revolute("j1", -1.5, 1.5, 2.0)), ["j1"])
+    assert result["j1"]["max_position"] == pytest.approx(1.5)
+
+
+def test_revolute_joint_max_velocity():
+    result = parse_joint_limits(_robot(_revolute("j1", -1.5, 1.5, 2.0)), ["j1"])
+    assert result["j1"]["max_velocity"] == pytest.approx(2.0)
+
+
+def test_revolute_joint_has_position_limits_true():
+    # Revolute joints are bounded — the GUI slider should enforce limits
+    result = parse_joint_limits(_robot(_revolute("j1", -1.5, 1.5, 2.0)), ["j1"])
+    assert result["j1"]["has_position_limits"] is True
+
+
+# ---------------------------------------------------------------------------
+# Group 2: Continuous joint — like a wheel, no position bounds.
+# When lower/upper are absent, minidom returns "", float("") raises
+# ValueError, and our code must default to -pi / +pi so the slider
+# has a usable range.
+# ---------------------------------------------------------------------------
+
+
+def test_continuous_joint_appears_in_result():
+    result = parse_joint_limits(_robot(_continuous("wheel", 5.0)), ["wheel"])
+    assert "wheel" in result
+
+
+def test_continuous_joint_min_defaults_to_minus_pi():
+    result = parse_joint_limits(_robot(_continuous("wheel", 5.0)), ["wheel"])
+    assert result["wheel"]["min_position"] == pytest.approx(-math.pi)
+
+
+def test_continuous_joint_max_defaults_to_plus_pi():
+    result = parse_joint_limits(_robot(_continuous("wheel", 5.0)), ["wheel"])
+    assert result["wheel"]["max_position"] == pytest.approx(math.pi)
+
+
+def test_continuous_joint_has_position_limits_false():
+    # Continuous joints are unbounded — the GUI should not enforce limits
+    result = parse_joint_limits(_robot(_continuous("wheel", 5.0)), ["wheel"])
+    assert result["wheel"]["has_position_limits"] is False
+
+
+def test_continuous_joint_velocity_is_preserved():
+    result = parse_joint_limits(_robot(_continuous("wheel", 5.0)), ["wheel"])
+    assert result["wheel"]["max_velocity"] == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Group 3: Fixed joints — they have no DOF and must be completely ignored.
+# ---------------------------------------------------------------------------
+
+
+def test_fixed_joint_not_in_result():
+    result = parse_joint_limits(_robot(_fixed("camera_mount")), [])
+    assert "camera_mount" not in result
+
+
+def test_urdf_with_only_fixed_joints_returns_empty_dict():
+    result = parse_joint_limits(_robot(_fixed("j1"), _fixed("j2")), [])
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Group 4: Multiple joints — all non-fixed joints must appear in the result.
+# This mirrors a real robot arm with mixed joint types.
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_joints_all_present():
+    urdf = _robot(
+        _revolute("shoulder", -1.0, 1.0, 1.0),
+        _revolute("elbow", -2.0, 2.0, 1.5),
+        _continuous("wrist_roll", 3.0),
+        _fixed("tool_mount"),
+    )
+    result = parse_joint_limits(urdf, ["shoulder", "elbow", "wrist_roll"])
+    assert set(result.keys()) == {"shoulder", "elbow", "wrist_roll"}
+
+
+def test_multiple_joints_fixed_excluded():
+    urdf = _robot(
+        _revolute("shoulder", -1.0, 1.0, 1.0),
+        _fixed("tool_mount"),
+    )
+    result = parse_joint_limits(urdf, [])
+    assert "tool_mount" not in result
+
+
+def test_multiple_joints_individual_limits_correct():
+    urdf = _robot(
+        _revolute("shoulder", -1.0, 1.0, 1.0),
+        _revolute("elbow", -2.0, 2.0, 1.5),
+    )
+    result = parse_joint_limits(urdf, ["shoulder", "elbow"])
+    assert result["elbow"]["min_position"] == pytest.approx(-2.0)
+    assert result["shoulder"]["max_velocity"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Group 5: Safety controller soft limits.
+# When use_smallest_joint_limits=True, soft limits should narrow the range.
+# When False, only the hard limits from <limit> should be used.
+# This is entirely our application logic — minidom knows nothing about it.
+# ---------------------------------------------------------------------------
+
+
+def test_soft_limits_narrow_range_when_flag_true():
+    urdf = _robot(
+        '<link name="j1_link"/>'
+        '<joint name="j1" type="revolute">'
+        '<parent link="base"/><child link="j1_link"/>'
+        '<limit lower="-2.0" upper="2.0" velocity="1.0" effort="10"/>'
+        '<safety_controller soft_lower_limit="-1.0" soft_upper_limit="1.0"'
+        ' k_position="100" k_velocity="10"/>'
+        "</joint>"
+    )
+    result = parse_joint_limits(urdf, ["j1"], use_smallest_joint_limits=True)
+    assert result["j1"]["min_position"] == pytest.approx(-1.0)
+    assert result["j1"]["max_position"] == pytest.approx(1.0)
+
+
+def test_soft_limits_ignored_when_flag_false():
+    urdf = _robot(
+        '<link name="j1_link"/>'
+        '<joint name="j1" type="revolute">'
+        '<parent link="base"/><child link="j1_link"/>'
+        '<limit lower="-2.0" upper="2.0" velocity="1.0" effort="10"/>'
+        '<safety_controller soft_lower_limit="-1.0" soft_upper_limit="1.0"'
+        ' k_position="100" k_velocity="10"/>'
+        "</joint>"
+    )
+    result = parse_joint_limits(urdf, ["j1"], use_smallest_joint_limits=False)
+    assert result["j1"]["min_position"] == pytest.approx(-2.0)
+    assert result["j1"]["max_position"] == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Group 6: Mimic joints — follow another joint mechanically.
+# They cannot be independently commanded, so the GUI must not show a
+# slider for them. They must be absent from free_joints.
+# ---------------------------------------------------------------------------
+
+
+def test_mimic_joint_excluded_from_result():
+    urdf = _robot(
+        _revolute("driver", -1.0, 1.0, 1.0),
+        '<link name="follower_link"/>'
+        '<joint name="follower" type="revolute">'
+        '<parent link="base"/><child link="follower_link"/>'
+        '<limit lower="-1.0" upper="1.0" velocity="1.0" effort="5"/>'
+        '<mimic joint="driver" multiplier="1.0" offset="0.0"/>'
+        "</joint>",
+    )
+    result = parse_joint_limits(urdf, ["driver"])
+    assert "follower" not in result
+
+
+def test_driver_joint_present_when_follower_is_mimic():
+    urdf = _robot(
+        _revolute("driver", -1.0, 1.0, 1.0),
+        '<link name="follower_link"/>'
+        '<joint name="follower" type="revolute">'
+        '<parent link="base"/><child link="follower_link"/>'
+        '<limit lower="-1.0" upper="1.0" velocity="1.0" effort="5"/>'
+        '<mimic joint="driver" multiplier="1.0" offset="0.0"/>'
+        "</joint>",
+    )
+    result = parse_joint_limits(urdf, ["driver"])
+    assert "driver" in result
+
+
+# ---------------------------------------------------------------------------
+# Group 7: Error cases — our application logic, not minidom's.
+# minidom parses all of these successfully and returns data.
+# Our code is the one that decides they are errors.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_limit_tag_for_required_joint_raises():
+    """Joint in joints_names with no <limit> element at all must raise.
+
+    minidom parses this fine — joint.getElementsByTagName("limit") just
+    returns an empty list, and [0] raises IndexError. Our except block
+    is what turns that into a meaningful exception message.
+    """
+    urdf = _robot(
+        '<link name="j_link"/>'
+        '<joint name="j" type="revolute">'
+        '<parent link="base"/><child link="j_link"/>'
+        "</joint>"
+    )
+    with pytest.raises(Exception, match="Missing limits tag"):
+        parse_joint_limits(urdf, ["j"])
+
+
+def test_missing_limit_tag_for_unrequired_joint_skipped_silently():
+    """Joint NOT in joints_names with no <limit> is silently ignored.
+
+    The URDF may describe joints that this controller does not manage.
+    Those joints do not need limits.
+    """
+    urdf = _robot(
+        '<link name="j_link"/>'
+        '<joint name="j" type="revolute">'
+        '<parent link="base"/><child link="j_link"/>'
+        "</joint>"
+    )
+    result = parse_joint_limits(urdf, [])
+    assert "j" not in result
+
+
+def test_revolute_joint_missing_lower_upper_raises():
+    """Revolute joint with no lower/upper attributes raises.
+
+    minidom returns "" for absent attributes. float("") raises ValueError.
+    Our except block turns that into a meaningful message for non-continuous
+    joints. This is our own logic — worth testing.
+    """
+    urdf = _robot(
+        '<link name="j_link"/>'
+        '<joint name="j" type="revolute">'
+        '<parent link="base"/><child link="j_link"/>'
+        '<limit velocity="1.0" effort="5"/>'
+        "</joint>"
+    )
+    with pytest.raises(Exception, match="Missing lower/upper position limits"):
+        parse_joint_limits(urdf, ["j"])
+
+
+def test_missing_velocity_raises():
+    """Joint with no velocity attribute raises.
+
+    minidom returns "" for absent velocity. float("") raises ValueError.
+    Our except block turns that into a meaningful message. Our own logic.
+    """
+    urdf = _robot(
+        '<link name="j_link"/>'
+        '<joint name="j" type="revolute">'
+        '<parent link="base"/><child link="j_link"/>'
+        '<limit lower="-1.0" upper="1.0" effort="5"/>'
+        "</joint>"
+    )
+    with pytest.raises(Exception, match="Missing velocity limits"):
+        parse_joint_limits(urdf, ["j"])


### PR DESCRIPTION
Closes #2253

## What this PR does

`get_joint_limits()` read from a global `description` variable set only by a ROS topic subscription — impossible to unit test without a live node.

This PR extracts all parsing logic into a new pure function `parse_joint_limits(urdf_string, ...)` that takes the URDF directly as a string with no ROS dependency. `get_joint_limits()` becomes a thin wrapper that reads the global and delegates to it. The minidom parsing logic itself is **unchanged**.

## Files changed

| File | Change |
|---|---|
| `joint_limits_urdf.py` | Extract `parse_joint_limits()` from `get_joint_limits()` |
| `test/test_joint_limits_urdf.py` | 23 pytest tests, fully ROS-free |
| `test/__init__.py` | New (marks test dir as Python package) |
| `package.xml` | Add `python3-pytest` test dependency |

## Tests (23 total, all passing)

- Revolute joint — correct min/max position, velocity, limit flag
- Continuous joint — defaults to ±π when no bounds given
- Fixed joints — silently ignored
- Multiple mixed joints — all handled correctly
- `safety_controller` soft limits — narrowed when flag is `True`, ignored when `False`
- Mimic joints — excluded from `free_joints`
- Missing `<limit>` for a required joint → raises with clear message
- Missing `lower`/`upper` on revolute → raises (minidom returns `""`, our code raises)
- Missing `velocity` → raises (same reason — our logic, not minidom's)
<img width="1649" height="618" alt="Screenshot from 2026-04-04 00-14-26" src="https://github.com/user-attachments/assets/c75fff97-4311-48cd-acae-0537682b95b5" />

