### PR TITLE
fix(parallel_gripper): rename variables for consistency

### DIFF
--- a/parallel_gripper_controller/include/parallel_gripper_controller/parallel_gripper_action_controller.hpp
+++ b/parallel_gripper_controller/include/parallel_gripper_controller/parallel_gripper_action_controller.hpp
@@ -62,8 +62,8 @@ public:
   struct Commands
   {
     double position_cmd_;  // Commanded position
-    double max_velocity_;  // Desired max gripper velocity
-    double max_effort_;    // Desired max allowed effort
+    double velocity_cmd_;  // Commanded velocity
+    double effort_cmd_;    // Commanded effort
   };
   GripperActionController();
 
@@ -112,11 +112,11 @@ protected:
 
   std::string name_;  ///< Controller name.
   std::optional<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
-    joint_command_interface_;
+    joint_position_command_interface_;
   std::optional<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
-    effort_interface_;
+    joint_effort_command_interface_;
   std::optional<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>
-    speed_interface_;
+    joint_speed_command_interface_;
   std::optional<std::reference_wrapper<hardware_interface::LoanedStateInterface>>
     joint_position_state_interface_;
   std::optional<std::reference_wrapper<hardware_interface::LoanedStateInterface>>

--- a/parallel_gripper_controller/include/parallel_gripper_controller/parallel_gripper_action_controller_impl.hpp
+++ b/parallel_gripper_controller/include/parallel_gripper_controller/parallel_gripper_action_controller_impl.hpp
@@ -83,25 +83,25 @@ controller_interface::return_type GripperActionController::update(
   check_for_success(
     get_node()->now(), error_position, current_position_op.value(), current_velocity_op.value());
 
-  if (!joint_command_interface_->get().set_value(command_struct_rt_.position_cmd_))
+  if (!joint_position_command_interface_->get().set_value(command_struct_rt_.position_cmd_))
   {
     RCLCPP_WARN(
       logger, "Unable to set the joint position command to: %f", command_struct_rt_.position_cmd_);
     return controller_interface::return_type::OK;
   }
   if (
-    speed_interface_.has_value() &&
-    !speed_interface_->get().set_value(command_struct_rt_.max_velocity_))
+    joint_speed_command_interface_.has_value() &&
+    !joint_speed_command_interface_->get().set_value(command_struct_rt_.velocity_cmd_))
   {
-    RCLCPP_WARN(logger, "Unable to set the speed command to: %f", command_struct_rt_.max_velocity_);
+    RCLCPP_WARN(logger, "Unable to set the speed command to: %f", command_struct_rt_.velocity_cmd_);
 
     return controller_interface::return_type::OK;
   }
   if (
-    effort_interface_.has_value() &&
-    !effort_interface_->get().set_value(command_struct_rt_.max_effort_))
+    joint_effort_command_interface_.has_value() &&
+    !joint_effort_command_interface_->get().set_value(command_struct_rt_.effort_cmd_))
   {
-    RCLCPP_WARN(logger, "Unable to set the effort command to: %f", command_struct_rt_.max_effort_);
+    RCLCPP_WARN(logger, "Unable to set the effort command to: %f", command_struct_rt_.effort_cmd_);
     return controller_interface::return_type::OK;
   }
 
@@ -140,19 +140,19 @@ void GripperActionController::accepted_callback(
   command_struct_.position_cmd_ = goal_handle->get_goal()->command.position[0];
   if (!params_.max_velocity_interface.empty() && !goal_handle->get_goal()->command.velocity.empty())
   {
-    command_struct_.max_velocity_ = goal_handle->get_goal()->command.velocity[0];
+    command_struct_.velocity_cmd_ = goal_handle->get_goal()->command.velocity[0];
   }
   else
   {
-    command_struct_.max_velocity_ = params_.max_velocity;
+    command_struct_.velocity_cmd_ = params_.max_velocity;
   }
   if (!params_.max_effort_interface.empty() && !goal_handle->get_goal()->command.effort.empty())
   {
-    command_struct_.max_effort_ = goal_handle->get_goal()->command.effort[0];
+    command_struct_.effort_cmd_ = goal_handle->get_goal()->command.effort[0];
   }
   else
   {
-    command_struct_.max_effort_ = params_.max_effort;
+    command_struct_.effort_cmd_ = params_.max_effort;
   }
   command_.set(command_struct_);
 
@@ -206,8 +206,8 @@ void GripperActionController::set_hold_position()
     RCLCPP_DEBUG(get_node()->get_logger(), "Unable to retrieve data of joint position");
   }
   command_struct_.position_cmd_ = position_op.value();
-  command_struct_.max_effort_ = params_.max_effort;
-  command_struct_.max_velocity_ = params_.max_velocity;
+  command_struct_.effort_cmd_ = params_.max_effort;
+  command_struct_.velocity_cmd_ = params_.max_velocity;
   command_.set(command_struct_);
 }
 
@@ -347,7 +347,7 @@ controller_interface::CallbackReturn GripperActionController::on_activate(
     return controller_interface::CallbackReturn::ERROR;
   }
 
-  joint_command_interface_ = *command_interface_it;
+  joint_position_command_interface_ = *command_interface_it;
   joint_position_state_interface_ = *position_state_interface_it;
   joint_velocity_state_interface_ = *velocity_state_interface_it;
 
@@ -355,11 +355,11 @@ controller_interface::CallbackReturn GripperActionController::on_activate(
   {
     if (interface.get_interface_name() == "set_gripper_max_effort")
     {
-      effort_interface_ = interface;
+      joint_effort_command_interface_ = interface;
     }
     else if (interface.get_interface_name() == "set_gripper_max_velocity")
     {
-      speed_interface_ = interface;
+      joint_speed_command_interface_ = interface;
     }
   }
 
@@ -373,8 +373,8 @@ controller_interface::CallbackReturn GripperActionController::on_activate(
   {
     command_struct_.position_cmd_ = position_op.value();
   }
-  command_struct_.max_effort_ = params_.max_effort;
-  command_struct_.max_velocity_ = params_.max_velocity;
+  command_struct_.effort_cmd_ = params_.max_effort;
+  command_struct_.velocity_cmd_ = params_.max_velocity;
   command_.try_set(command_struct_);
 
   // Result
@@ -401,7 +401,7 @@ controller_interface::CallbackReturn GripperActionController::on_activate(
 controller_interface::CallbackReturn GripperActionController::on_deactivate(
   const rclcpp_lifecycle::State &)
 {
-  joint_command_interface_ = std::nullopt;
+  joint_position_command_interface_ = std::nullopt;
   joint_position_state_interface_ = std::nullopt;
   joint_velocity_state_interface_ = std::nullopt;
   return controller_interface::CallbackReturn::SUCCESS;


### PR DESCRIPTION
## Description

Rename internal variables in parallel_gripper_controller for consistency 
and clarity.

Relates to #1229

### Is this user-facing behavior change?

### Did you use Generative AI?

Yes, Claude (Anthropic) was used to help understand the codebase and 
discuss the changes. The actual code changes were made manually.

### Additional Information

This is the first of multiple PRs addressing the issues raised in #1229.
Each issue will be addressed in a separate PR as suggested by the maintainer.

