### PR TITLE
fix: update dead documentation links

### DIFF
--- a/motion_primitives_controllers/doc/README.md
+++ b/motion_primitives_controllers/doc/README.md
@@ -26,7 +26,7 @@ These interfaces are used to communicate the internal status of the hardware int
 - `ready_for_new_primitive`: Boolean flag indicating whether the interface is ready to receive a new motion primitive
 
 ## motion_primitives_forward_controller
-This controller provides an interface for sending motion primitives to an industrial robot controller using the `ExecuteMotionPrimitiveSequence.action` action from [control_msgs](https://github.com/ros-controls/control_msgs/blob/motion_primitives/control_msgs/action/ExecuteMotionPrimitiveSequence.action). The controller receives the primitives via the action interface and forwards them through command interfaces to the robot-specific hardware interface. Currently, hardware interfaces for [Universal Robots](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver) and [KUKA Robots](https://github.com/b-robotized-forks/kuka_experimental/tree/motion_primitive_kuka_driver) are implemented.
+This controller provides an interface for sending motion primitives to an industrial robot controller using the `ExecuteMotionPrimitiveSequence.action` action from [control_msgs](https://github.com/ros-controls/control_msgs/blob/master/control_msgs/action/ExecuteMotionPrimitiveSequence.action). The controller receives the primitives via the action interface and forwards them through command interfaces to the robot-specific hardware interface. Currently, hardware interfaces for [Universal Robots](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver) and [KUKA Robots](https://github.com/b-robotized-forks/kuka_experimental/tree/motion_primitive_kuka_driver) are implemented.
 
 - Supported motion primitives:
   - `LINEAR_JOINT`


### PR DESCRIPTION
Updates dead documentation links causing CI 404 failures:
* Fixes the `ExecuteMotionPrimitiveSequence.action` link by pointing to `master` (the `motion_primitives` branch was deleted post-merge [ros-controls/control_msgs#228](https://github.com/ros-controls/control_msgs/pull/228)).
* Updates hardcoded `control.ros.org/master` routes to `rolling`.

### Related Issue
Resolves #2397 