### PR TITLE
fix TOC ordering for GPIO and motion primitive controllers

### DIFF
--- a/doc/controllers_index.rst
+++ b/doc/controllers_index.rst
@@ -41,11 +41,11 @@ Controllers for Manipulators and Other Robots
 
    Admittance Controller <../admittance_controller/doc/userdoc.rst>
    Forward Command Controller <../forward_command_controller/doc/userdoc.rst>
+   Gpio Command Controller <../gpio_controllers/doc/userdoc.rst>
    Joint Trajectory Controller <../joint_trajectory_controller/doc/userdoc.rst>
+   Motion Primitive Controller <../motion_primitives_controllers/userdoc.rst>
    Parallel Gripper Controller <../parallel_gripper_controller/doc/userdoc.rst>
    PID Controller <../pid_controller/doc/userdoc.rst>
-   Gpio Command Controller <../gpio_controllers/doc/userdoc.rst>
-   Motion Primitive Controller <../motion_primitives_controllers/userdoc.rst>
 
 Broadcasters
 **********************


### PR DESCRIPTION
Closes #2216

`Gpio Command Controller` and `Motion Primitive Controller` were appended at the bottom of the manipulators TOC list instead of being sorted alphabetically with the rest. This caused the broken/inconsistent TOC appearance reported in the issue.

Sorted both entries into their correct alphabetical positions:
- `Gpio Command Controller` between `Forward Command Controller` and `Joint Trajectory Controller`
- `Motion Primitive Controller` between `Joint Trajectory Controller` and `Parallel Gripper Controller`