### PR TITLE
rqt-jtc: Add launch test

### DIFF
--- a/rqt_joint_trajectory_controller/package.xml
+++ b/rqt_joint_trajectory_controller/package.xml
@@ -32,6 +32,8 @@
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>qt_gui</exec_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/rqt_joint_trajectory_controller/plugin.xml
+++ b/rqt_joint_trajectory_controller/plugin.xml
@@ -12,7 +12,7 @@
         <statustip>Plugins related to robot tools.</statustip>
       </group>
       <label>Joint trajectory controller</label>
-      <icon>resource/scope.png</icon>
+      <icon type="file">resource/scope.png</icon>
       <statustip>
         Monitor and send commands to running joint trajectory controllers.
       </statustip>

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -176,8 +176,8 @@ class JointTrajectoryController(Plugin):
         # Signal connections
         w = self._widget
         w.enable_button.toggled.connect(self._on_jtc_enabled)
-        w.jtc_combo.currentIndexChanged[str].connect(self._on_jtc_change)
-        w.cm_combo.currentIndexChanged[str].connect(self._on_cm_change)
+        w.jtc_combo.currentTextChanged.connect(self._on_jtc_change)
+        w.cm_combo.currentTextChanged.connect(self._on_cm_change)
 
         self._cmd_pub = None  # Controller command publisher
         self._state_sub = None  # Controller state subscriber
@@ -456,7 +456,7 @@ class JointTrajectoryController(Plugin):
         widgets = []
         layout = self._widget.joint_group.layout()
         for row_id in range(layout.rowCount()):
-            widgets.append(layout.itemAt(row_id, QFormLayout.FieldRole).widget())
+            widgets.append(layout.itemAt(row_id, QFormLayout.ItemRole.FieldRole).widget())
         return widgets
 
 

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -21,7 +21,9 @@ from ament_index_python.packages import get_package_share_directory
 
 from qt_gui.plugin import Plugin
 from python_qt_binding import loadUi
-from python_qt_binding.QtCore import QTimer, Signal
+from python_qt_binding.QtCore import QTimer, Signal, Qt
+from python_qt_binding.QtGui import QIcon, QPainter, QPixmap
+from python_qt_binding.QtSvg import QSvgRenderer
 from python_qt_binding.QtWidgets import QWidget, QFormLayout
 
 from control_msgs.msg import JointTrajectoryControllerState
@@ -114,6 +116,15 @@ class JointTrajectoryController(Plugin):
         )
         loadUi(ui_file, self._widget)
         self._widget.setObjectName("JointTrajectoryControllerUi")
+
+        # Use the original icon assets from package resources.
+        icon_path = get_package_share_directory("rqt_joint_trajectory_controller") + "/resource"
+        enable_icon = self._load_enable_icon(
+            f"{icon_path}/off.svg",
+            f"{icon_path}/on.svg",
+        )
+        self._widget.enable_button.setIcon(enable_icon)
+
         ns = self._node.get_namespace()[1:-1]
         self._widget.controller_group.setTitle("ns: " + ns)
 
@@ -303,6 +314,32 @@ class JointTrajectoryController(Plugin):
         self._jtc_name = jtc_name
         if self._jtc_name:
             self._load_jtc()
+
+    def _load_enable_icon(self, off_path, on_path):
+        icon = QIcon()
+        icon.addFile(off_path, mode=QIcon.Mode.Normal, state=QIcon.State.Off)
+        icon.addFile(on_path, mode=QIcon.Mode.Normal, state=QIcon.State.On)
+
+        # Some Qt setups do not decode SVGs through QIcon; render them via QSvgRenderer.
+        if icon.isNull():
+            off_pixmap = self._render_svg(off_path)
+            on_pixmap = self._render_svg(on_path)
+            if off_pixmap is not None:
+                icon.addPixmap(off_pixmap, mode=QIcon.Mode.Normal, state=QIcon.State.Off)
+            if on_pixmap is not None:
+                icon.addPixmap(on_pixmap, mode=QIcon.Mode.Normal, state=QIcon.State.On)
+        return icon
+
+    def _render_svg(self, path, size=48):
+        renderer = QSvgRenderer(path)
+        if not renderer.isValid():
+            return None
+        pixmap = QPixmap(size, size)
+        pixmap.fill(Qt.GlobalColor.transparent)
+        painter = QPainter(pixmap)
+        renderer.render(painter)
+        painter.end()
+        return pixmap
 
     def _on_jtc_enabled(self, val):
         # Don't allow enabling if there are no controllers selected

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -226,7 +226,16 @@ class JointTrajectoryController(Plugin):
     # Usually used to open a modal configuration dialog
 
     def _update_cm_list(self):
-        update_combo(self._widget.cm_combo, self._list_cm())
+        try:
+            update_combo(self._widget.cm_combo, self._list_cm())
+        except rclpy.exceptions.NotInitializedException:
+            # Can happen during shutdown if the timer fires after rclpy teardown.
+            self._update_cm_list_timer.stop()
+        except Exception as e:
+            if "context is not valid" in str(e):
+                self._update_cm_list_timer.stop()
+            else:
+                raise
 
     def _update_jtc_list(self):
         # Clear controller list if no controller information is available
@@ -234,9 +243,22 @@ class JointTrajectoryController(Plugin):
             self._widget.jtc_combo.clear()
             return
 
+        try:
+            running_jtc = self._running_jtc_info()
+        except rclpy.exceptions.NotInitializedException:
+            self._update_jtc_list_timer.stop()
+            return
+        except rclpy.executors.ExternalShutdownException:
+            self._update_jtc_list_timer.stop()
+            return
+        except Exception as e:
+            if "context is not valid" in str(e):
+                self._update_jtc_list_timer.stop()
+                return
+            raise
+
         # List of running controllers with a valid joint limits specification
         # for _all_ their joints
-        running_jtc = self._running_jtc_info()
         if running_jtc and not self._robot_joint_limits:
             self._robot_joint_limits = {}
             for jtc_info in running_jtc:
@@ -350,8 +372,18 @@ class JointTrajectoryController(Plugin):
 
         self._executor = rclpy.executors.SingleThreadedExecutor()
         self._executor.add_node(self._node)
-        self._executor_thread = threading.Thread(target=self._executor.spin, daemon=True)
+        self._executor_thread = threading.Thread(target=self._spin_executor, daemon=True)
         self._executor_thread.start()
+
+    def _spin_executor(self):
+        try:
+            self._executor.spin()
+        except (KeyboardInterrupt, rclpy.executors.ExternalShutdownException):
+            pass
+        except Exception as e:
+            # During SIGINT shutdown, the ROS context can become invalid before spin exits.
+            if "context is not valid" not in str(e):
+                print(f"Executor thread failed: {e}")
 
     def _unload_jtc(self):
         # Stop updating the joint positions
@@ -409,6 +441,7 @@ class JointTrajectoryController(Plugin):
             self._executor.shutdown()
             self._executor_thread.join()
             self._executor = None
+            self._executor_thread = None
 
     def _state_cb(self, msg):
         current_pos = {}

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
@@ -71,15 +71,20 @@ def get_controller_managers(namespace="/", initial_guess=None):
 
     # Get list of (potential) currently running controller managers
     node = rclpy.node.Node("get_controller_managers_node")
-    ns_list_curr = _sloppy_get_controller_managers(node, namespace)
+    try:
+        ns_list_curr = _sloppy_get_controller_managers(node, namespace)
 
-    # Update initial guess:
-    # 1. Remove entries not found in current list
-    # 2. Add new untracked controller managers
-    ns_list[:] = [ns for ns in ns_list if ns in ns_list_curr]
-    ns_list += [ns for ns in ns_list_curr if ns not in ns_list and is_controller_manager(node, ns)]
+        # Update initial guess:
+        # 1. Remove entries not found in current list
+        # 2. Add new untracked controller managers
+        ns_list[:] = [ns for ns in ns_list if ns in ns_list_curr]
+        ns_list += [
+            ns for ns in ns_list_curr if ns not in ns_list and is_controller_manager(node, ns)
+        ]
 
-    return sorted(ns_list)
+        return sorted(ns_list)
+    finally:
+        node.destroy_node()
 
 
 def is_controller_manager(node, namespace):

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
@@ -223,9 +223,17 @@ class ControllerLister:
     """
 
     def __call__(self):
-        controller_list = self._srv_client.call_async(ListControllers.Request())
-        rclpy.spin_until_future_complete(self._node, controller_list)
-        return controller_list.result().controller
+        try:
+            controller_list = self._srv_client.call_async(ListControllers.Request())
+            rclpy.spin_until_future_complete(self._node, controller_list)
+            result = controller_list.result()
+            return result.controller if result else []
+        except rclpy.executors.ExternalShutdownException:
+            return []
+        except Exception as e:
+            if "context is not valid" in str(e) or "destruction was requested" in str(e):
+                return []
+            raise
 
     def _create_client(self):
         return self._node.create_client(ListControllers, self._srv_name)

--- a/rqt_joint_trajectory_controller/test/test_run_launch.py
+++ b/rqt_joint_trajectory_controller/test/test_run_launch.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 ros-controls Maintainers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+
+import launch
+import launch_ros.actions
+import launch_testing.actions
+import launch_testing.markers
+import pytest
+import rclpy
+from rclpy.node import Node
+
+node_name = "rqt_joint_trajectory_controller_node"
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    return launch.LaunchDescription(
+        [
+            launch_ros.actions.Node(
+                executable="rqt_joint_trajectory_controller",
+                package="rqt_joint_trajectory_controller",
+                name=node_name,
+                additional_env={"QT_QPA_PLATFORM": "offscreen"},
+            ),
+            launch_testing.actions.ReadyToTest(),
+        ]
+    )
+
+
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        time.sleep(2)
+        assert node_name in self.node.get_node_names()

--- a/rqt_joint_trajectory_controller/test/test_run_launch.py
+++ b/rqt_joint_trajectory_controller/test/test_run_launch.py
@@ -55,3 +55,11 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         time.sleep(2)
         assert node_name in self.node.get_node_names()
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check if the process exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description
Similar to the test added with https://github.com/ros-controls/ros2_control/pull/3367 but with additional test of exit codes.
I also fixed 

- some race conditions during destruction
- This warning: ` [WARN] [1781557092.901062497] [rcl.logging_rosout]: Publisher already registered for node name: 'get_controller_managers_node'. If this is due to multiple nodes with the same name then all logs for the logger named 'get_controller_managers_node' will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.`
- and the icon, which was not rendered.

### Is this user-facing behavior change?
no

### Did you use Generative AI?
GPT Codex 5.3

## context
This plugin failed launching on lyrical/resolute
```
ros2 run rqt_joint_trajectory_control
ler rqt_joint_trajectory_controller 
PluginManager._load_plugin() could not load plugin "rqt_joint_trajectory_controller/JointTrajectoryController":
Traceback (most recent call last):
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/plugin_handler.py", line 102, in load
    self._load()
    ~~~~~~~~~~^^
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/plugin_handler_direct.py", line 55, in _load
    self._plugin = self._plugin_provider.load(self._instance_id.plugin_id, self._context)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/composite_plugin_provider.py", line 72, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/composite_plugin_provider.py", line 72, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/rolling/lib/python3.14/site-packages/rqt_gui_py/ros_py_plugin_provider.py", line 69, in load
    return super(RosPyPluginProvider, self).load(plugin_id, ros_plugin_context)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/composite_plugin_provider.py", line 72, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/rolling/lib/python3.14/site-packages/rqt_gui/ros_plugin_provider.py", line 107, in load
    return class_ref(plugin_context)
  File "/workspaces/ros2_rolling_ws/build/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py", line 141, in __init__
    context.add_widget(self._widget)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/plugin_context.py", line 80, in add_widget
    self._handler.add_widget(widget)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/plugin_handler_direct.py", line 135, in add_widget
    dock_widget = self._create_dock_widget()
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/plugin_handler.py", line 254, in _create_dock_widget
    self._set_window_icon(dock_widget)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/plugin_handler.py", line 296, in _set_window_icon
    icon = get_icon(
        action_attributes['icon'], action_attributes.get('icontype', None), base_path)
  File "/opt/ros/rolling/lib/python3.14/site-packages/qt_gui/icon_loader.py", line 40, in get_icon
    if 'file' in type_ or type_ is None:
       ^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not a container or iterable
```