### PR TITLE
Suppress cppcheck errors from macros from version.h

### DIFF
--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -36,6 +36,7 @@
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "rclcpp/parameter_value.hpp"
 #include "rclcpp/version.h"
+// cppcheck-suppress syntaxError
 #if RCLCPP_VERSION_GTE(18, 0, 0)
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
 #endif
@@ -229,6 +230,7 @@ protected:
 
   void broadcast_tfs()
   {
+// cppcheck-suppress syntaxError
 #if RCLCPP_VERSION_GTE(18, 0, 0)
     static tf2_ros::TransformBroadcaster br(
       rclcpp::node_interfaces::NodeInterfaces(

--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -36,7 +36,7 @@
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "rclcpp/parameter_value.hpp"
 #include "rclcpp/version.h"
-#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(18, 0, 0)
+#if RCLCPP_VERSION_GTE(18, 0, 0)
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
 #endif
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
@@ -229,7 +229,7 @@ protected:
 
   void broadcast_tfs()
   {
-#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(18, 0, 0)
+#if RCLCPP_VERSION_GTE(18, 0, 0)
     static tf2_ros::TransformBroadcaster br(
       rclcpp::node_interfaces::NodeInterfaces(
         test_broadcaster_node_->get_node_parameters_interface(),

--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -36,7 +36,7 @@
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "rclcpp/parameter_value.hpp"
 #include "rclcpp/version.h"
-#if RCLCPP_VERSION_GTE(18, 0, 0)
+#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(18, 0, 0)
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
 #endif
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
@@ -229,7 +229,7 @@ protected:
 
   void broadcast_tfs()
   {
-#if RCLCPP_VERSION_GTE(18, 0, 0)
+#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(18, 0, 0)
     static tf2_ros::TransformBroadcaster br(
       rclcpp::node_interfaces::NodeInterfaces(
         test_broadcaster_node_->get_node_parameters_interface(),

--- a/force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp
+++ b/force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp
@@ -32,6 +32,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/version.h"
+// cppcheck-suppress syntaxError
 #if RCLCPP_VERSION_GTE(18, 0, 0)
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
 #endif
@@ -60,6 +61,7 @@ protected:
   {
     auto tf_node = std::make_shared<rclcpp::Node>("static_tf_broadcaster");
     executor_->add_node(tf_node);
+// cppcheck-suppress syntaxError
 #if RCLCPP_VERSION_GTE(18, 0, 0)
     tf2_ros::StaticTransformBroadcaster tf_broadcaster(
       rclcpp::node_interfaces::NodeInterfaces(

--- a/force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp
+++ b/force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp
@@ -32,7 +32,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/version.h"
-#if RCLCPP_VERSION_GTE(18, 0, 0)
+#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(18, 0, 0)
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
 #endif
 #include "tf2/exceptions.hpp"
@@ -60,7 +60,7 @@ protected:
   {
     auto tf_node = std::make_shared<rclcpp::Node>("static_tf_broadcaster");
     executor_->add_node(tf_node);
-#if RCLCPP_VERSION_GTE(18, 0, 0)
+#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(18, 0, 0)
     tf2_ros::StaticTransformBroadcaster tf_broadcaster(
       rclcpp::node_interfaces::NodeInterfaces(
         tf_node->get_node_parameters_interface(), tf_node->get_node_topics_interface()));

--- a/force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp
+++ b/force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp
@@ -32,7 +32,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/version.h"
-#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(18, 0, 0)
+#if RCLCPP_VERSION_GTE(18, 0, 0)
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
 #endif
 #include "tf2/exceptions.hpp"
@@ -60,7 +60,7 @@ protected:
   {
     auto tf_node = std::make_shared<rclcpp::Node>("static_tf_broadcaster");
     executor_->add_node(tf_node);
-#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(18, 0, 0)
+#if RCLCPP_VERSION_GTE(18, 0, 0)
     tf2_ros::StaticTransformBroadcaster tf_broadcaster(
       rclcpp::node_interfaces::NodeInterfaces(
         tf_node->get_node_parameters_interface(), tf_node->get_node_topics_interface()));

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -26,6 +26,7 @@
 #include "sensor_msgs/msg/joint_state.hpp"
 
 #include "rclcpp/version.h"
+// cppcheck-suppress syntaxError
 #if RCLCPP_VERSION_GTE(29, 0, 0)
 #include "urdf/model.hpp"
 #else

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -26,7 +26,7 @@
 #include "sensor_msgs/msg/joint_state.hpp"
 
 #include "rclcpp/version.h"
-#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(29, 0, 0)
+#if RCLCPP_VERSION_GTE(29, 0, 0)
 #include "urdf/model.hpp"
 #else
 #include "urdf/model.h"

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -26,7 +26,7 @@
 #include "sensor_msgs/msg/joint_state.hpp"
 
 #include "rclcpp/version.h"
-#if RCLCPP_VERSION_GTE(29, 0, 0)
+#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(29, 0, 0)
 #include "urdf/model.hpp"
 #else
 #include "urdf/model.h"

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -35,6 +35,7 @@
 #include "rclcpp_lifecycle/state.hpp"
 
 #include "rclcpp/version.h"
+// cppcheck-suppress syntaxError
 #if RCLCPP_VERSION_GTE(29, 0, 0)
 #include "urdf/model.hpp"
 #else

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -35,7 +35,7 @@
 #include "rclcpp_lifecycle/state.hpp"
 
 #include "rclcpp/version.h"
-#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(29, 0, 0)
+#if RCLCPP_VERSION_GTE(29, 0, 0)
 #include "urdf/model.hpp"
 #else
 #include "urdf/model.h"

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -35,7 +35,7 @@
 #include "rclcpp_lifecycle/state.hpp"
 
 #include "rclcpp/version.h"
-#if RCLCPP_VERSION_GTE(29, 0, 0)
+#if defined(RCLCPP_VERSION_GTE) && RCLCPP_VERSION_GTE(29, 0, 0)
 #include "urdf/model.hpp"
 #else
 #include "urdf/model.h"


### PR DESCRIPTION
Should fix
```

ament_cppcheck...........................................................Failed
- hook id: ament_cppcheck
- exit code: 1

[force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp:35]: (error: syntaxError) failed to evaluate #if condition, undefined function-like macro invocation: RCLCPP_VERSION_GTE( ... )
[joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp:29]: (error: syntaxError) failed to evaluate #if condition, undefined function-like macro invocation: RCLCPP_VERSION_GTE( ... )
2 errors
[joint_trajectory_controller/src/joint_trajectory_controller.cpp:38]: (error: syntaxError) failed to evaluate #if condition, undefined function-like macro invocation: RCLCPP_VERSION_GTE( ... )
[admittance_controller/test/test_admittance_controller.hpp:39]: (error: syntaxError) failed to evaluate #if condition, undefined function-like macro invocation: RCLCPP_VERSION_GTE( ... )
2 errors
No problems found
[admittance_controller/test/test_admittance_controller.hpp:39]: (error: syntaxError) failed to evaluate #if condition, undefined function-like macro invocation: RCLCPP_VERSION_GTE( ... )
1 errors

```
https://github.com/ros-controls/ros2_controllers/actions/runs/25400217669/job/74497477883