### PR TITLE
Test fix - call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library

### DIFF
--- a/chained_filter_controller/test/test_chained_filter.cpp
+++ b/chained_filter_controller/test/test_chained_filter.cpp
@@ -85,19 +85,16 @@ TEST_F(ChainedFilterTest, ConfigureFailureWithWrongInterfaceSizes)
      rclcpp::Parameter(
        "output_interfaces",
        std::vector<std::string>{"wheel_left/filtered_position", "extra_interface"})});
-  auto configure_result = controller_->on_configure(rclcpp_lifecycle::State());
-  EXPECT_EQ(configure_result, CallbackReturn::FAILURE);
+
+  ASSERT_FALSE(configure_succeeds(controller_));
 }
 
 TEST_F(ChainedFilterTest, ActivateReturnsSuccessWithoutError)
 {
   SetUpController();
 
-  auto configure_result = controller_->on_configure(rclcpp_lifecycle::State());
-  EXPECT_EQ(configure_result, CallbackReturn::SUCCESS);
-
-  auto activate_result = controller_->on_activate(rclcpp_lifecycle::State());
-  EXPECT_EQ(activate_result, CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   ASSERT_FALSE(controller_->is_in_chained_mode())
     << "No controller is claiming the reference interfaces (it has none).";
@@ -107,7 +104,7 @@ TEST_F(ChainedFilterTest, state_interface_configuration_succeeds_when_wheels_are
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(1u));
@@ -127,8 +124,8 @@ TEST_F(ChainedFilterTest, state_interface_configuration_succeeds_when_wheels_are
 TEST_F(ChainedFilterTest, UpdateFilter)
 {
   SetUpController();
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   ASSERT_EQ(
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),
@@ -154,19 +151,30 @@ TEST_F(ChainedFilterTest, UpdateFilter)
   EXPECT_EQ(state_if_exported_conf[0]->get_optional().value(), joint_states_[0]);
 }
 
-TEST_F(ChainedFilterTest, DeactivateDoesNotCrash)
+TEST_F(ChainedFilterTest, DeactivateSucceeds)
 {
-  EXPECT_NO_THROW({ controller_->on_deactivate(rclcpp_lifecycle::State()); });
+  SetUpController();
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
+  ASSERT_TRUE(deactivate_succeeds(controller_));
 }
 
-TEST_F(ChainedFilterTest, CleanupDoesNotCrash)
+TEST_F(ChainedFilterTest, CleanupSucceeds)
 {
-  EXPECT_NO_THROW({ controller_->on_cleanup(rclcpp_lifecycle::State()); });
+  SetUpController();
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
+  ASSERT_TRUE(deactivate_succeeds(controller_));
+  ASSERT_TRUE(cleanup_succeeds(controller_));
 }
 
-TEST_F(ChainedFilterTest, ShutdownDoesNotCrash)
+TEST_F(ChainedFilterTest, ShutdownSucceeds)
 {
-  EXPECT_NO_THROW({ controller_->on_shutdown(rclcpp_lifecycle::State()); });
+  SetUpController();
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
+  ASSERT_TRUE(deactivate_succeeds(controller_));
+  ASSERT_TRUE(shutdown_succeeds(controller_));
 }
 
 int main(int argc, char ** argv)

--- a/chained_filter_controller/test/test_chained_filter.hpp
+++ b/chained_filter_controller/test/test_chained_filter.hpp
@@ -22,9 +22,16 @@
 #include "gmock/gmock.h"
 
 #include "chained_filter_controller/chained_filter.hpp"
+#include "controller_interface/test_utils.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::cleanup_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
+using controller_interface::shutdown_succeeds;
 
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::StateInterface;

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
@@ -119,7 +119,7 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_InterfaceNames_NotSet)
   SetUpFTSBroadcaster("test_force_torque_sensor_broadcaster");
 
   // configure failed
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
+  ASSERT_FALSE(configure_succeeds(fts_broadcaster_));
 }
 
 TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_InterfaceNames_Set)
@@ -134,7 +134,7 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_InterfaceNames_Set)
   fts_broadcaster_->get_node()->set_parameter({"interface_names.torque.z", "fts_sensor/torque.z"});
 
   // configure failed, both 'sensor_name' and 'interface_names' supplied
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
+  ASSERT_FALSE(configure_succeeds(fts_broadcaster_));
 }
 
 TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_IsEmpty_InterfaceNames_NotSet)
@@ -145,7 +145,7 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_IsEmpty_InterfaceNames_NotSe
   fts_broadcaster_->get_node()->set_parameter({"sensor_name", ""});
 
   // configure failed, 'sensor_name' parameter empty
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
+  ASSERT_FALSE(configure_succeeds(fts_broadcaster_));
 }
 
 TEST_F(ForceTorqueSensorBroadcasterTest, InterfaceNames_IsEmpty_SensorName_NotSet)
@@ -157,7 +157,7 @@ TEST_F(ForceTorqueSensorBroadcasterTest, InterfaceNames_IsEmpty_SensorName_NotSe
   fts_broadcaster_->get_node()->set_parameter({"interface_names.torque.z", ""});
 
   // configure failed, 'interface_name' parameter empty
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
+  ASSERT_FALSE(configure_succeeds(fts_broadcaster_));
 }
 
 TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_Configure_Success)
@@ -171,7 +171,7 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_Configure_Success)
   fts_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
   // configure passed
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
 
   // check interface configuration
   auto cmd_if_conf = fts_broadcaster_->command_interface_configuration();
@@ -194,9 +194,8 @@ TEST_F(ForceTorqueSensorBroadcasterTest, InterfaceNames_Configure_Success)
   // set the 'frame_id'
   fts_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
-  RCLCPP_INFO(fts_broadcaster_->get_node()->get_logger(), "Calling on_configure");
   // configure passed
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
 }
 
 TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_ActivateDeactivate_Success)
@@ -208,8 +207,8 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_ActivateDeactivate_Success)
   fts_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
   // configure and activate success
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   // check interface configuration
   auto cmd_if_conf = fts_broadcaster_->command_interface_configuration();
@@ -220,7 +219,7 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_ActivateDeactivate_Success)
   ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // deactivate passed
-  ASSERT_EQ(fts_broadcaster_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(deactivate_succeeds(fts_broadcaster_));
 
   // check interface configuration
   cmd_if_conf = fts_broadcaster_->command_interface_configuration();
@@ -239,8 +238,8 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_Update_Success)
   fts_broadcaster_->get_node()->set_parameter({"sensor_name", sensor_name_});
   fts_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   ASSERT_EQ(
     fts_broadcaster_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
@@ -256,8 +255,8 @@ TEST_F(ForceTorqueSensorBroadcasterTest, InterfaceNames_Success)
   fts_broadcaster_->get_node()->set_parameter({"interface_names.torque.z", "fts_sensor/torque.z"});
   fts_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
   ASSERT_EQ(
     fts_broadcaster_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
@@ -271,8 +270,8 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_Publish_Success)
   fts_broadcaster_->get_node()->set_parameter({"sensor_name", sensor_name_});
   fts_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   geometry_msgs::msg::WrenchStamped wrench_msg;
   std::string topic_name = "/test_force_torque_sensor_broadcaster/wrench";
@@ -303,8 +302,8 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_Publish_Success_with_Offsets
   fts_broadcaster_->get_node()->set_parameter({"offset.torque.y", torque_offsets[1]});
   fts_broadcaster_->get_node()->set_parameter({"offset.torque.z", torque_offsets[2]});
 
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   geometry_msgs::msg::WrenchStamped wrench_msg;
   std::string topic_name = "/test_force_torque_sensor_broadcaster/wrench";
@@ -371,8 +370,8 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorName_Publish_Success_with_Multipl
   fts_broadcaster_->get_node()->set_parameter({"multiplier.torque.z", torque_multipliers[2]});
 
   // Configure & activate
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   // Publish & grab the message
   geometry_msgs::msg::WrenchStamped wrench_msg;
@@ -430,8 +429,8 @@ TEST_F(ForceTorqueSensorBroadcasterTest, InterfaceNames_Publish_Success)
   fts_broadcaster_->get_node()->set_parameter({"interface_names.torque.z", "fts_sensor/torque.z"});
   fts_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   geometry_msgs::msg::WrenchStamped wrench_msg;
   std::string topic_name = "/test_force_torque_sensor_broadcaster/wrench";
@@ -472,8 +471,8 @@ TEST_F(ForceTorqueSensorBroadcasterTest, All_InterfaceNames_Publish_Success)
   fts_broadcaster_->get_node()->set_parameter({"interface_names.torque.z", "fts_sensor/torque.z"});
   fts_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   geometry_msgs::msg::WrenchStamped wrench_msg;
   std::string topic_name = "/test_force_torque_sensor_broadcaster/wrench";
@@ -515,7 +514,7 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorFilterChain_Configure_Success)
   SetUpFTSBroadcaster("test_force_torque_sensor_broadcaster_with_chain");
 
   // configure passed
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
   ASSERT_EQ(fts_broadcaster_->has_filter_chain_, true);
 
   // check interface configuration
@@ -534,9 +533,9 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorFilterChain_ActivateDeactivate_Su
   SetUpFTSBroadcaster("test_force_torque_sensor_broadcaster_with_chain");
 
   // configure and activate success
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
   ASSERT_EQ(fts_broadcaster_->has_filter_chain_, true);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   // check interface configuration
   auto cmd_if_conf = fts_broadcaster_->command_interface_configuration();
@@ -547,7 +546,7 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorFilterChain_ActivateDeactivate_Su
   ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // deactivate passed
-  ASSERT_EQ(fts_broadcaster_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(deactivate_succeeds(fts_broadcaster_));
 
   // check interface configuration
   cmd_if_conf = fts_broadcaster_->command_interface_configuration();
@@ -562,9 +561,9 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorFilterChain_Update_Success)
 {
   SetUpFTSBroadcaster("test_force_torque_sensor_broadcaster_with_chain");
 
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
   ASSERT_EQ(fts_broadcaster_->has_filter_chain_, true);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   ASSERT_EQ(
     fts_broadcaster_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
@@ -596,9 +595,9 @@ TEST_F(ForceTorqueSensorBroadcasterTest, SensorFilterChain_Publish_Success)
 {
   SetUpFTSBroadcaster("test_force_torque_sensor_broadcaster_with_chain");
 
-  ASSERT_EQ(fts_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(fts_broadcaster_));
   ASSERT_EQ(fts_broadcaster_->has_filter_chain_, true);
-  ASSERT_EQ(fts_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(fts_broadcaster_));
 
   geometry_msgs::msg::WrenchStamped wrench_msg_filtered;
   std::string topic_name = "/test_force_torque_sensor_broadcaster_with_chain/wrench_filtered";

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.hpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.hpp
@@ -24,7 +24,13 @@
 #include <memory>
 #include <string>
 
+#include "controller_interface/test_utils.hpp"
+
 #include "force_torque_sensor_broadcaster/force_torque_sensor_broadcaster.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 // subclassing and friending so we can access member variables
 class FriendForceTorqueSensorBroadcaster

--- a/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
+++ b/parallel_gripper_controller/test/test_parallel_gripper_controller.cpp
@@ -93,9 +93,7 @@ TEST_F(GripperControllerTest, ConfigureParamsSuccess)
   executor.spin_some();
 
   // configure successful
-  ASSERT_EQ(
-    this->controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // check interface configuration
   auto cmd_if_conf = this->controller_->command_interface_configuration();
@@ -117,12 +115,8 @@ TEST_F(GripperControllerTest, ActivateSuccess)
   this->controller_->get_node()->set_parameter({"joint", "joint1"});
 
   // activate successful
-  ASSERT_EQ(
-    this->controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
-  ASSERT_EQ(
-    this->controller_->on_activate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 }
 
 TEST_F(GripperControllerTest, ActivateDeactivateActivateSuccess)
@@ -131,15 +125,9 @@ TEST_F(GripperControllerTest, ActivateDeactivateActivateSuccess)
 
   this->controller_->get_node()->set_parameter({"joint", "joint1"});
 
-  ASSERT_EQ(
-    this->controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
-  ASSERT_EQ(
-    this->controller_->on_activate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
-  ASSERT_EQ(
-    this->controller_->on_deactivate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
+  ASSERT_TRUE(deactivate_succeeds(controller_));
   this->controller_->release_interfaces();
 
   // re-assign interfaces
@@ -150,12 +138,8 @@ TEST_F(GripperControllerTest, ActivateDeactivateActivateSuccess)
   state_ifs.emplace_back(this->joint_1_vel_state_, nullptr);
   this->controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
 
-  ASSERT_EQ(
-    this->controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
-  ASSERT_EQ(
-    this->controller_->on_activate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 }
 
 int main(int argc, char ** argv)

--- a/parallel_gripper_controller/test/test_parallel_gripper_controller.hpp
+++ b/parallel_gripper_controller/test/test_parallel_gripper_controller.hpp
@@ -21,9 +21,14 @@
 
 #include "gmock/gmock.h"
 
+#include "controller_interface/test_utils.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "parallel_gripper_controller/parallel_gripper_action_controller.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 namespace
 {

--- a/steering_controllers_library/test/test_steering_controllers_library.cpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.cpp
@@ -30,7 +30,7 @@ TEST_F(SteeringControllersLibraryTest, check_exported_interfaces)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto cmd_if_conf = controller_->command_interface_configuration();
   ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());
@@ -93,7 +93,7 @@ TEST_F(SteeringControllersLibraryTest, configure_succeeds_tf_prefix_no_namespace
 
   SetUpController("test_steering_controllers_library", node_options);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto odometry_message = controller_->odom_state_msg_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -116,7 +116,7 @@ TEST_F(SteeringControllersLibraryTest, configure_succeeds_tf_blank_prefix_no_nam
 
   SetUpController("test_steering_controllers_library", node_options);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto odometry_message = controller_->odom_state_msg_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -145,7 +145,7 @@ TEST_F(SteeringControllersLibraryTest, configure_succeeds_tf_prefix_set_namespac
 
   SetUpController("test_steering_controllers_library", node_options, test_namespace);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto odometry_message = controller_->odom_state_msg_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -173,7 +173,7 @@ TEST_F(SteeringControllersLibraryTest, configure_succeeds_tf_tilde_prefix_set_na
 
   SetUpController("test_steering_controllers_library", node_options, test_namespace);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto odometry_message = controller_->odom_state_msg_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -196,9 +196,9 @@ TEST_F(SteeringControllersLibraryTest, test_position_feedback_ref_timeout)
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(false);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_FALSE(controller_->is_in_chained_mode());
 
   for (const auto & interface : controller_->reference_interfaces_)
@@ -301,9 +301,9 @@ TEST_F(SteeringControllersLibraryTest, test_velocity_feedback_ref_timeout)
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(false);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_FALSE(controller_->is_in_chained_mode());
 
   for (const auto & interface : controller_->reference_interfaces_)
@@ -390,12 +390,12 @@ TEST_F(SteeringControllersLibraryTest, odometry_set_service)
 {
   // 0. Initialize and Activate
   SetUpController();
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->get_node()->trigger_transition(
     rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE));
 
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   controller_->get_node()->trigger_transition(
     rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE));
   ASSERT_EQ(

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "controller_interface/test_utils.hpp"
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "rclcpp/executor.hpp"
@@ -30,6 +31,9 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "steering_controllers_library/steering_controllers_library.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
 
 using ControllerStateMsg =
   steering_controllers_library::SteeringControllersLibrary::SteeringControllerStateMsg;
@@ -57,13 +61,6 @@ static constexpr size_t NR_REF_ITFS = 2;
 static constexpr double WHEELBASE_ = 3.24644;
 static constexpr double WHEELS_TRACK_ = 2.12321;
 static constexpr double WHEELS_RADIUS_ = 0.45;
-
-namespace
-{
-constexpr auto NODE_SUCCESS = controller_interface::CallbackReturn::SUCCESS;
-constexpr auto NODE_ERROR = controller_interface::CallbackReturn::ERROR;
-}  // namespace
-// namespace
 
 // subclassing and friending so we can access member variables
 class TestableSteeringControllersLibrary


### PR DESCRIPTION
Partial fix for https://github.com/ros-controls/ros2_controllers/issues/1660, utilize test utility functions to call appropriate lifecycle transitions and evaluate expected state.
This PR covers:
force_torque_sensor_broadcaster
chained_filter_controller
parallel_gripper_controller
steering_controllers_library