### PR TITLE
Migrate tests to use new Handle API

### DIFF
--- a/chained_filter_controller/test/test_chained_filter.cpp
+++ b/chained_filter_controller/test/test_chained_filter.cpp
@@ -142,13 +142,13 @@ TEST_F(ChainedFilterTest, UpdateFilter)
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),
     controller_interface::return_type::OK);
   // input and output should have changed
-  EXPECT_EQ(joint_1_pos_->get_optional().value(), joint_states_[0]);
+  EXPECT_EQ(joint_1_pos_->get_optional().value(), 2.0);
   EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), 1.55);
   ASSERT_EQ(
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),
     controller_interface::return_type::OK);
   // output should have reached steady state (mean filter)
-  EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), joint_states_[0]);
+  EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), 2.0);
 }
 
 TEST_F(ChainedFilterTest, DeactivateSucceeds)

--- a/chained_filter_controller/test/test_chained_filter.hpp
+++ b/chained_filter_controller/test/test_chained_filter.hpp
@@ -54,10 +54,10 @@ protected:
 
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"wheel_left"};
-  std::vector<double> joint_states_ = {1.1};
+  const std::vector<double> joint_states_ = {1.1};
 
   StateInterface::SharedPtr joint_1_pos_ =
-    std::make_shared<StateInterface>(joint_names_[0], HW_IF_POSITION, &joint_states_[0]);
+    std::make_shared<StateInterface>(joint_names_[0], HW_IF_POSITION, "double", "1.1");
   rclcpp::executors::SingleThreadedExecutor executor;
 };
 

--- a/chained_filter_controller/test/test_multiple_chained_filter.cpp
+++ b/chained_filter_controller/test/test_multiple_chained_filter.cpp
@@ -138,17 +138,17 @@ TEST_F(MultipleChainedFilterTest, UpdateFilter_multiple_interfaces)
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),
     controller_interface::return_type::OK);
   // input and output should have changed
-  EXPECT_EQ(joint_1_pos_->get_optional().value(), joint_states_[0]);
+  EXPECT_EQ(joint_1_pos_->get_optional().value(), 2.0);
   EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), 1.55);
-  EXPECT_EQ(joint_2_pos_->get_optional().value(), joint_states_[1]);
+  EXPECT_EQ(joint_2_pos_->get_optional().value(), 3.0);
   EXPECT_EQ(state_if_exported_conf[1]->get_optional().value(), 2.6);
 
   ASSERT_EQ(
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),
     controller_interface::return_type::OK);
   // output should have reached steady state (mean filter)
-  EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), joint_states_[0]);
-  EXPECT_EQ(state_if_exported_conf[1]->get_optional().value(), joint_states_[1]);
+  EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), 2.0);
+  EXPECT_EQ(state_if_exported_conf[1]->get_optional().value(), 3.0);
 }
 
 TEST_F(MultipleChainedFilterTest, UpdateFilter_multiple_interfaces_config_per_input)
@@ -175,9 +175,9 @@ TEST_F(MultipleChainedFilterTest, UpdateFilter_multiple_interfaces_config_per_in
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),
     controller_interface::return_type::OK);
   // input and output should have changed
-  EXPECT_EQ(joint_1_pos_->get_optional().value(), joint_states_[0]);
+  EXPECT_EQ(joint_1_pos_->get_optional().value(), 2.0);
   EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), 1.55);
-  EXPECT_EQ(joint_2_pos_->get_optional().value(), joint_states_[1]);
+  EXPECT_EQ(joint_2_pos_->get_optional().value(), 2.8);
   // second update call, mean of (2.2, 2.8)
   EXPECT_EQ(state_if_exported_conf[1]->get_optional().value(), 2.5);
 
@@ -185,7 +185,7 @@ TEST_F(MultipleChainedFilterTest, UpdateFilter_multiple_interfaces_config_per_in
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),
     controller_interface::return_type::OK);
   // output should have reached steady state for the first input (mean filter)
-  EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), joint_states_[0]);
+  EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), 2.0);
   // third update call, mean of (2.2, 2.8, 2.8)
   EXPECT_EQ(state_if_exported_conf[1]->get_optional().value(), 2.6);
 
@@ -193,9 +193,9 @@ TEST_F(MultipleChainedFilterTest, UpdateFilter_multiple_interfaces_config_per_in
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),
     controller_interface::return_type::OK);
   // no change
-  EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), joint_states_[0]);
+  EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), 2.0);
   // output should have reached steady state (mean filter)
-  EXPECT_NEAR(state_if_exported_conf[1]->get_optional().value(), joint_states_[1], 1e-5);
+  EXPECT_NEAR(state_if_exported_conf[1]->get_optional().value(), 2.8, 1e-5);
 }
 
 int main(int argc, char ** argv)

--- a/chained_filter_controller/test/test_multiple_chained_filter.hpp
+++ b/chained_filter_controller/test/test_multiple_chained_filter.hpp
@@ -47,12 +47,12 @@ protected:
 
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"wheel_left", "wheel_right"};
-  std::vector<double> joint_states_ = {1.1, 2.2};
+  const std::vector<double> joint_states_ = {1.1, 2.2};
 
   StateInterface::SharedPtr joint_1_pos_ =
-    std::make_shared<StateInterface>(joint_names_[0], HW_IF_POSITION, &joint_states_[0]);
+    std::make_shared<StateInterface>(joint_names_[0], HW_IF_POSITION, "double", "1.1");
   StateInterface::SharedPtr joint_2_pos_ =
-    std::make_shared<StateInterface>(joint_names_[1], HW_IF_POSITION, &joint_states_[1]);
+    std::make_shared<StateInterface>(joint_names_[1], HW_IF_POSITION, "double", "2.2");
   rclcpp::executors::SingleThreadedExecutor executor;
 };
 

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -232,26 +232,26 @@ protected:
   std::unique_ptr<TestableDiffDriveController> controller_;
 
   std::vector<double> position_values_ = {0.1, 0.2};
-  std::vector<double> velocity_values_ = {0.01, 0.02};
+  const std::vector<double> velocity_values_ = {0.01, 0.02};
 
   hardware_interface::StateInterface::SharedPtr left_wheel_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      left_wheel_names[0], HW_IF_POSITION, &position_values_[0]);
+      left_wheel_names[0], HW_IF_POSITION, "double", "0.1");
   hardware_interface::StateInterface::SharedPtr right_wheel_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      right_wheel_names[0], HW_IF_POSITION, &position_values_[1]);
+      right_wheel_names[0], HW_IF_POSITION, "double", "0.2");
   hardware_interface::StateInterface::SharedPtr left_wheel_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      left_wheel_names[0], HW_IF_VELOCITY, &velocity_values_[0]);
+      left_wheel_names[0], HW_IF_VELOCITY, "double", "0.01");
   hardware_interface::StateInterface::SharedPtr right_wheel_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      right_wheel_names[0], HW_IF_VELOCITY, &velocity_values_[1]);
+      right_wheel_names[0], HW_IF_VELOCITY, "double", "0.02");
   hardware_interface::CommandInterface::SharedPtr left_wheel_vel_cmd_ =
     std::make_shared<hardware_interface::CommandInterface>(
-      left_wheel_names[0], HW_IF_VELOCITY, &velocity_values_[0]);
+      left_wheel_names[0], HW_IF_VELOCITY, "double", "0.01");
   hardware_interface::CommandInterface::SharedPtr right_wheel_vel_cmd_ =
     std::make_shared<hardware_interface::CommandInterface>(
-      right_wheel_names[0], HW_IF_VELOCITY, &velocity_values_[1]);
+      right_wheel_names[0], HW_IF_VELOCITY, "double", "0.02");
 
   rclcpp::Node::SharedPtr pub_node;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr velocity_publisher;
@@ -1359,7 +1359,9 @@ TEST_F(TestDiffDriveController, odometry_set_service)
 
   // simulate the movement by updating the position feedback
   position_values_[0] += 0.1;  // left wheel moved
+  left_wheel_pos_state_->set_value(position_values_[0]);
   position_values_[1] += 0.1;  // right wheel moved
+  right_wheel_pos_state_->set_value(position_values_[1]);
   controller_->update(test_time, period);
   test_time += period;
   EXPECT_GT(controller_->odometry_.getY(), -2.0);

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.hpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.hpp
@@ -66,26 +66,25 @@ public:
 protected:
   const std::string sensor_name_ = "fts_sensor";
   const std::string frame_id_ = "fts_sensor_frame";
-  std::array<double, 6> sensor_values_ = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6}};
-
+  const std::array<double, 6> sensor_values_ = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6}};
   hardware_interface::StateInterface::SharedPtr fts_force_x_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "force.x", &sensor_values_[0]);
+      sensor_name_, "force.x", "double", "1.1");
   hardware_interface::StateInterface::SharedPtr fts_force_y_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "force.y", &sensor_values_[1]);
+      sensor_name_, "force.y", "double", "2.2");
   hardware_interface::StateInterface::SharedPtr fts_force_z_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "force.z", &sensor_values_[2]);
+      sensor_name_, "force.z", "double", "3.3");
   hardware_interface::StateInterface::SharedPtr fts_torque_x_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "torque.x", &sensor_values_[3]);
+      sensor_name_, "torque.x", "double", "4.4");
   hardware_interface::StateInterface::SharedPtr fts_torque_y_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "torque.y", &sensor_values_[4]);
+      sensor_name_, "torque.y", "double", "5.5");
   hardware_interface::StateInterface::SharedPtr fts_torque_z_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "torque.z", &sensor_values_[5]);
+      sensor_name_, "torque.z", "double", "6.6");
 
   std::unique_ptr<FriendForceTorqueSensorBroadcaster> fts_broadcaster_;
 

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.hpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.hpp
@@ -68,23 +68,17 @@ protected:
   const std::string frame_id_ = "fts_sensor_frame";
   const std::array<double, 6> sensor_values_ = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6}};
   hardware_interface::StateInterface::SharedPtr fts_force_x_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "force.x", "double", "1.1");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "force.x", "double", "1.1");
   hardware_interface::StateInterface::SharedPtr fts_force_y_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "force.y", "double", "2.2");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "force.y", "double", "2.2");
   hardware_interface::StateInterface::SharedPtr fts_force_z_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "force.z", "double", "3.3");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "force.z", "double", "3.3");
   hardware_interface::StateInterface::SharedPtr fts_torque_x_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "torque.x", "double", "4.4");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "torque.x", "double", "4.4");
   hardware_interface::StateInterface::SharedPtr fts_torque_y_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "torque.y", "double", "5.5");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "torque.y", "double", "5.5");
   hardware_interface::StateInterface::SharedPtr fts_torque_z_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "torque.z", "double", "6.6");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "torque.z", "double", "6.6");
 
   std::unique_ptr<FriendForceTorqueSensorBroadcaster> fts_broadcaster_;
 

--- a/forward_command_controller/test/test_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_forward_command_controller.hpp
@@ -69,14 +69,13 @@ protected:
 
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
-  std::vector<double> joint_commands_ = {1.1, 2.1, 3.1};
 
   CommandInterface::SharedPtr joint_1_pos_cmd_ =
-    std::make_shared<CommandInterface>(joint_names_[0], HW_IF_POSITION, &joint_commands_[0]);
+    std::make_shared<CommandInterface>(joint_names_[0], HW_IF_POSITION, "double", "1.1");
   CommandInterface::SharedPtr joint_2_pos_cmd_ =
-    std::make_shared<CommandInterface>(joint_names_[1], HW_IF_POSITION, &joint_commands_[1]);
+    std::make_shared<CommandInterface>(joint_names_[1], HW_IF_POSITION, "double", "2.1");
   CommandInterface::SharedPtr joint_3_pos_cmd_ =
-    std::make_shared<CommandInterface>(joint_names_[2], HW_IF_POSITION, &joint_commands_[2]);
+    std::make_shared<CommandInterface>(joint_names_[2], HW_IF_POSITION, "double", "3.1");
   rclcpp::executors::SingleThreadedExecutor executor;
 };
 

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
@@ -76,16 +76,12 @@ protected:
   // dummy joint state value used for tests
   const std::string joint_name_ = "joint1";
 
-  double pos_cmd_ = 1.1;
-  double vel_cmd_ = 2.1;
-  double eff_cmd_ = 3.1;
-
   CommandInterface::SharedPtr joint_1_pos_cmd_ =
-    std::make_shared<CommandInterface>(joint_name_, HW_IF_POSITION, &pos_cmd_);
+    std::make_shared<CommandInterface>(joint_name_, HW_IF_POSITION, "double", "1.1");
   CommandInterface::SharedPtr joint_1_vel_cmd_ =
-    std::make_shared<CommandInterface>(joint_name_, HW_IF_VELOCITY, &vel_cmd_);
+    std::make_shared<CommandInterface>(joint_name_, HW_IF_VELOCITY, "double", "2.1");
   CommandInterface::SharedPtr joint_1_eff_cmd_ =
-    std::make_shared<CommandInterface>(joint_name_, HW_IF_EFFORT, &eff_cmd_);
+    std::make_shared<CommandInterface>(joint_name_, HW_IF_EFFORT, "double", "3.1");
   rclcpp::executors::SingleThreadedExecutor executor;
 };
 

--- a/gpio_controllers/test/test_gpio_command_controller.cpp
+++ b/gpio_controllers/test/test_gpio_command_controller.cpp
@@ -218,22 +218,22 @@ public:
     return params;
   }
   const std::vector<std::string> gpio_names{"gpio1", "gpio2"};
-  std::vector<double> gpio_commands{1.0, 0.0, 3.1};
-  std::vector<double> gpio_states{1.0, 0.0, 3.1};
+  const std::vector<double> gpio_commands{1.0, 0.0, 3.1};
+  const std::vector<double> gpio_states{1.0, 0.0, 3.1};
 
   CommandInterface::SharedPtr gpio_1_1_dig_cmd =
-    std::make_shared<CommandInterface>(gpio_names.at(0), "dig.1", &gpio_commands.at(0));
+    std::make_shared<CommandInterface>(gpio_names.at(0), "dig.1", "double", "1.0");
   CommandInterface::SharedPtr gpio_1_2_dig_cmd =
-    std::make_shared<CommandInterface>(gpio_names.at(0), "dig.2", &gpio_commands.at(1));
+    std::make_shared<CommandInterface>(gpio_names.at(0), "dig.2", "double", "0.0");
   CommandInterface::SharedPtr gpio_2_ana_cmd =
-    std::make_shared<CommandInterface>(gpio_names.at(1), "ana.1", &gpio_commands.at(2));
+    std::make_shared<CommandInterface>(gpio_names.at(1), "ana.1", "double", "3.1");
 
   StateInterface::SharedPtr gpio_1_1_dig_state =
-    std::make_shared<StateInterface>(gpio_names.at(0), "dig.1", &gpio_states.at(0));
+    std::make_shared<StateInterface>(gpio_names.at(0), "dig.1", "double", "1.0");
   StateInterface::SharedPtr gpio_1_2_dig_state =
-    std::make_shared<StateInterface>(gpio_names.at(0), "dig.2", &gpio_states.at(1));
+    std::make_shared<StateInterface>(gpio_names.at(0), "dig.2", "double", "0.0");
   StateInterface::SharedPtr gpio_2_ana_state =
-    std::make_shared<StateInterface>(gpio_names.at(1), "ana.1", &gpio_states.at(2));
+    std::make_shared<StateInterface>(gpio_names.at(1), "ana.1", "double", "3.1");
   std::unique_ptr<rclcpp::Node> node;
 };
 

--- a/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
+++ b/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
@@ -133,20 +133,16 @@ protected:
   const rclcpp::Parameter frame_id_ = rclcpp::Parameter("frame_id", "gps_sensor_frame");
   const std::array<double, 8> sensor_values_ = {{1.0, 1.0, 1.1, 2.2, 3.3, 0.5, 0.7, 0.9}};
   hardware_interface::StateInterface::SharedPtr gps_status_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "status", "double", "1.0");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "status", "double", "1.0");
   hardware_interface::StateInterface::SharedPtr gps_service_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "service", "double", "1.0");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "service", "double", "1.0");
   hardware_interface::StateInterface::SharedPtr gps_latitude_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "latitude", "double", "1.1");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "latitude", "double", "1.1");
   hardware_interface::StateInterface::SharedPtr gps_longitude_ =
     std::make_shared<hardware_interface::StateInterface>(
       sensor_name_, "longitude", "double", "2.2");
   hardware_interface::StateInterface::SharedPtr gps_altitude_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "altitude", "double", "3.3");
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "altitude", "double", "3.3");
   hardware_interface::StateInterface::SharedPtr latitude_covariance_ =
     std::make_shared<hardware_interface::StateInterface>(
       sensor_name_, "latitude_covariance", "double", "0.5");

--- a/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
+++ b/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
@@ -131,31 +131,31 @@ protected:
   const rclcpp::Parameter sensor_name_param_ = rclcpp::Parameter("sensor_name", "gps_sensor");
   const std::string sensor_name_ = sensor_name_param_.get_value<std::string>();
   const rclcpp::Parameter frame_id_ = rclcpp::Parameter("frame_id", "gps_sensor_frame");
-  std::array<double, 8> sensor_values_ = {{1.0, 1.0, 1.1, 2.2, 3.3, 0.5, 0.7, 0.9}};
+  const std::array<double, 8> sensor_values_ = {{1.0, 1.0, 1.1, 2.2, 3.3, 0.5, 0.7, 0.9}};
   hardware_interface::StateInterface::SharedPtr gps_status_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "status", &sensor_values_[0]);
+      sensor_name_, "status", "double", "1.0");
   hardware_interface::StateInterface::SharedPtr gps_service_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "service", &sensor_values_[1]);
+      sensor_name_, "service", "double", "1.0");
   hardware_interface::StateInterface::SharedPtr gps_latitude_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "latitude", &sensor_values_[2]);
+      sensor_name_, "latitude", "double", "1.1");
   hardware_interface::StateInterface::SharedPtr gps_longitude_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "longitude", &sensor_values_[3]);
+      sensor_name_, "longitude", "double", "2.2");
   hardware_interface::StateInterface::SharedPtr gps_altitude_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "altitude", &sensor_values_[4]);
+      sensor_name_, "altitude", "double", "3.3");
   hardware_interface::StateInterface::SharedPtr latitude_covariance_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "latitude_covariance", &sensor_values_[5]);
+      sensor_name_, "latitude_covariance", "double", "0.5");
   hardware_interface::StateInterface::SharedPtr longitude_covariance_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "longitude_covariance", &sensor_values_[6]);
+      sensor_name_, "longitude_covariance", "double", "0.7");
   hardware_interface::StateInterface::SharedPtr altitude_covariance_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "altitude_covariance", &sensor_values_[7]);
+      sensor_name_, "altitude_covariance", "double", "0.9");
 
   std::unique_ptr<gps_sensor_broadcaster::GPSSensorBroadcaster> gps_broadcaster_;
 };

--- a/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.hpp
+++ b/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.hpp
@@ -61,38 +61,38 @@ public:
 protected:
   const std::string sensor_name_ = "imu_sensor";
   const std::string frame_id_ = "imu_sensor_frame";
-  std::array<double, 10> sensor_values_ = {
+  const std::array<double, 10> sensor_values_ = {
     {0.1826, 0.3651, 0.5477, 0.7303, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10}};
   hardware_interface::StateInterface::SharedPtr imu_orientation_x_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "orientation.x", &sensor_values_[0]);
+      sensor_name_, "orientation.x", "double", "0.1826");
   hardware_interface::StateInterface::SharedPtr imu_orientation_y_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "orientation.y", &sensor_values_[1]);
+      sensor_name_, "orientation.y", "double", "0.3651");
   hardware_interface::StateInterface::SharedPtr imu_orientation_z_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "orientation.z", &sensor_values_[2]);
+      sensor_name_, "orientation.z", "double", "0.5477");
   hardware_interface::StateInterface::SharedPtr imu_orientation_w_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "orientation.w", &sensor_values_[3]);
+      sensor_name_, "orientation.w", "double", "0.7303");
   hardware_interface::StateInterface::SharedPtr imu_angular_velocity_x_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "angular_velocity.x", &sensor_values_[4]);
+      sensor_name_, "angular_velocity.x", "double", "5.5");
   hardware_interface::StateInterface::SharedPtr imu_angular_velocity_y_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "angular_velocity.y", &sensor_values_[5]);
+      sensor_name_, "angular_velocity.y", "double", "6.6");
   hardware_interface::StateInterface::SharedPtr imu_angular_velocity_z_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "angular_velocity.z", &sensor_values_[6]);
+      sensor_name_, "angular_velocity.z", "double", "7.7");
   hardware_interface::StateInterface::SharedPtr imu_linear_acceleration_x_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "linear_acceleration.x", &sensor_values_[7]);
+      sensor_name_, "linear_acceleration.x", "double", "8.8");
   hardware_interface::StateInterface::SharedPtr imu_linear_acceleration_y_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "linear_acceleration.y", &sensor_values_[8]);
+      sensor_name_, "linear_acceleration.y", "double", "9.9");
   hardware_interface::StateInterface::SharedPtr imu_linear_acceleration_z_ =
     std::make_shared<hardware_interface::StateInterface>(
-      sensor_name_, "linear_acceleration.z", &sensor_values_[9]);
+      sensor_name_, "linear_acceleration.z", "double", "10.1");
 
   std::unique_ptr<FriendIMUSensorBroadcaster> imu_broadcaster_;
 

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -834,69 +834,69 @@ TEST_F(JointStateBroadcasterTest, UpdatePerformanceTest)
     // standard
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "position", &custom_joint_value_));
+        joint_name, "position", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "velocity", &custom_joint_value_));
+        joint_name, "velocity", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "effort", &custom_joint_value_));
+        joint_name, "effort", "double", "12.34"));
 
     // non standard
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "mode", &custom_joint_value_));
+        joint_name, "mode", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "absolute_position", &custom_joint_value_));
+        joint_name, "absolute_position", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "acceleration", &custom_joint_value_));
+        joint_name, "acceleration", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "current", &custom_joint_value_));
+        joint_name, "current", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "torque", &custom_joint_value_));
+        joint_name, "torque", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "force", &custom_joint_value_));
+        joint_name, "force", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "temperature_board", &custom_joint_value_));
+        joint_name, "temperature_board", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "temperature_motor", &custom_joint_value_));
+        joint_name, "temperature_motor", "double", "12.34"));
 
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "position.kd", &custom_joint_value_));
+        joint_name, "position.kd", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "position.ki", &custom_joint_value_));
+        joint_name, "position.ki", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "position.kp", &custom_joint_value_));
+        joint_name, "position.kp", "double", "12.34"));
 
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "velocity.kd", &custom_joint_value_));
+        joint_name, "velocity.kd", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "velocity.ki", &custom_joint_value_));
+        joint_name, "velocity.ki", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "velocity.kp", &custom_joint_value_));
+        joint_name, "velocity.kp", "double", "12.34"));
 
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "current.kd", &custom_joint_value_));
+        joint_name, "current.kd", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "current.ki", &custom_joint_value_));
+        joint_name, "current.ki", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "current.kp", &custom_joint_value_));
+        joint_name, "current.kp", "double", "12.34"));
   }
 
   RCLCPP_INFO(

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -844,8 +844,7 @@ TEST_F(JointStateBroadcasterTest, UpdatePerformanceTest)
 
     // non standard
     test_interfaces_.emplace_back(
-      std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "mode", "double", "12.34"));
+      std::make_shared<hardware_interface::StateInterface>(joint_name, "mode", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
         joint_name, "absolute_position", "double", "12.34"));
@@ -859,8 +858,7 @@ TEST_F(JointStateBroadcasterTest, UpdatePerformanceTest)
       std::make_shared<hardware_interface::StateInterface>(
         joint_name, "torque", "double", "12.34"));
     test_interfaces_.emplace_back(
-      std::make_shared<hardware_interface::StateInterface>(
-        joint_name, "force", "double", "12.34"));
+      std::make_shared<hardware_interface::StateInterface>(joint_name, "force", "double", "12.34"));
     test_interfaces_.emplace_back(
       std::make_shared<hardware_interface::StateInterface>(
         joint_name, "temperature_board", "double", "12.34"));

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -129,40 +129,40 @@ protected:
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
   const std::vector<std::string> interface_names_ = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
   std::string custom_interface_name_ = "measured_position";
-  std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
+  const std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
   double custom_joint_value_ = 3.5;
 
   hardware_interface::StateInterface::SharedPtr joint_1_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[0], interface_names_[0], &joint_values_[0]);
+      joint_names_[0], interface_names_[0], "double", "1.1");
   hardware_interface::StateInterface::SharedPtr joint_2_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[1], interface_names_[0], &joint_values_[1]);
+      joint_names_[1], interface_names_[0], "double", "2.1");
   hardware_interface::StateInterface::SharedPtr joint_3_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[2], interface_names_[0], &joint_values_[2]);
+      joint_names_[2], interface_names_[0], "double", "3.1");
   hardware_interface::StateInterface::SharedPtr joint_1_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[0], interface_names_[1], &joint_values_[0]);
+      joint_names_[0], interface_names_[1], "double", "1.1");
   hardware_interface::StateInterface::SharedPtr joint_2_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[1], interface_names_[1], &joint_values_[1]);
+      joint_names_[1], interface_names_[1], "double", "2.1");
   hardware_interface::StateInterface::SharedPtr joint_3_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[2], interface_names_[1], &joint_values_[2]);
+      joint_names_[2], interface_names_[1], "double", "3.1");
   hardware_interface::StateInterface::SharedPtr joint_1_eff_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[0], interface_names_[2], &joint_values_[0]);
+      joint_names_[0], interface_names_[2], "double", "1.1");
   hardware_interface::StateInterface::SharedPtr joint_2_eff_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[1], interface_names_[2], &joint_values_[1]);
+      joint_names_[1], interface_names_[2], "double", "2.1");
   hardware_interface::StateInterface::SharedPtr joint_3_eff_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[2], interface_names_[2], &joint_values_[2]);
+      joint_names_[2], interface_names_[2], "double", "3.1");
 
   hardware_interface::StateInterface::SharedPtr joint_X_custom_state =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[0], custom_interface_name_, &custom_joint_value_);
+      joint_names_[0], custom_interface_name_, "double", "3.5");
 
   hardware_interface::StateInterface::SharedPtr joint_1_moving_state_ =
     std::make_shared<hardware_interface::StateInterface>(

--- a/parallel_gripper_controller/test/test_parallel_gripper_controller.hpp
+++ b/parallel_gripper_controller/test/test_parallel_gripper_controller.hpp
@@ -56,18 +56,16 @@ protected:
 
   // dummy joint state values used for tests
   const std::string joint_name_ = "joint1";
-  std::vector<double> joint_states_ = {1.1, 2.1};
-  std::vector<double> joint_commands_ = {3.1};
 
   hardware_interface::StateInterface::SharedPtr joint_1_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_name_, hardware_interface::HW_IF_POSITION, &joint_states_[0]);
+      joint_name_, hardware_interface::HW_IF_POSITION, "double", "1.1");
   hardware_interface::StateInterface::SharedPtr joint_1_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_name_, hardware_interface::HW_IF_VELOCITY, &joint_states_[1]);
+      joint_name_, hardware_interface::HW_IF_VELOCITY, "double", "2.1");
   hardware_interface::CommandInterface::SharedPtr joint_1_cmd_ =
     std::make_shared<hardware_interface::CommandInterface>(
-      joint_name_, hardware_interface::HW_IF_POSITION, &joint_commands_[0]);
+      joint_name_, hardware_interface::HW_IF_POSITION);
 };
 
 }  // anonymous namespace

--- a/pose_broadcaster/test/test_pose_broadcaster.hpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.hpp
@@ -49,14 +49,11 @@ protected:
     {1.1, 2.2, 3.3, 0.39190382, 0.20056212, 0.53197575, 0.72331744}};
 
   hardware_interface::StateInterface::SharedPtr pose_position_x_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "position.x", "double", "1.1");
+    std::make_shared<hardware_interface::StateInterface>(pose_name_, "position.x", "double", "1.1");
   hardware_interface::StateInterface::SharedPtr pose_position_y_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "position.y", "double", "2.2");
+    std::make_shared<hardware_interface::StateInterface>(pose_name_, "position.y", "double", "2.2");
   hardware_interface::StateInterface::SharedPtr pose_position_z_ =
-    std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "position.z", "double", "3.3");
+    std::make_shared<hardware_interface::StateInterface>(pose_name_, "position.z", "double", "3.3");
   hardware_interface::StateInterface::SharedPtr pose_orientation_x_ =
     std::make_shared<hardware_interface::StateInterface>(
       pose_name_, "orientation.x", "double", "0.39190382");

--- a/pose_broadcaster/test/test_pose_broadcaster.hpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.hpp
@@ -45,30 +45,30 @@ protected:
   const std::string frame_id_ = "pose_base_frame";
   const std::string tf_child_frame_id_ = "pose_frame";
 
-  std::array<double, 7> pose_values_ = {
+  const std::array<double, 7> pose_values_ = {
     {1.1, 2.2, 3.3, 0.39190382, 0.20056212, 0.53197575, 0.72331744}};
 
   hardware_interface::StateInterface::SharedPtr pose_position_x_ =
     std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "position.x", &pose_values_[0]);
+      pose_name_, "position.x", "double", "1.1");
   hardware_interface::StateInterface::SharedPtr pose_position_y_ =
     std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "position.y", &pose_values_[1]);
+      pose_name_, "position.y", "double", "2.2");
   hardware_interface::StateInterface::SharedPtr pose_position_z_ =
     std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "position.z", &pose_values_[2]);
+      pose_name_, "position.z", "double", "3.3");
   hardware_interface::StateInterface::SharedPtr pose_orientation_x_ =
     std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "orientation.x", &pose_values_[3]);
+      pose_name_, "orientation.x", "double", "0.39190382");
   hardware_interface::StateInterface::SharedPtr pose_orientation_y_ =
     std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "orientation.y", &pose_values_[4]);
+      pose_name_, "orientation.y", "double", "0.20056212");
   hardware_interface::StateInterface::SharedPtr pose_orientation_z_ =
     std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "orientation.z", &pose_values_[5]);
+      pose_name_, "orientation.z", "double", "0.53197575");
   hardware_interface::StateInterface::SharedPtr pose_orientation_w_ =
     std::make_shared<hardware_interface::StateInterface>(
-      pose_name_, "orientation.w", &pose_values_[6]);
+      pose_name_, "orientation.w", "double", "0.72331744");
 
   std::unique_ptr<PoseBroadcaster> pose_broadcaster_;
 

--- a/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
+++ b/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
@@ -226,6 +226,7 @@ TEST_F(RangeSensorBroadcasterTest, Publish_Bandaries_RangeBroadcaster_Success)
   sensor_msgs::msg::Range range_msg;
 
   sensor_range_ = 0.10f;
+  range_->set_value(sensor_range_);
   subscribe_and_get_message(range_msg);
 
   EXPECT_EQ(range_msg.header.frame_id, frame_id_);
@@ -239,6 +240,7 @@ TEST_F(RangeSensorBroadcasterTest, Publish_Bandaries_RangeBroadcaster_Success)
 #endif
 
   sensor_range_ = 4.0;
+  range_->set_value(sensor_range_);
   subscribe_and_get_message(range_msg);
 
   EXPECT_EQ(range_msg.header.frame_id, frame_id_);
@@ -262,6 +264,7 @@ TEST_F(RangeSensorBroadcasterTest, Publish_OutOfBandaries_RangeBroadcaster_Succe
   sensor_msgs::msg::Range range_msg;
 
   sensor_range_ = 0.0;
+  range_->set_value(sensor_range_);
   subscribe_and_get_message(range_msg);
 
   EXPECT_EQ(range_msg.header.frame_id, frame_id_);
@@ -276,6 +279,7 @@ TEST_F(RangeSensorBroadcasterTest, Publish_OutOfBandaries_RangeBroadcaster_Succe
 #endif
 
   sensor_range_ = 6.0;
+  range_->set_value(sensor_range_);
   subscribe_and_get_message(range_msg);
 
   EXPECT_EQ(range_msg.header.frame_id, frame_id_);

--- a/range_sensor_broadcaster/test/test_range_sensor_broadcaster.hpp
+++ b/range_sensor_broadcaster/test/test_range_sensor_broadcaster.hpp
@@ -53,7 +53,7 @@ protected:
 
   double sensor_range_ = 3.1;
   hardware_interface::StateInterface::SharedPtr range_ =
-    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "range", &sensor_range_);
+    std::make_shared<hardware_interface::StateInterface>(sensor_name_, "range", "double", "3.1");
 
   std::unique_ptr<range_sensor_broadcaster::RangeSensorBroadcaster> range_broadcaster_;
 

--- a/state_interfaces_broadcaster/test/test_state_interfaces_broadcaster.hpp
+++ b/state_interfaces_broadcaster/test/test_state_interfaces_broadcaster.hpp
@@ -73,40 +73,40 @@ protected:
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
   const std::vector<std::string> interface_names_ = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
   std::string custom_interface_name_ = "measured_position";
-  std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
-  double custom_joint_value_ = 3.5;
+  const std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
+  const double custom_joint_value_ = 3.5;
 
   hardware_interface::StateInterface::SharedPtr joint_1_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[0], interface_names_[0], &joint_values_[0]);
+      joint_names_[0], interface_names_[0], "double", "1.1");
   hardware_interface::StateInterface::SharedPtr joint_2_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[1], interface_names_[0], &joint_values_[1]);
+      joint_names_[1], interface_names_[0], "double", "2.1");
   hardware_interface::StateInterface::SharedPtr joint_3_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[2], interface_names_[0], &joint_values_[2]);
+      joint_names_[2], interface_names_[0], "double", "3.1");
   hardware_interface::StateInterface::SharedPtr joint_1_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[0], interface_names_[1], &joint_values_[0]);
+      joint_names_[0], interface_names_[1], "double", "1.1");
   hardware_interface::StateInterface::SharedPtr joint_2_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[1], interface_names_[1], &joint_values_[1]);
+      joint_names_[1], interface_names_[1], "double", "2.1");
   hardware_interface::StateInterface::SharedPtr joint_3_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[2], interface_names_[1], &joint_values_[2]);
+      joint_names_[2], interface_names_[1], "double", "3.1");
   hardware_interface::StateInterface::SharedPtr joint_1_eff_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[0], interface_names_[2], &joint_values_[0]);
+      joint_names_[0], interface_names_[2], "double", "1.1");
   hardware_interface::StateInterface::SharedPtr joint_2_eff_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[1], interface_names_[2], &joint_values_[1]);
+      joint_names_[1], interface_names_[2], "double", "2.1");
   hardware_interface::StateInterface::SharedPtr joint_3_eff_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[2], interface_names_[2], &joint_values_[2]);
+      joint_names_[2], interface_names_[2], "double", "3.1");
 
   hardware_interface::StateInterface::SharedPtr joint_X_custom_state =
     std::make_shared<hardware_interface::StateInterface>(
-      joint_names_[0], custom_interface_name_, &custom_joint_value_);
+      joint_names_[0], custom_interface_name_, "double", "3.5");
 
   std::vector<hardware_interface::StateInterface::SharedPtr> test_interfaces_;
 

--- a/tricycle_controller/test/test_tricycle_controller.cpp
+++ b/tricycle_controller/test/test_tricycle_controller.cpp
@@ -181,24 +181,24 @@ protected:
   const std::string controller_name = "test_tricycle_controller";
   std::unique_ptr<TestableTricycleController> controller_;
 
-  double position_ = 0.1;
-  double velocity_ = 0.2;
+  const double position_ = 0.1;
+  const double velocity_ = 0.2;
 
   hardware_interface::StateInterface::SharedPtr steering_joint_pos_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      steering_joint_name, HW_IF_POSITION, &position_);
+      steering_joint_name, HW_IF_POSITION, "double", "0.1");
 
   hardware_interface::StateInterface::SharedPtr traction_joint_vel_state_ =
     std::make_shared<hardware_interface::StateInterface>(
-      traction_joint_name, HW_IF_VELOCITY, &velocity_);
+      traction_joint_name, HW_IF_VELOCITY, "double", "0.2");
 
   hardware_interface::CommandInterface::SharedPtr steering_joint_pos_cmd_ =
     std::make_shared<hardware_interface::CommandInterface>(
-      steering_joint_name, HW_IF_POSITION, &position_);
+      steering_joint_name, HW_IF_POSITION, "double", "0.1");
 
   hardware_interface::CommandInterface::SharedPtr traction_joint_vel_cmd_ =
     std::make_shared<hardware_interface::CommandInterface>(
-      traction_joint_name, HW_IF_VELOCITY, &velocity_);
+      traction_joint_name, HW_IF_VELOCITY, "double", "0.2");
 
   rclcpp::Node::SharedPtr pub_node;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr velocity_publisher;


### PR DESCRIPTION
This changes the StateInterface and CommandInterfaces used inside the tests to use the new Handles API and to move away from the deprecated API, so it'll be easier to break the API of the Handle where it needed a variable reference parsed. This is the first step toward that direction