### PR TITLE
fix JTC userdoc YAML indentation and stray quote

### DIFF
--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -48,7 +48,7 @@ This leads to the following allowed combinations of command and state interfaces
 Further restrictions of state interfaces exist:
 
 * ``velocity`` state interface cannot be used if ``position`` interface  is missing.
-* ``acceleration`` state interface cannot be used if ``position`` and ``velocity`` interfaces are not present."
+* ``acceleration`` state interface cannot be used if ``position`` and ``velocity`` interfaces are not present.
 
 Example controller configurations can be found :ref:`below <ROS 2 interface>`.
 
@@ -80,7 +80,7 @@ A yaml file for using it could be:
       controller_manager:
         ros__parameters:
           joint_trajectory_controller:
-          type: "joint_trajectory_controller/JointTrajectoryController"
+            type: "joint_trajectory_controller/JointTrajectoryController"
 
       joint_trajectory_controller:
         ros__parameters:


### PR DESCRIPTION
Two small fixes in `joint_trajectory_controller/doc/userdoc.rst`:

1. The example YAML had `type:` at the same indentation level as the controller name, which is invalid. Copying it from the rendered docs on control.ros.org produces a configuration error. Fixed to nest `type:` under the controller name, matching the pattern used in `gazebo_ros2_control` and `velocity_controllers` documentation.

2. Removed a stray trailing `"` on the state-interface restriction bullet.

### Description

Docs-only change in `joint_trajectory_controller/doc/userdoc.rst`.

### Is this user-facing behavior change?

No. Documentation only.

### Did you use Generative AI?

Used AI assistance for workflow guidance and review. The code change was identified and written manually after reading the file and cross-referencing the YAML against working examples in other ros2_controllers documentation.

### Additional Information

None.

### TODOs

- [x] Forked the repository
- [x] Modified only the relevant file
- [x] `pre-commit run` passes
- [x] Commit message is clear and signed
- [ ] `colcon test` — N/A for docs-only change