### PR TITLE
Trajectory blending with new trajectory deferral

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -48,6 +48,11 @@ joint_trajectory_controller
   up to the first waypoint will use the same interpolation as the rest of the trajectory. (`#2043
   <https://github.com/ros-controls/ros2_controllers/pull/2043>`_)
 * Added decelerate-to-stop functionality when a trajectory is canceled or preempted. Instead of immediately holding position, the controller can now smoothly decelerate each joint to a stop using the per-joint ``max_deceleration_on_cancel`` parameter. (`#2163 <https://github.com/ros-controls/ros2_controllers/pull/2163>`_)
+* Added trajectory deferral support via the ``allow_trajectory_replacement`` parameter. When enabled,
+  a trajectory with a future ``header.stamp`` is deferred: the currently active trajectory
+  continues executing until the start time arrives, then the new trajectory is installed.
+  This is a partial port of the ROS 1 trajectory replacement behavior.
+  (`#2401 <https://github.com/ros-controls/ros2_controllers/pull/2401>`_)
 
 pid_controller
 **************

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -50,7 +50,7 @@ joint_trajectory_controller
 * Added decelerate-to-stop functionality when a trajectory is canceled or preempted. Instead of immediately holding position, the controller can now smoothly decelerate each joint to a stop using the per-joint ``max_deceleration_on_cancel`` parameter. (`#2163 <https://github.com/ros-controls/ros2_controllers/pull/2163>`_)
 * Added trajectory deferral support via the ``allow_trajectory_replacement`` parameter. When enabled,
   a trajectory with a future ``header.stamp`` is deferred: the currently active trajectory
-  continues executing until the start time arrives, then the new trajectory is installed.
+  continues executing until the start time arrives, then the new trajectory is executed.
   This is a partial port of the ROS 1 trajectory replacement behavior.
   (`#2401 <https://github.com/ros-controls/ros2_controllers/pull/2401>`_)
 

--- a/joint_trajectory_controller/doc/trajectory.rst
+++ b/joint_trajectory_controller/doc/trajectory.rst
@@ -119,16 +119,16 @@ Joint trajectory messages allow to specify the time at which a new trajectory sh
   Partial support for this functionality has been ported to ROS 2 via the ``allow_trajectory_replacement`` parameter (see `#84 <https://github.com/ros-controls/ros2_controllers/issues/84>`__).
   When enabled, a trajectory arriving with a future ``header.stamp`` is deferred. The controller
   continues executing the active trajectory until the requested start time is reached, at which
-  point the new trajectory is installed and execution begins.
+  point the new trajectory is handled, and the execution begins.
 
   The current ROS 2 implementation differs from the legacy behavior described below in the following ways:
 
   + The controller does not splice or stitch the current and new trajectories together. At the handoff time, the new trajectory fully replaces the old one.
   + Omitted joints in a partial goal are filled with their current position at the handoff time (hold-in-place), rather than continuing to follow the old trajectory.
   + Only a single deferred trajectory is stored. A newer deferred trajectory overwrites any previously deferred one.
-  + When a new action goal is accepted and deferred, the currently active goal is immediately aborted instead of continuing to emit feedback until the handoff time.
+  + When a new action goal is accepted, the currently active goal is immediately aborted instead of continuing to emit feedback until the handoff time.
   + While a deferred action goal is waiting for its start time, it does not publish action feedback and is not evaluated for path tolerances.
-  + The handoff trigger uses the controller's wall-clock time. If the controller is running with a ``speed_scaling`` other than 1.0, the handoff may occur out of sync with the active trajectory's execution state.
+  + The handoff trigger uses the controller's clock time. If the controller is running with a ``speed_scaling`` other than 1.0, the handoff may occur out of sync with the active trajectory's execution state.
 
 The arrival of a new trajectory command does not necessarily mean that the controller will completely discard the currently running trajectory and substitute it with the new one.
 Rather, the controller will take the useful parts of both and combine them appropriately, yielding a smarter trajectory replacement strategy.

--- a/joint_trajectory_controller/doc/trajectory.rst
+++ b/joint_trajectory_controller/doc/trajectory.rst
@@ -115,10 +115,20 @@ Trajectory Replacement
 
 Joint trajectory messages allow to specify the time at which a new trajectory should start executing by means of the header timestamp, where zero time (the default) means "start now".
 
-.. warning::
+.. note::
+  Partial support for this functionality has been ported to ROS 2 via the ``allow_trajectory_replacement`` parameter (see `#84 <https://github.com/ros-controls/ros2_controllers/issues/84>`__).
+  When enabled, a trajectory arriving with a future ``header.stamp`` is deferred. The controller
+  continues executing the active trajectory until the requested start time is reached, at which
+  point the new trajectory is installed and execution begins.
 
-  As of now, this functionality is not ported to ROS 2, see `this issue <https://github.com/ros-controls/ros2_controllers/issues/84>`__ for more information.
-  The current implementation just forgets the old trajectory.
+  The current ROS 2 implementation differs from the legacy behavior described below in the following ways:
+
+  + The controller does not splice or stitch the current and new trajectories together. At the handoff time, the new trajectory fully replaces the old one.
+  + Omitted joints in a partial goal are filled with their current position at the handoff time (hold-in-place), rather than continuing to follow the old trajectory.
+  + Only a single deferred trajectory is stored. A newer deferred trajectory overwrites any previously deferred one.
+  + When a new action goal is accepted and deferred, the currently active goal is immediately aborted instead of continuing to emit feedback until the handoff time.
+  + While a deferred action goal is waiting for its start time, it does not publish action feedback and is not evaluated for path tolerances.
+  + The handoff trigger uses the controller's wall-clock time. If the controller is running with a ``speed_scaling`` other than 1.0, the handoff may occur out of sync with the active trajectory's execution state.
 
 The arrival of a new trajectory command does not necessarily mean that the controller will completely discard the currently running trajectory and substitute it with the new one.
 Rather, the controller will take the useful parts of both and combine them appropriately, yielding a smarter trajectory replacement strategy.

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -182,6 +182,14 @@ protected:
   realtime_tools::RealtimeBuffer<std::shared_ptr<trajectory_msgs::msg::JointTrajectory>>
     new_trajectory_msg_;
 
+  // Trajectory deferred until its future start time.
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> pending_traj_msg_ = nullptr;
+  rclcpp::Time pending_start_;
+  // Written by goal_cancelled_callback (non-RT), read in update() (RT) to drop pending.
+  std::atomic<bool> rt_clear_pending_{false};
+  // Suppresses feedback/tolerance/success for an action goal whose trajectory is still deferred.
+  std::atomic<bool> rt_active_goal_deferred_{false};
+
   std::shared_ptr<trajectory_msgs::msg::JointTrajectory> hold_position_msg_ptr_ = nullptr;
 
   using ControllerStateMsg = control_msgs::msg::JointTrajectoryControllerState;
@@ -233,6 +241,12 @@ protected:
   // sorts the joints of the incoming message to our local order
   void sort_to_local_joint_order(
     std::shared_ptr<trajectory_msgs::msg::JointTrajectory> trajectory_msg) const;
+  // true if msg is one of the internally generated hold/success/decelerate trajectories.
+  bool is_internal_hold(const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & msg) const
+  {
+    return msg == hold_position_msg_ptr_ ||
+           (stop_trajectory_ != nullptr && msg == stop_trajectory_);
+  }
   bool validate_trajectory_msg(const trajectory_msgs::msg::JointTrajectory & trajectory) const;
   void add_new_trajectory_msg(
     const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & traj_msg);

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -267,14 +267,59 @@ controller_interface::return_type JointTrajectoryController::update(
   // Check if a new trajectory message has been received from Non-RT threads
   const auto current_trajectory_msg = current_trajectory_->get_trajectory_msg();
   auto new_external_msg = new_trajectory_msg_.readFromRT();
+
+  // A cancel (goal_cancelled_callback) asked us to drop any deferred trajectory.
+  if (rt_clear_pending_.exchange(false))
+  {
+    pending_traj_msg_ = nullptr;
+    rt_active_goal_deferred_ = false;
+  }
+
+  // The trajectory message to be installed into current_trajectory_ this cycle (if any).
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> traj_msg_to_install = nullptr;
+
   // Discard, if a goal is pending but still not active (somewhere stuck in goal_handle_timer_)
   if (
-    current_trajectory_msg != *new_external_msg && (rt_has_pending_goal_ && !active_goal) == false)
+    current_trajectory_msg != *new_external_msg && *new_external_msg != pending_traj_msg_ &&
+    (rt_has_pending_goal_ && !active_goal) == false)
   {
-    fill_partial_goal(*new_external_msg);
-    sort_to_local_joint_order(*new_external_msg);
-    // TODO(denis): Add here integration of position and velocity
-    current_trajectory_->update(*new_external_msg);
+    if (is_internal_hold(*new_external_msg))
+    {
+      // Internal hold/success/decelerate: install but never cancel a deferred trajectory.
+      traj_msg_to_install = *new_external_msg;
+    }
+    else if (
+      params_.allow_trajectory_blending && has_active_trajectory() &&
+      rclcpp::Time((*new_external_msg)->header.stamp, time.get_clock_type()) > time)
+    {
+      // Future-stamped: defer until its start time, keep old trajectory running.
+      pending_traj_msg_ = *new_external_msg;
+      pending_start_ = rclcpp::Time((*new_external_msg)->header.stamp, time.get_clock_type());
+    }
+    else
+    {
+      // Immediate or blending off: install now, drop any previously deferred trajectory.
+      fill_partial_goal(*new_external_msg);
+      sort_to_local_joint_order(*new_external_msg);
+      traj_msg_to_install = *new_external_msg;
+      pending_traj_msg_ = nullptr;
+      rt_active_goal_deferred_ = false;
+    }
+  }
+
+  // FIRE: deferred trajectory's start time reached — install now.
+  if (pending_traj_msg_ && time >= pending_start_)
+  {
+    fill_partial_goal(pending_traj_msg_);
+    sort_to_local_joint_order(pending_traj_msg_);
+    traj_msg_to_install = pending_traj_msg_;
+    pending_traj_msg_ = nullptr;
+    rt_active_goal_deferred_ = false;
+  }
+
+  if (traj_msg_to_install)
+  {
+    current_trajectory_->update(traj_msg_to_install);
   }
 
   // current state update
@@ -460,7 +505,9 @@ controller_interface::return_type JointTrajectoryController::update(
         last_commanded_time_ = time;
       }
 
-      if (active_goal)
+      // Do not report on an action goal whose trajectory is still deferred (blending): its real
+      // trajectory has not started yet, so the old trajectory's progress must not succeed/abort it.
+      if (active_goal && !rt_active_goal_deferred_)
       {
         // send feedback
         auto feedback = std::make_shared<FollowJTrajAction::Feedback>();
@@ -1198,6 +1245,10 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
   current_trajectory_ = std::make_shared<Trajectory>();
   new_trajectory_msg_.writeFromNonRT(std::shared_ptr<trajectory_msgs::msg::JointTrajectory>());
 
+  pending_traj_msg_ = nullptr;
+  rt_active_goal_deferred_ = false;
+  rt_clear_pending_ = false;
+
   subscriber_is_active_ = true;
 
   // Initialize current state storage from hardware state interfaces
@@ -1342,6 +1393,10 @@ bool JointTrajectoryController::reset()
 
   current_trajectory_.reset();
 
+  pending_traj_msg_ = nullptr;
+  rt_active_goal_deferred_ = false;
+  rt_clear_pending_ = false;
+
   return true;
 }
 
@@ -1431,6 +1486,7 @@ rclcpp_action::CancelResponse JointTrajectoryController::goal_cancelled_callback
 
     // Mark the current goal as canceled
     rt_has_pending_goal_ = false;
+    rt_clear_pending_ = true;
     auto action_res = std::make_shared<FollowJTrajAction::Result>();
     active_goal->setCanceled(action_res);
     rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
@@ -1463,6 +1519,12 @@ void JointTrajectoryController::goal_accepted_callback(
 
     add_new_trajectory_msg(traj_msg);
     rt_is_holding_ = false;
+
+    // If blending is on and this goal starts in the future, its trajectory will be deferred by
+    // update(); mark it so the result/feedback block does not judge the goal before it starts.
+    const auto now = get_node()->now();
+    rt_active_goal_deferred_ = params_.allow_trajectory_blending && has_active_trajectory() &&
+                               rclcpp::Time(traj_msg->header.stamp, now.get_clock_type()) > now;
   }
 
   // Update the active goal

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1487,7 +1487,6 @@ rclcpp_action::CancelResponse JointTrajectoryController::goal_cancelled_callback
 
     // Mark the current goal as canceled
     rt_has_pending_goal_ = false;
-    rt_clear_pending_ = true;
     auto action_res = std::make_shared<FollowJTrajAction::Result>();
     active_goal->setCanceled(action_res);
     rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
@@ -1502,6 +1501,8 @@ rclcpp_action::CancelResponse JointTrajectoryController::goal_cancelled_callback
       // hold current position
       add_new_trajectory_msg(set_hold_position());
     }
+    // Written after add_new_trajectory_msg so the hold is visible before RT clears pending.
+    rt_clear_pending_ = true;
   }
   return rclcpp_action::CancelResponse::ACCEPT;
 }

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -289,7 +289,7 @@ controller_interface::return_type JointTrajectoryController::update(
       traj_msg_to_install = *new_external_msg;
     }
     else if (
-      params_.allow_trajectory_blending && has_active_trajectory() &&
+      params_.allow_trajectory_replacement && has_active_trajectory() &&
       rclcpp::Time((*new_external_msg)->header.stamp, time.get_clock_type()) > time)
     {
       // Future-stamped: defer until its start time, keep old trajectory running.
@@ -1525,7 +1525,7 @@ void JointTrajectoryController::goal_accepted_callback(
     // If blending is on, trajectory will be deferred by update(). Mark it so the result/feedback
     // block does not judge the goal before it starts.
     const auto now = get_node()->now();
-    rt_active_goal_deferred_ = params_.allow_trajectory_blending && has_active_trajectory() &&
+    rt_active_goal_deferred_ = params_.allow_trajectory_replacement && has_active_trajectory() &&
                                rclcpp::Time(traj_msg->header.stamp, now.get_clock_type()) > now;
   }
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -319,6 +319,7 @@ controller_interface::return_type JointTrajectoryController::update(
 
   if (traj_msg_to_install)
   {
+    // TODO(denis): Add here integration of position and velocity
     current_trajectory_->update(traj_msg_to_install);
   }
 
@@ -1520,8 +1521,7 @@ void JointTrajectoryController::goal_accepted_callback(
     add_new_trajectory_msg(traj_msg);
     rt_is_holding_ = false;
 
-    // If blending is on and this goal starts in the future, its trajectory will be deferred by
-    // update(); mark it so the result/feedback block does not judge the goal before it starts.
+    // If blending is on, trajectory will be deferred by update(). Mark it so the result/feedback block does not judge the goal before it starts.
     const auto now = get_node()->now();
     rt_active_goal_deferred_ = params_.allow_trajectory_blending && has_active_trajectory() &&
                                rclcpp::Time(traj_msg->header.stamp, now.get_clock_type()) > now;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1521,7 +1521,8 @@ void JointTrajectoryController::goal_accepted_callback(
     add_new_trajectory_msg(traj_msg);
     rt_is_holding_ = false;
 
-    // If blending is on, trajectory will be deferred by update(). Mark it so the result/feedback block does not judge the goal before it starts.
+    // If blending is on, trajectory will be deferred by update(). Mark it so the result/feedback
+    // block does not judge the goal before it starts.
     const auto now = get_node()->now();
     rt_active_goal_deferred_ = params_.allow_trajectory_blending && has_active_trajectory() &&
                                rclcpp::Time(traj_msg->header.stamp, now.get_clock_type()) > now;

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -97,6 +97,16 @@ joint_trajectory_controller:
     default_value: false,
     description: "Allow integration in goal trajectories to accept goals without position or velocity specified",
   }
+  allow_trajectory_blending: {
+    type: bool,
+    default_value: true,
+    description: "Port of the ROS 1 'update existing trajectory' behavior.
+      \n\n
+      If true (default), a trajectory whose ``header.stamp`` lies in the future is deferred: the
+      active trajectory keeps executing until that start time, then the new one is installed.
+      \n\n
+      If false, every incoming trajectory replaces the active one immediately (legacy behavior).",
+  }
   set_last_command_interface_value_as_state_on_activation: {
     type: bool,
     default_value: true,

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -97,7 +97,7 @@ joint_trajectory_controller:
     default_value: false,
     description: "Allow integration in goal trajectories to accept goals without position or velocity specified",
   }
-  allow_trajectory_blending: {
+  allow_trajectory_replacement: {
     type: bool,
     default_value: true,
     description: "Port of the ROS 1 'update existing trajectory' behavior.

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -1470,7 +1470,7 @@ INSTANTIATE_TEST_SUITE_P(
  */
 TEST_F(TestTrajectoryActions, blend_cancel_deferred_action_goal)
 {
-  SetUpExecutor({rclcpp::Parameter("allow_trajectory_blending", true)});
+  SetUpExecutor({rclcpp::Parameter("allow_trajectory_replacement", true)});
 
   setup_controller_hw_ = true;
   controller_hw_thread_ = std::thread(
@@ -1536,7 +1536,7 @@ TEST_F(TestTrajectoryActions, blend_cancel_deferred_action_goal)
  */
 TEST_F(TestTrajectoryActions, blend_action_replaces_action_with_future_stamp)
 {
-  SetUpExecutor({rclcpp::Parameter("allow_trajectory_blending", true)});
+  SetUpExecutor({rclcpp::Parameter("allow_trajectory_replacement", true)});
 
   setup_controller_hw_ = true;
   controller_hw_thread_ = std::thread(
@@ -1602,7 +1602,7 @@ TEST_F(TestTrajectoryActions, blend_action_replaces_action_with_future_stamp)
  */
 TEST_F(TestTrajectoryActions, blend_topic_preempts_deferred_action_goal)
 {
-  SetUpExecutor({rclcpp::Parameter("allow_trajectory_blending", true)});
+  SetUpExecutor({rclcpp::Parameter("allow_trajectory_replacement", true)});
 
   setup_controller_hw_ = true;
   controller_hw_thread_ = std::thread(
@@ -1670,7 +1670,7 @@ TEST_F(TestTrajectoryActions, blend_topic_preempts_deferred_action_goal)
  */
 TEST_F(TestTrajectoryActions, blend_deactivate_aborts_deferred_action_goal)
 {
-  SetUpExecutor({rclcpp::Parameter("allow_trajectory_blending", true)});
+  SetUpExecutor({rclcpp::Parameter("allow_trajectory_replacement", true)});
 
   setup_controller_hw_ = true;
   controller_hw_thread_ = std::thread(

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -1463,3 +1463,260 @@ TEST_P(TestTrajectoryActionsTestScalingFactor, test_scaling_sampling_is_correct)
 
 INSTANTIATE_TEST_SUITE_P(
   ScaledJTCTests, TestTrajectoryActionsTestScalingFactor, ::testing::Values(0.25, 0.87, 1.0, 2.0));
+
+/**
+ * @brief Cancelling a deferred goal before its fire time yields CANCELED and prevents
+ * the trajectory from executing.
+ */
+TEST_F(TestTrajectoryActions, blend_cancel_deferred_action_goal)
+{
+  SetUpExecutor({rclcpp::Parameter("allow_trajectory_blending", true)});
+
+  setup_controller_hw_ = true;
+  controller_hw_thread_ = std::thread(
+    [&]()
+    {
+      auto clock = rclcpp::Clock(RCL_ROS_TIME);
+      auto now_time = clock.now();
+      auto last_time = now_time;
+      const auto end_time = now_time + rclcpp::Duration::from_seconds(3.0);
+      while (clock.now() < end_time)
+      {
+        now_time = clock.now();
+        traj_controller_->update(now_time, now_time - last_time);
+        last_time = now_time;
+      }
+    });
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  {
+    std::vector<JointTrajectoryPoint> points_a(1);
+    points_a[0].time_from_start = rclcpp::Duration::from_seconds(2.0);
+    points_a[0].positions = {4.0, 5.0, 6.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_a;
+    goal_a.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_a.trajectory.joint_names = joint_names_;
+    goal_a.trajectory.points = points_a;
+    action_client_->async_send_goal(goal_a, goal_options_);
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  rclcpp_action::ResultCode resultcode_b = rclcpp_action::ResultCode::UNKNOWN;
+  std::shared_future<typename GoalHandle::SharedPtr> gh_b;
+  {
+    std::vector<JointTrajectoryPoint> points_b(1);
+    points_b[0].time_from_start = rclcpp::Duration::from_seconds(0.4);
+    points_b[0].positions = {7.0, 8.0, 9.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_b;
+    goal_b.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_b.trajectory.joint_names = joint_names_;
+    goal_b.trajectory.points = points_b;
+    goal_b.trajectory.header.stamp =
+      traj_controller_->get_node()->now() + rclcpp::Duration::from_seconds(0.5);
+    GoalOptions opts_b;
+    opts_b.result_callback = [&resultcode_b](const GoalHandle::WrappedResult & r)
+    { resultcode_b = r.code; };
+    gh_b = action_client_->async_send_goal(goal_b, opts_b);
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));  // well before 500 ms fire time
+  auto goal_handle_b = gh_b.get();
+  ASSERT_TRUE(goal_handle_b);
+  action_client_->async_cancel_goal(goal_handle_b);
+
+  controller_hw_thread_.join();
+
+  EXPECT_EQ(rclcpp_action::ResultCode::CANCELED, resultcode_b);
+}
+
+/**
+ * @brief Accepting future-stamped goal B while A executes immediately preempts A (ABORTED —
+ * server-side preemption in ROS 2). The old trajectory continues until B's stamp, then B
+ * executes and completes with SUCCEEDED. Mirrors ROS 1's executePartialActionTrajInFuture.
+ */
+TEST_F(TestTrajectoryActions, blend_action_replaces_action_with_future_stamp)
+{
+  SetUpExecutor({rclcpp::Parameter("allow_trajectory_blending", true)});
+
+  setup_controller_hw_ = true;
+  controller_hw_thread_ = std::thread(
+    [&]()
+    {
+      auto clock = rclcpp::Clock(RCL_ROS_TIME);
+      auto now_time = clock.now();
+      auto last_time = now_time;
+      const auto end_time = now_time + rclcpp::Duration::from_seconds(3.0);
+      while (clock.now() < end_time)
+      {
+        now_time = clock.now();
+        traj_controller_->update(now_time, now_time - last_time);
+        last_time = now_time;
+      }
+    });
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  rclcpp_action::ResultCode resultcode_a = rclcpp_action::ResultCode::UNKNOWN;
+  {
+    std::vector<JointTrajectoryPoint> points_a(1);
+    points_a[0].time_from_start = rclcpp::Duration::from_seconds(2.0);
+    points_a[0].positions = {4.0, 5.0, 6.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_a;
+    goal_a.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_a.trajectory.joint_names = joint_names_;
+    goal_a.trajectory.points = points_a;
+    GoalOptions opts_a;
+    opts_a.result_callback = [&resultcode_a](const GoalHandle::WrappedResult & r)
+    { resultcode_a = r.code; };
+    action_client_->async_send_goal(goal_a, opts_a);
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  rclcpp_action::ResultCode resultcode_b = rclcpp_action::ResultCode::UNKNOWN;
+  {
+    std::vector<JointTrajectoryPoint> points_b(1);
+    points_b[0].time_from_start = rclcpp::Duration::from_seconds(0.4);
+    points_b[0].positions = {7.0, 8.0, 9.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_b;
+    goal_b.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_b.trajectory.joint_names = joint_names_;
+    goal_b.trajectory.points = points_b;
+    goal_b.trajectory.header.stamp =
+      traj_controller_->get_node()->now() + rclcpp::Duration::from_seconds(0.4);
+    GoalOptions opts_b;
+    opts_b.result_callback = [&resultcode_b](const GoalHandle::WrappedResult & r)
+    { resultcode_b = r.code; };
+    action_client_->async_send_goal(goal_b, opts_b);
+  }
+
+  controller_hw_thread_.join();
+
+  EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, resultcode_a);
+  EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, resultcode_b);
+}
+
+/**
+ * @brief A stamp=0 topic trajectory preempts a deferred action goal at the trajectory level:
+ * the topic trajectory installs immediately and the deferred goal never fires.
+ * NOTE: the action goal handle is not formally canceled on topic preemption — that
+ * cross-interface preemption gap is pre-existing; this test covers trajectory behavior only.
+ */
+TEST_F(TestTrajectoryActions, blend_topic_preempts_deferred_action_goal)
+{
+  SetUpExecutor({rclcpp::Parameter("allow_trajectory_blending", true)});
+
+  setup_controller_hw_ = true;
+  controller_hw_thread_ = std::thread(
+    [&]()
+    {
+      auto clock = rclcpp::Clock(RCL_ROS_TIME);
+      auto now_time = clock.now();
+      auto last_time = now_time;
+      const auto end_time = now_time + rclcpp::Duration::from_seconds(3.0);
+      while (clock.now() < end_time)
+      {
+        now_time = clock.now();
+        traj_controller_->update(now_time, now_time - last_time);
+        last_time = now_time;
+      }
+    });
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  {
+    std::vector<JointTrajectoryPoint> points_init(1);
+    points_init[0].time_from_start = rclcpp::Duration::from_seconds(2.0);
+    points_init[0].positions = {4.0, 5.0, 6.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_init;
+    goal_init.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_init.trajectory.joint_names = joint_names_;
+    goal_init.trajectory.points = points_init;
+    action_client_->async_send_goal(goal_init, goal_options_);
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  {
+    std::vector<JointTrajectoryPoint> points_a(1);
+    points_a[0].time_from_start = rclcpp::Duration::from_seconds(0.5);
+    points_a[0].positions = {7.0, 8.0, 9.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_a;
+    goal_a.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_a.trajectory.joint_names = joint_names_;
+    goal_a.trajectory.points = points_a;
+    goal_a.trajectory.header.stamp =
+      traj_controller_->get_node()->now() + rclcpp::Duration::from_seconds(1.0);
+    action_client_->async_send_goal(goal_a, goal_options_);
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  const builtin_interfaces::msg::Duration half_s{rclcpp::Duration::from_seconds(0.5)};
+  std::vector<std::vector<double>> topic_traj{{{-1., -2., -3.}}};
+  publish(half_s, topic_traj, rclcpp::Time());
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  controller_hw_thread_.join();
+
+  if (traj_controller_->has_position_command_interface())
+  {
+    const auto state = traj_controller_->get_state_reference();
+    EXPECT_NEAR(-1., state.positions[0], 0.2);
+    EXPECT_NEAR(-2., state.positions[1], 0.2);
+    EXPECT_NEAR(-3., state.positions[2], 0.2);
+  }
+}
+
+/**
+ * @brief Deactivating the controller while an action goal is deferred (future-stamped, not yet
+ * fired) must report ABORTED — the goal never executed and the controller is going inactive.
+ * Deactivation at 0.3 s fires before the deferred goal's start at 0.5 s.
+ */
+TEST_F(TestTrajectoryActions, blend_deactivate_aborts_deferred_action_goal)
+{
+  SetUpExecutor({rclcpp::Parameter("allow_trajectory_blending", true)});
+
+  setup_controller_hw_ = true;
+  controller_hw_thread_ = std::thread(
+    [&]()
+    {
+      auto clock = rclcpp::Clock(RCL_ROS_TIME);
+      auto now_time = clock.now();
+      auto last_time = now_time;
+      const auto end_time = now_time + rclcpp::Duration::from_seconds(0.3);
+      while (clock.now() < end_time)
+      {
+        now_time = clock.now();
+        traj_controller_->update(now_time, now_time - last_time);
+        last_time = now_time;
+      }
+      traj_controller_->get_node()->deactivate();
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    });
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  {
+    std::vector<JointTrajectoryPoint> points_a(1);
+    points_a[0].time_from_start = rclcpp::Duration::from_seconds(1.0);
+    points_a[0].positions = {4.0, 5.0, 6.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_a;
+    goal_a.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_a.trajectory.joint_names = joint_names_;
+    goal_a.trajectory.points = points_a;
+    action_client_->async_send_goal(goal_a, goal_options_);
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  {
+    std::vector<JointTrajectoryPoint> points_b(1);
+    points_b[0].time_from_start = rclcpp::Duration::from_seconds(0.4);
+    points_b[0].positions = {7.0, 8.0, 9.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_b;
+    goal_b.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_b.trajectory.joint_names = joint_names_;
+    goal_b.trajectory.points = points_b;
+    goal_b.trajectory.header.stamp =
+      traj_controller_->get_node()->now() + rclcpp::Duration::from_seconds(0.5);
+    action_client_->async_send_goal(goal_b, goal_options_);
+  }
+
+  controller_hw_thread_.join();
+
+  EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, common_resultcode_);
+}

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -1493,11 +1493,7 @@ TEST_F(TestTrajectoryActions, blend_cancel_deferred_action_goal)
     std::vector<JointTrajectoryPoint> points_a(1);
     points_a[0].time_from_start = rclcpp::Duration::from_seconds(2.0);
     points_a[0].positions = {4.0, 5.0, 6.0};
-    control_msgs::action::FollowJointTrajectory_Goal goal_a;
-    goal_a.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
-    goal_a.trajectory.joint_names = joint_names_;
-    goal_a.trajectory.points = points_a;
-    action_client_->async_send_goal(goal_a, goal_options_);
+    sendActionGoal(points_a, 1.0, goal_options_);
   }
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
@@ -1526,6 +1522,7 @@ TEST_F(TestTrajectoryActions, blend_cancel_deferred_action_goal)
 
   controller_hw_thread_.join();
 
+  EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, common_resultcode_);
   EXPECT_EQ(rclcpp_action::ResultCode::CANCELED, resultcode_b);
 }
 
@@ -1560,14 +1557,10 @@ TEST_F(TestTrajectoryActions, blend_action_replaces_action_with_future_stamp)
     std::vector<JointTrajectoryPoint> points_a(1);
     points_a[0].time_from_start = rclcpp::Duration::from_seconds(2.0);
     points_a[0].positions = {4.0, 5.0, 6.0};
-    control_msgs::action::FollowJointTrajectory_Goal goal_a;
-    goal_a.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
-    goal_a.trajectory.joint_names = joint_names_;
-    goal_a.trajectory.points = points_a;
     GoalOptions opts_a;
     opts_a.result_callback = [&resultcode_a](const GoalHandle::WrappedResult & r)
     { resultcode_a = r.code; };
-    action_client_->async_send_goal(goal_a, opts_a);
+    sendActionGoal(points_a, 1.0, opts_a);
   }
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
@@ -1621,15 +1614,12 @@ TEST_F(TestTrajectoryActions, blend_topic_preempts_deferred_action_goal)
     });
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
+  // goal_init establishes an active trajectory; deferral only triggers when has_active_trajectory()
   {
     std::vector<JointTrajectoryPoint> points_init(1);
     points_init[0].time_from_start = rclcpp::Duration::from_seconds(2.0);
     points_init[0].positions = {4.0, 5.0, 6.0};
-    control_msgs::action::FollowJointTrajectory_Goal goal_init;
-    goal_init.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
-    goal_init.trajectory.joint_names = joint_names_;
-    goal_init.trajectory.points = points_init;
-    action_client_->async_send_goal(goal_init, goal_options_);
+    sendActionGoal(points_init, 1.0, goal_options_);
   }
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
@@ -1666,7 +1656,7 @@ TEST_F(TestTrajectoryActions, blend_topic_preempts_deferred_action_goal)
 /**
  * @brief Deactivating the controller while an action goal is deferred (future-stamped, not yet
  * fired) must report ABORTED — the goal never executed and the controller is going inactive.
- * Deactivation at 0.3 s fires before the deferred goal's start at 0.5 s.
+ * Deactivation at 0.5 s fires before the deferred goal's start at 0.8 s.
  */
 TEST_F(TestTrajectoryActions, blend_deactivate_aborts_deferred_action_goal)
 {
@@ -1679,7 +1669,7 @@ TEST_F(TestTrajectoryActions, blend_deactivate_aborts_deferred_action_goal)
       auto clock = rclcpp::Clock(RCL_ROS_TIME);
       auto now_time = clock.now();
       auto last_time = now_time;
-      const auto end_time = now_time + rclcpp::Duration::from_seconds(0.3);
+      const auto end_time = now_time + rclcpp::Duration::from_seconds(0.5);
       while (clock.now() < end_time)
       {
         now_time = clock.now();
@@ -1689,17 +1679,14 @@ TEST_F(TestTrajectoryActions, blend_deactivate_aborts_deferred_action_goal)
       traj_controller_->get_node()->deactivate();
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
     });
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
+  // goal_a establishes an active trajectory; deferral only triggers when has_active_trajectory()
   {
     std::vector<JointTrajectoryPoint> points_a(1);
     points_a[0].time_from_start = rclcpp::Duration::from_seconds(1.0);
     points_a[0].positions = {4.0, 5.0, 6.0};
-    control_msgs::action::FollowJointTrajectory_Goal goal_a;
-    goal_a.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
-    goal_a.trajectory.joint_names = joint_names_;
-    goal_a.trajectory.points = points_a;
-    action_client_->async_send_goal(goal_a, goal_options_);
+    sendActionGoal(points_a, 1.0, goal_options_);
   }
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
@@ -1712,7 +1699,7 @@ TEST_F(TestTrajectoryActions, blend_deactivate_aborts_deferred_action_goal)
     goal_b.trajectory.joint_names = joint_names_;
     goal_b.trajectory.points = points_b;
     goal_b.trajectory.header.stamp =
-      traj_controller_->get_node()->now() + rclcpp::Duration::from_seconds(0.5);
+      traj_controller_->get_node()->now() + rclcpp::Duration::from_seconds(0.8);
     action_client_->async_send_goal(goal_b, goal_options_);
   }
 

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -3299,6 +3299,5 @@ TEST_F(TrajectoryControllerTest, blend_partial_goal_fill_uses_fire_time_state)
     EXPECT_NEAR(2.0, state.positions[0], 0.15);
     EXPECT_NEAR(2.5, state.positions[1], 0.15);
     EXPECT_NEAR(4.55, state.positions[2], 0.25);
-    EXPECT_GT(state.positions[2], 4.1);  // clearly above receive-time value ≈3.73
   }
 }

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -2064,7 +2064,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_ignore_partial_old_trajectory
 TEST_P(TrajectoryControllerTestParameterized, test_execute_partial_traj_in_future)
 {
   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
-  rclcpp::Parameter blending_parameters("allow_trajectory_blending", true);
+  rclcpp::Parameter blending_parameters("allow_trajectory_replacement", true);
   rclcpp::executors::SingleThreadedExecutor executor;
   SetUpAndActivateTrajectoryController(executor, {partial_joints_parameters, blending_parameters});
 
@@ -3232,7 +3232,7 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_velocity_command_ra
 }
 
 // ===========================================================================
-// Trajectory deferral tests (allow_trajectory_blending)
+// Trajectory deferral tests (allow_trajectory_replacement)
 // ===========================================================================
 
 /**
@@ -3243,7 +3243,7 @@ TEST_F(TrajectoryControllerTest, blend_stamp0_preempts_pending)
 {
   rclcpp::executors::SingleThreadedExecutor executor;
   SetUpAndActivateTrajectoryController(
-    executor, {rclcpp::Parameter("allow_trajectory_blending", true)});
+    executor, {rclcpp::Parameter("allow_trajectory_replacement", true)});
 
   const rclcpp::Time start_time = traj_controller_->get_node()->now();
   const builtin_interfaces::msg::Duration step{rclcpp::Duration::from_seconds(0.5)};
@@ -3269,7 +3269,7 @@ TEST_F(TrajectoryControllerTest, blend_partial_goal_fill_uses_fire_time_state)
 {
   rclcpp::executors::SingleThreadedExecutor executor;
   SetUpAndActivateTrajectoryController(
-    executor, {rclcpp::Parameter("allow_trajectory_blending", true),
+    executor, {rclcpp::Parameter("allow_trajectory_replacement", true),
                rclcpp::Parameter("allow_partial_joints_goal", true)});
 
   const rclcpp::Time start_time = traj_controller_->get_node()->now();

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -2064,15 +2064,9 @@ TEST_P(TrajectoryControllerTestParameterized, test_ignore_partial_old_trajectory
 TEST_P(TrajectoryControllerTestParameterized, test_execute_partial_traj_in_future)
 {
   rclcpp::Parameter partial_joints_parameters("allow_partial_joints_goal", true);
+  rclcpp::Parameter blending_parameters("allow_trajectory_blending", true);
   rclcpp::executors::SingleThreadedExecutor executor;
-  SetUpAndActivateTrajectoryController(executor, {partial_joints_parameters});
-
-  RCLCPP_WARN(
-    traj_controller_->get_node()->get_logger(),
-    "Test disabled until current_trajectory is taken into account when adding a new trajectory.");
-  // https://github.com/ros-controls/ros_controllers/blob/melodic-devel/
-  // joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h#L149
-  return;
+  SetUpAndActivateTrajectoryController(executor, {partial_joints_parameters, blending_parameters});
 
   // *INDENT-OFF*
   std::vector<std::vector<double>> full_traj{{{2., 3., 4.}, {4., 6., 8.}}};
@@ -2082,24 +2076,24 @@ TEST_P(TrajectoryControllerTestParameterized, test_execute_partial_traj_in_futur
   // *INDENT-ON*
   const auto delay = std::chrono::milliseconds(500);
   builtin_interfaces::msg::Duration points_delay{rclcpp::Duration(delay)};
-  // Send full trajectory
+
+  // Use node clock so future-stamped publish and controller update() share the same time base.
+  const rclcpp::Time start_time = traj_controller_->get_node()->now();
+
   publish(points_delay, full_traj, rclcpp::Time(), {}, full_traj_velocities);
-  // Sleep until first waypoint of full trajectory
 
   trajectory_msgs::msg::JointTrajectoryPoint expected_actual, expected_desired;
   expected_actual.positions = {full_traj[0].begin(), full_traj[0].end()};
   expected_desired = expected_actual;
-  //  Check that we reached end of points_old[0]trajectory and are starting points_old[1]
-  auto end_time =
-    waitAndCompareState(expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1);
+  auto end_time = waitAndCompareState(
+    expected_actual, expected_desired, executor, rclcpp::Duration(delay), 0.1, start_time);
 
-  // Send partial trajectory starting after full trajecotry is complete
   RCLCPP_INFO(traj_controller_->get_node()->get_logger(), "Sending new trajectory in the future");
   publish(
-    points_delay, partial_traj, rclcpp::Clock(RCL_STEADY_TIME).now() + delay * 2, {},
+    points_delay, partial_traj, end_time + rclcpp::Duration(delay * 2), {},
     partial_traj_velocities);
-  // Wait until the end start and end of partial traj
 
+  // joints 0 and 1 follow partial_traj; joint 2 holds at full_traj's last position
   expected_actual.positions = {partial_traj.back()[0], partial_traj.back()[1], full_traj.back()[2]};
   expected_desired = expected_actual;
 

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -3230,3 +3230,75 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_velocity_command_ra
 
   executor.cancel();
 }
+
+// ===========================================================================
+// Trajectory deferral tests (allow_trajectory_blending)
+// ===========================================================================
+
+/**
+ * @brief A stamp=0 trajectory arriving while a deferred trajectory is pending must drop the
+ * pending one and install itself immediately, even well past the pending's fire time.
+ */
+TEST_F(TrajectoryControllerTest, blend_stamp0_preempts_pending)
+{
+  rclcpp::executors::SingleThreadedExecutor executor;
+  SetUpAndActivateTrajectoryController(
+    executor, {rclcpp::Parameter("allow_trajectory_blending", true)});
+
+  const rclcpp::Time start_time = traj_controller_->get_node()->now();
+  const builtin_interfaces::msg::Duration step{rclcpp::Duration::from_seconds(0.5)};
+
+  std::vector<std::vector<double>> traj_a{{{2., 3., 4.}}};
+  publish(step, traj_a, start_time + rclcpp::Duration::from_seconds(2.0));
+  traj_controller_->wait_for_trajectory(executor);
+  auto t1 = updateControllerAsync(rclcpp::Duration::from_seconds(0.01), start_time);
+
+  std::vector<std::vector<double>> traj_b{{{5., 6., 7.}}};
+  publish(step, traj_b, rclcpp::Time());
+
+  trajectory_msgs::msg::JointTrajectoryPoint expected;
+  expected.positions = {5., 6., 7.};
+  waitAndCompareState(expected, expected, executor, rclcpp::Duration::from_seconds(3.0), 0.1, t1);
+}
+
+/**
+ * @brief fill_partial_goal() for a deferred partial trajectory is called at FIRE time,
+ * not at receive time. The omitted joint holds the position it had when the trajectory fired.
+ */
+TEST_F(TrajectoryControllerTest, blend_partial_goal_fill_uses_fire_time_state)
+{
+  rclcpp::executors::SingleThreadedExecutor executor;
+  SetUpAndActivateTrajectoryController(
+    executor, {rclcpp::Parameter("allow_trajectory_blending", true),
+               rclcpp::Parameter("allow_partial_joints_goal", true)});
+
+  const rclcpp::Time start_time = traj_controller_->get_node()->now();
+
+  // joint3: initial 3.1 → 6.0 over 1 s. Cubic spline values used in assertions:
+  //   t=0.3 s (receive time): ≈ 3.73
+  //   t=0.5 s (FIRE time):    ≈ 4.55
+  const builtin_interfaces::msg::Duration one_s{rclcpp::Duration::from_seconds(1.0)};
+  std::vector<std::vector<double>> old_traj{{{4.0, 5.0, 6.0}}};
+  publish(one_s, old_traj, rclcpp::Time());
+  traj_controller_->wait_for_trajectory(executor);
+
+  auto t_receive = updateControllerAsync(rclcpp::Duration::from_seconds(0.3), start_time);
+
+  const builtin_interfaces::msg::Duration half_s{rclcpp::Duration::from_seconds(0.5)};
+  std::vector<std::vector<double>> partial_traj{{{2.0, 2.5}}};
+  publish(half_s, partial_traj, start_time + rclcpp::Duration::from_seconds(0.5));
+  traj_controller_->wait_for_trajectory(executor);
+
+  auto t_parked = updateControllerAsync(rclcpp::Duration::from_seconds(0.01), t_receive);
+  updateControllerAsync(rclcpp::Duration::from_seconds(0.8), t_parked);
+
+  // joint3 must be near FIRE-time value (≈4.55), not receive-time value (≈3.73).
+  if (traj_controller_->has_position_command_interface())
+  {
+    auto state = traj_controller_->get_state_reference();
+    EXPECT_NEAR(2.0, state.positions[0], 0.15);
+    EXPECT_NEAR(2.5, state.positions[1], 0.15);
+    EXPECT_NEAR(4.55, state.positions[2], 0.25);
+    EXPECT_GT(state.positions[2], 4.1);  // clearly above receive-time value ≈3.73
+  }
+}

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -594,7 +594,7 @@ public:
     rclcpp::Time start_time = rclcpp::Time(0, 0, RCL_STEADY_TIME),
     const rclcpp::Duration update_rate = rclcpp::Duration::from_seconds(0.01))
   {
-    if (start_time == rclcpp::Time(0, 0, RCL_STEADY_TIME))
+    if (start_time.nanoseconds() == 0)
     {
       start_time = rclcpp::Clock(RCL_STEADY_TIME).now();
     }


### PR DESCRIPTION
## Description

Partial port of the ROS 1 "update existing trajectory" behavior to ROS 2 joint_trajectory_controller.

Related to #84 

What this PR does:

- Adds a new parameter allow_trajectory_blending (default: true)
- When enabled, a trajectory with a future header.stamp is deferred: the currently active trajectory continues executing until that start time arrives, then the new trajectory is installed
- This eliminates the legacy behavior where a future-stamped trajectory would immediately kill the active trajectory and create a slow spline ramp to the first point
- Deferred trajectories are correctly dropped on goal cancellation, controller deactivation, and controller reset
- Action Server feedback/tolerance checking is suppressed during the deferral period to prevent spurious aborts
- Immediate trajectories (stamp = 0 or stamp <= now) behave exactly as before (no behavioral change)

What this PR does NOT target: ( Compared to ROS1 blending feature )
- Does not allow omitted joints to continue their old trajectory after the new one starts (ROS 1 full blend). Omitted joints freeze at their current position via fill_partial_goal(), same as legacy ROS 2 behavior
- Does not handle speed scaling during the deferral period. The trigger uses wall-clock time, so if speed_scaling != 1.0, there will be a positional mismatch at handoff
- Does not track multiple action goals simultaneously. The new goal immediately preempts the old one at the Action Server level; only the physical trajectory execution is deferred


### Is this user-facing behavior change?

Yes. When allow_trajectory_blending is true (default), the active trajectory will continue running until the new trajectory's start time.

### Did you use Generative AI?

Yes, Google Gemini and Claude were used to make improvements in manually written code, architectural analysis, edge-case review. 

### Additional Information

- The existing disabled test test_execute_partial_traj_in_future referenced in #84 has been enabled and passes

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
