### PR TITLE
[JTC] Fix segfault when last trajectory segment is skipped

### DIFF
--- a/joint_trajectory_controller/src/trajectory.cpp
+++ b/joint_trajectory_controller/src/trajectory.cpp
@@ -209,7 +209,34 @@ bool Trajectory::sample(
   start_segment_itr = --end();
   end_segment_itr = end();
   last_sample_idx_ = last_idx;
+
+  // If the last segment was never entered (e.g. sample_time jumped past a very
+  // short last segment because the controller rate is slower than the segment
+  // duration), the last trajectory point's positions may have never been
+  // deduced from velocities. Recover by deducing them from the previous point
+  // if that point has positions; otherwise return false so the caller does not
+  // dereference an empty positions vector downstream. See #2282.
+  if (trajectory_msg_->points[last_idx].positions.empty() && last_idx > 0)
+  {
+    auto & prev_point = trajectory_msg_->points[last_idx - 1];
+    auto & last_point = trajectory_msg_->points[last_idx];
+    if (!prev_point.positions.empty())
+    {
+      const rclcpp::Time t_prev = trajectory_start_time_ + prev_point.time_from_start;
+      const rclcpp::Time t_last = trajectory_start_time_ + last_point.time_from_start;
+      deduce_from_derivatives(
+        prev_point, last_point, state_before_traj_msg_.positions.size(),
+        (t_last - t_prev).seconds());
+    }
+  }
+
   output_state = (*start_segment_itr);
+  if (output_state.positions.empty())
+  {
+    start_segment_itr = end();
+    end_segment_itr = end();
+    return false;
+  }
   // the trajectories in msg may have empty velocities/accel, so resize them
   if (output_state.velocities.empty())
   {

--- a/joint_trajectory_controller/test/test_trajectory.cpp
+++ b/joint_trajectory_controller/test/test_trajectory.cpp
@@ -1046,3 +1046,98 @@ TEST(TestWrapAroundJoint, wraparound_all_joints_no_offset)
   EXPECT_EQ(current_position[1], next_position[1]);
   EXPECT_EQ(current_position[2], next_position[2]);
 }
+// Regression test for #2282: with a velocity-only trajectory whose last
+// segment is skipped (sample_time advances past the last segment without
+// entering it, e.g. controller rate slower than the last segment duration),
+// the last point's positions never get deduced from velocities. Before the
+// fix, the "whole animation has played out" branch would copy that point
+// into output_state with empty positions, which then segfaults later in
+// JointTrajectoryController::compute_error_for_joint.
+TEST(TestTrajectory, sample_velocity_only_skipped_last_segment_deduces_positions)
+{
+  trajectory_msgs::msg::JointTrajectoryPoint p1;
+  p1.time_from_start = rclcpp::Duration::from_seconds(1.0);
+  p1.positions = {0.0};
+  p1.velocities = {1.0};
+
+  trajectory_msgs::msg::JointTrajectoryPoint p2;
+  p2.time_from_start = rclcpp::Duration::from_seconds(2.0);
+  // intentionally velocity-only; positions will be deduced
+  p2.velocities = {1.0};
+
+  trajectory_msgs::msg::JointTrajectoryPoint p3;
+  p3.time_from_start = rclcpp::Duration::from_seconds(2.001);
+  // intentionally velocity-only and tiny duration to model the skipped-last-segment case
+  p3.velocities = {1.0};
+
+  auto traj_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+  traj_msg->points = {p1, p2, p3};
+
+  const rclcpp::Time time_now = rclcpp::Clock().now();
+  auto traj = joint_trajectory_controller::Trajectory(time_now, p1, traj_msg);
+
+  trajectory_msgs::msg::JointTrajectoryPoint output_state;
+  joint_trajectory_controller::TrajectoryPointConstIter start, end;
+
+  // First sample at time_now anchors trajectory_start_time_ = time_now (header
+  // stamp left default so the sample() code path that sets it on first call
+  // fires). Second sample inside segment 0 so p2's positions get deduced from
+  // velocities.
+  traj.sample(time_now, DEFAULT_INTERPOLATION, output_state, start, end);
+  traj.sample(
+    time_now + rclcpp::Duration::from_seconds(1.5), DEFAULT_INTERPOLATION, output_state, start,
+    end);
+  ASSERT_FALSE(output_state.positions.empty());
+
+  // Now sample past the end: segment 1 (between p2 and p3, 1 ms) is skipped
+  // entirely, leaving p3.positions empty without the fix.
+  const bool ok = traj.sample(
+    time_now + rclcpp::Duration::from_seconds(3.0), DEFAULT_INTERPOLATION, output_state, start,
+    end);
+
+  EXPECT_TRUE(ok);
+  ASSERT_FALSE(output_state.positions.empty())
+    << "sample() must not return success with empty positions; would segfault "
+       "in JointTrajectoryController::compute_error_for_joint";
+  EXPECT_EQ(output_state.positions.size(), p1.positions.size());
+}
+// Regression test for #2282 pathological case: every point in the trajectory
+// is velocity-only and sample_time is so far past the end that no segment
+// was ever entered to deduce positions. With no usable position chain, the
+// "whole animation has played out" branch must return false rather than
+// copy empty positions into output_state.
+TEST(TestTrajectory, sample_velocity_only_all_segments_skipped_returns_false)
+{
+  trajectory_msgs::msg::JointTrajectoryPoint p1;
+  p1.time_from_start = rclcpp::Duration::from_seconds(0.001);
+  p1.velocities = {1.0};
+
+  trajectory_msgs::msg::JointTrajectoryPoint p2;
+  p2.time_from_start = rclcpp::Duration::from_seconds(0.002);
+  p2.velocities = {1.0};
+
+  auto traj_msg = std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+  traj_msg->points = {p1, p2};
+
+  trajectory_msgs::msg::JointTrajectoryPoint state_before;
+  // intentionally empty positions on the prior-state too, to force the
+  // "no usable position anywhere" case
+  state_before.velocities = {1.0};
+
+  const rclcpp::Time time_now = rclcpp::Clock().now();
+  auto traj = joint_trajectory_controller::Trajectory(time_now, state_before, traj_msg);
+
+  trajectory_msgs::msg::JointTrajectoryPoint output_state;
+  joint_trajectory_controller::TrajectoryPointConstIter start, end;
+
+  // Anchor trajectory_start_time_ = time_now via a first sample. With
+  // state_before.positions also empty, no segment will ever produce non-empty
+  // positions, so the "whole animation has played out" branch must return false.
+  traj.sample(time_now, DEFAULT_INTERPOLATION, output_state, start, end);
+  const bool ok = traj.sample(
+    time_now + rclcpp::Duration::from_seconds(10.0), DEFAULT_INTERPOLATION, output_state, start,
+    end);
+
+  EXPECT_FALSE(ok)
+    << "sample() must return false when it cannot produce a non-empty positions vector";
+}


### PR DESCRIPTION
## Summary

Fixes #2282.

When the controller rate is slower than the duration of the last trajectory segment, `Trajectory::sample()` can fall through to the "whole animation has played out" branch without ever entering the last segment in its for-loop. The last point's positions never get deduced from velocities (the deduce step only runs when a segment is actually entered for interpolation at `trajectory.cpp:192`). The empty positions vector then gets copied into `output_state` and downstream `JointTrajectoryController::compute_error_for_joint` accesses `desired.positions[index]` against a zero-length vector, which is the segfault at `0x18` the reporter saw.

This PR recovers in the same branch by deducing the last point's positions from the previous point's positions plus the segment velocities, reusing the existing `deduce_from_derivatives` helper. If even that recovery is not possible (no point along the chain has usable positions, e.g. a velocity-only trajectory whose first sample was past the end), `sample()` now returns `false` so the caller does not dereference an empty positions vector. This matches @domire8's suggestion from the issue, with the additional recovery path on top so the common single-skip case continues working.

## Change

`joint_trajectory_controller/src/trajectory.cpp`: inside the "whole animation has played out" branch, before assigning to `output_state`:

1. If `trajectory_msg_->points[last_idx].positions` is empty and the previous point has positions, call `deduce_from_derivatives(prev_point, last_point, ...)` to fill them in.
2. After the copy to `output_state`, if positions is still empty, set the iterators to `end()` and return `false`.

No change to the inner for-loop path or to non-initialize requests.

## Test plan

Two new regression tests in `joint_trajectory_controller/test/test_trajectory.cpp`:

- [x] `sample_velocity_only_skipped_last_segment_deduces_positions`: trajectory with `p1` (position + velocity), then `p2` and `p3` velocity-only with a tiny last segment duration. After anchoring `trajectory_start_time_` and entering segment 0 (which deduces `p2`), a sample past the end with the fix populates `output_state.positions` via the new recovery path. Without the fix, this asserts on empty positions.
- [x] `sample_velocity_only_all_segments_skipped_returns_false`: trajectory with two velocity-only points, prior state also velocity-only. Sample-time far past the end. With the fix, `sample()` returns `false` rather than copying empty positions into `output_state`.

Local build + test (jazzy branch, since master's `FollowJointTrajectory_Feedback.index` requires a control_msgs that has not yet hit the jazzy binary repos; `trajectory.cpp` and `test_trajectory.cpp` are byte-identical between master and jazzy in the touched area):

```
$ colcon build --packages-select joint_trajectory_controller
Summary: 1 package finished [33.8s]

$ ctest -R 'test_trajectory$'
[==========] 16 tests from 2 test suites ran.
[  PASSED  ] 16 tests.
```

clang-format clean. The 4 pre-existing `ament_cpplint` `whitespace/newline` warnings in `trajectory.cpp` (`} else { ... }` style at lines 155, 189, 334, 365) are not in the touched lines.

## Branch choice

Targeted at `master` per the standard ros-controls workflow. Mergify should backport to `jazzy` (where the reporter is) and `humble` / `kilted` as appropriate.

## AI Assistance Disclosure

Analysis and implementation drafted with Claude assistance. I reviewed every line, traced the bug path against the source, validated the fix and tests locally on jazzy, and am the human contributor accountable for this PR.
