### PR TITLE
Simplify reduce_wheel_speed_until_steering_reached logic

### DIFF
--- a/steering_controllers_library/src/steering_kinematics.cpp
+++ b/steering_controllers_library/src/steering_kinematics.cpp
@@ -267,19 +267,15 @@ std::tuple<std::vector<double>, std::vector<double>> SteeringKinematics::get_com
     double phi_delta = abs(steer_pos_ - phi);
     double scale;
     const double min_phi_delta = M_PI / 6.;
+    const double max_phi_delta = 1.5608;
     if (phi_delta < min_phi_delta)
     {
       scale = 1;
     }
-    else if (phi_delta >= 1.5608)
-    {
-      // cos(1.5608) = 0.01
-      scale = 0.01 / cos(min_phi_delta);
-    }
     else
     {
       // TODO(anyone): find the best function, e.g convex power functions
-      scale = cos(phi_delta) / cos(min_phi_delta);
+      scale = cos(std::min(phi_delta, max_phi_delta)) / cos(min_phi_delta);
     }
     Ws *= scale;
   }


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

While checking https://github.com/ros-controls/ros2_controllers/pull/2392 I was confused by the code. I used the chance to simplify the logic a bit.

### Is this user-facing behavior change?
Minimal, the scale is continuous now as `cos(max_phi_delta) / cos(min_phi_delta)` is not exactly 0.01.

### Did you use Generative AI?

no

### Additional Information
