### PR TITLE
fix(magnetometer_broadcaster): Refactor to avoid pluginlib in tests

### DIFF
--- a/magnetometer_broadcaster/CMakeLists.txt
+++ b/magnetometer_broadcaster/CMakeLists.txt
@@ -30,6 +30,10 @@ add_library(magnetometer_broadcaster SHARED
   src/magnetometer_broadcaster.cpp
 )
 target_compile_features(magnetometer_broadcaster PUBLIC cxx_std_20)
+target_include_directories(magnetometer_broadcaster PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(magnetometer_broadcaster PUBLIC
                       magnetometer_broadcaster_parameters
                       controller_interface::controller_interface
@@ -65,6 +69,11 @@ if(BUILD_TESTING)
     ros2_control_test_assets::ros2_control_test_assets
   )
 endif()
+
+install(
+  DIRECTORY include/
+  DESTINATION include/magnetometer_broadcaster
+)
 
 install(
   TARGETS

--- a/magnetometer_broadcaster/include/magnetometer_broadcaster/magnetometer_broadcaster.hpp
+++ b/magnetometer_broadcaster/include/magnetometer_broadcaster/magnetometer_broadcaster.hpp
@@ -1,0 +1,69 @@
+// Copyright 2026 Christian Rauch
+// Copyright 2021 PAL Robotics SL.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Authors: Christian Rauch, Subhas Das, Denis Stogl, Victor Lopez
+ */
+
+#ifndef MAGNETOMETER_BROADCASTER__MAGNETOMETER_BROADCASTER_HPP_
+#define MAGNETOMETER_BROADCASTER__MAGNETOMETER_BROADCASTER_HPP_
+
+#include <memory>
+
+#include <controller_interface/controller_interface.hpp>
+#include <magnetometer_broadcaster/magnetometer_broadcaster_parameters.hpp>
+#include <realtime_tools/realtime_publisher.hpp>
+#include <semantic_components/magnetic_field_sensor.hpp>
+#include <sensor_msgs/msg/magnetic_field.hpp>
+
+namespace magnetometer_broadcaster
+{
+
+class MagnetometerBroadcaster : public controller_interface::ControllerInterface
+{
+public:
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  controller_interface::CallbackReturn on_init() override;
+
+  controller_interface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  controller_interface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  controller_interface::CallbackReturn on_deactivate(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  controller_interface::return_type update(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+protected:
+  std::shared_ptr<ParamListener> param_listener_;
+  Params params_;
+
+  std::unique_ptr<semantic_components::MagneticFieldSensor> magnetometer_;
+
+  using StatePublisher = realtime_tools::RealtimePublisher<sensor_msgs::msg::MagneticField>;
+  rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr sensor_state_publisher_;
+  std::unique_ptr<StatePublisher> realtime_publisher_;
+  sensor_msgs::msg::MagneticField state_message_;
+};
+
+}  // namespace magnetometer_broadcaster
+
+#endif  // MAGNETOMETER_BROADCASTER__MAGNETOMETER_BROADCASTER_HPP_

--- a/magnetometer_broadcaster/src/magnetometer_broadcaster.cpp
+++ b/magnetometer_broadcaster/src/magnetometer_broadcaster.cpp
@@ -17,129 +17,107 @@
  * Authors: Christian Rauch, Subhas Das, Denis Stogl, Victor Lopez
  */
 
-#include <memory>
-#include <vector>
-
-#include <controller_interface/controller_interface.hpp>
+#include <magnetometer_broadcaster/magnetometer_broadcaster.hpp>
 #include <magnetometer_broadcaster/magnetometer_broadcaster_parameters.hpp>
 #include <pluginlib/class_list_macros.hpp>
-#include <rclcpp_lifecycle/state.hpp>
-#include <realtime_tools/realtime_publisher.hpp>
-#include <semantic_components/magnetic_field_sensor.hpp>
-#include <sensor_msgs/msg/magnetic_field.hpp>
 
 namespace magnetometer_broadcaster
 {
-
-class MagnetometerBroadcaster : public controller_interface::ControllerInterface
+controller_interface::InterfaceConfiguration
+MagnetometerBroadcaster::command_interface_configuration() const
 {
-public:
-  controller_interface::InterfaceConfiguration command_interface_configuration() const override
+  return {};
+}
+
+controller_interface::InterfaceConfiguration
+MagnetometerBroadcaster::state_interface_configuration() const
+{
+  return {
+    .type = controller_interface::interface_configuration_type::INDIVIDUAL,
+    .names = magnetometer_->get_state_interface_names(),
+  };
+}
+
+controller_interface::CallbackReturn MagnetometerBroadcaster::on_init()
+{
+  try
   {
-    return {};
+    param_listener_ = std::make_shared<ParamListener>(get_node());
+  }
+  catch (const std::exception & e)
+  {
+    RCLCPP_ERROR_STREAM(
+      get_node()->get_logger(), "Exception thrown during init stage with message: " << e.what());
+    return CallbackReturn::ERROR;
   }
 
-  controller_interface::InterfaceConfiguration state_interface_configuration() const override
+  return CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn MagnetometerBroadcaster::on_configure(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  try
   {
-    return {
-      .type = controller_interface::interface_configuration_type::INDIVIDUAL,
-      .names = magnetometer_->get_state_interface_names(),
-    };
+    params_ = param_listener_->get_params();
+  }
+  catch (const std::exception & e)
+  {
+    RCLCPP_ERROR_STREAM(
+      get_node()->get_logger(), "Exception thrown during config stage with message: " << e.what());
+    return CallbackReturn::ERROR;
   }
 
-  controller_interface::CallbackReturn on_init() override
+  magnetometer_ = std::make_unique<semantic_components::MagneticFieldSensor>(params_.sensor_name);
+  try
   {
-    try
-    {
-      param_listener_ = std::make_shared<ParamListener>(get_node());
-    }
-    catch (const std::exception & e)
-    {
-      RCLCPP_ERROR_STREAM(
-        get_node()->get_logger(), "Exception thrown during init stage with message: " << e.what());
-      return CallbackReturn::ERROR;
-    }
-
-    return CallbackReturn::SUCCESS;
+    sensor_state_publisher_ = get_node()->create_publisher<sensor_msgs::msg::MagneticField>(
+      "~/magnetic_field", rclcpp::SystemDefaultsQoS());
+    realtime_publisher_ = std::make_unique<StatePublisher>(sensor_state_publisher_);
+  }
+  catch (const std::exception & e)
+  {
+    RCLCPP_ERROR_STREAM(
+      get_node()->get_logger(),
+      "Exception thrown during publisher creation at configure stage with message: " << e.what());
+    return CallbackReturn::ERROR;
   }
 
-  controller_interface::CallbackReturn on_configure(
-    const rclcpp_lifecycle::State & /*previous_state*/) override
+  state_message_.header.frame_id = params_.frame_id;
+  std::copy(
+    params_.static_covariance.begin(), params_.static_covariance.end(),
+    state_message_.magnetic_field_covariance.begin());
+
+  return CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn MagnetometerBroadcaster::on_activate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  magnetometer_->assign_loaned_state_interfaces(state_interfaces_);
+  return CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn MagnetometerBroadcaster::on_deactivate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  magnetometer_->release_interfaces();
+  return CallbackReturn::SUCCESS;
+}
+
+controller_interface::return_type MagnetometerBroadcaster::update(
+  const rclcpp::Time & time, const rclcpp::Duration & /*period*/)
+{
+  magnetometer_->get_values_as_message(state_message_);
+
+  if (realtime_publisher_)
   {
-    try
-    {
-      params_ = param_listener_->get_params();
-    }
-    catch (const std::exception & e)
-    {
-      RCLCPP_ERROR_STREAM(
-        get_node()->get_logger(),
-        "Exception thrown during config stage with message: " << e.what());
-      return CallbackReturn::ERROR;
-    }
-
-    magnetometer_ = std::make_unique<semantic_components::MagneticFieldSensor>(params_.sensor_name);
-    try
-    {
-      sensor_state_publisher_ = get_node()->create_publisher<sensor_msgs::msg::MagneticField>(
-        "~/magnetic_field", rclcpp::SystemDefaultsQoS());
-      realtime_publisher_ = std::make_unique<StatePublisher>(sensor_state_publisher_);
-    }
-    catch (const std::exception & e)
-    {
-      RCLCPP_ERROR_STREAM(
-        get_node()->get_logger(),
-        "Exception thrown during publisher creation at configure stage with message: " << e.what());
-      return CallbackReturn::ERROR;
-    }
-
-    state_message_.header.frame_id = params_.frame_id;
-    std::copy(
-      params_.static_covariance.begin(), params_.static_covariance.end(),
-      state_message_.magnetic_field_covariance.begin());
-
-    return CallbackReturn::SUCCESS;
+    state_message_.header.stamp = time;
+    realtime_publisher_->try_publish(state_message_);
   }
 
-  controller_interface::CallbackReturn on_activate(
-    const rclcpp_lifecycle::State & /*previous_state*/) override
-  {
-    magnetometer_->assign_loaned_state_interfaces(state_interfaces_);
-    return CallbackReturn::SUCCESS;
-  }
-
-  controller_interface::CallbackReturn on_deactivate(
-    const rclcpp_lifecycle::State & /*previous_state*/) override
-  {
-    magnetometer_->release_interfaces();
-    return CallbackReturn::SUCCESS;
-  }
-
-  controller_interface::return_type update(
-    const rclcpp::Time & time, const rclcpp::Duration & /*period*/) override
-  {
-    magnetometer_->get_values_as_message(state_message_);
-
-    if (realtime_publisher_)
-    {
-      state_message_.header.stamp = time;
-      realtime_publisher_->try_publish(state_message_);
-    }
-
-    return controller_interface::return_type::OK;
-  }
-
-protected:
-  std::shared_ptr<ParamListener> param_listener_;
-  Params params_;
-
-  std::unique_ptr<semantic_components::MagneticFieldSensor> magnetometer_;
-
-  using StatePublisher = realtime_tools::RealtimePublisher<sensor_msgs::msg::MagneticField>;
-  rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr sensor_state_publisher_;
-  std::unique_ptr<StatePublisher> realtime_publisher_;
-  sensor_msgs::msg::MagneticField state_message_;
-};
+  return controller_interface::return_type::OK;
+}
 
 }  // namespace magnetometer_broadcaster
 

--- a/magnetometer_broadcaster/test/test_magnetometer_broadcaster.cpp
+++ b/magnetometer_broadcaster/test/test_magnetometer_broadcaster.cpp
@@ -19,11 +19,11 @@
 #include <gmock/gmock.h>
 #include <utility>
 
-#include <class_loader/class_loader.hpp>
 #include <controller_interface/controller_interface.hpp>
 #include <hardware_interface/loaned_state_interface.hpp>
 #include <hardware_interface/types/hardware_interface_return_values.hpp>
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
+#include <magnetometer_broadcaster/magnetometer_broadcaster.hpp>
 #include <magnetometer_broadcaster/magnetometer_broadcaster_parameters.hpp>
 #include <rclcpp/node.hpp>
 #include <rclcpp/wait_result_kind.hpp>
@@ -58,8 +58,7 @@ class MagnetometerBroadcasterTest : public ::testing::Test
 public:
   void SetUp()
   {
-    broadcaster = loader->createInstance<controller_interface::ControllerInterface>(
-      "magnetometer_broadcaster::MagnetometerBroadcaster");
+    broadcaster = std::make_shared<magnetometer_broadcaster::MagnetometerBroadcaster>();
   }
 
   void TearDown() { broadcaster.reset(); }
@@ -117,9 +116,6 @@ protected:
   hardware_interface::StateInterface::SharedPtr magnetic_field_z =
     std::make_shared<hardware_interface::StateInterface>(
       sensor_name_, "magnetic_field.z", &sensor_values_[2]);
-
-  std::unique_ptr<class_loader::ClassLoader> loader =
-    std::make_unique<class_loader::ClassLoader>(std::string{});
 
   controller_interface::ControllerInterfaceSharedPtr broadcaster = nullptr;
 };


### PR DESCRIPTION
## Description
Using the same pattern we have in all other tests, instantiating the class directly without using pluginlib.

:eyes: @christianrauch 

Fixes #2378, etc.
Fixes https://github.com/ros-controls/ros2_control_ci/issues/823, fixes https://github.com/ros-controls/ros2_control_ci/issues/824, fixes https://github.com/ros-controls/ros2_control_ci/issues/825, fixes https://github.com/ros-controls/ros2_control_ci/issues/828

### Is this user-facing behavior change?
no

### Did you use Generative AI?
Claude Sonnet 4.6