### PR TITLE
Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor

### DIFF
--- a/forward_command_controller/test/test_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_forward_command_controller.cpp
@@ -77,10 +77,7 @@ TEST_F(ForwardCommandControllerTest, ConfigureParamsSuccess)
     {rclcpp::Parameter("joints", std::vector<std::string>{"joint1", "joint2"}),
      rclcpp::Parameter("interface_name", "position")});
 
-  // configure successful
-  ASSERT_EQ(
-    controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // check interface configuration
   auto cmd_if_conf = controller_->command_interface_configuration();
@@ -96,10 +93,7 @@ TEST_F(ForwardCommandControllerTest, ActivateSuccess)
   SetUpController(
     {rclcpp::Parameter("joints", joint_names_), rclcpp::Parameter("interface_name", "position")});
 
-  // activate successful
-  ASSERT_EQ(
-    controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // check interface configuration
   auto cmd_if_conf = controller_->command_interface_configuration();
@@ -109,9 +103,7 @@ TEST_F(ForwardCommandControllerTest, ActivateSuccess)
   ASSERT_THAT(state_if_conf.names, IsEmpty());
   ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 
-  ASSERT_EQ(
-    controller_->on_activate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   // check interface configuration
   cmd_if_conf = controller_->command_interface_configuration();
@@ -128,9 +120,7 @@ TEST_F(ForwardCommandControllerTest, CommandSuccessTest)
     {rclcpp::Parameter("joints", joint_names_), rclcpp::Parameter("interface_name", "position")});
 
   // configure controller
-  ASSERT_EQ(
-    controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // update successful though no command has been send yet
   ASSERT_EQ(
@@ -164,9 +154,7 @@ TEST_F(ForwardCommandControllerTest, WrongCommandCheckTest)
     {rclcpp::Parameter("joints", joint_names_), rclcpp::Parameter("interface_name", "position")});
 
   // configure controller
-  ASSERT_EQ(
-    controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // send command with wrong number of joints
   forward_command_controller::CmdType command_msg;
@@ -190,9 +178,7 @@ TEST_F(ForwardCommandControllerTest, NoCommandCheckTest)
     {rclcpp::Parameter("joints", joint_names_), rclcpp::Parameter("interface_name", "position")});
 
   // configure controller
-  ASSERT_EQ(
-    controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // update successful, no command received yet
   ASSERT_EQ(
@@ -215,11 +201,9 @@ TEST_F(ForwardCommandControllerTest, CommandCallbackTest)
   ASSERT_EQ(joint_2_pos_cmd_->get_optional().value(), 2.1);
   ASSERT_EQ(joint_3_pos_cmd_->get_optional().value(), 3.1);
 
-  auto node_state = controller_->configure();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
-  node_state = controller_->get_node()->activate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   // send a new command
   rclcpp::Node test_node("test_node");
@@ -259,11 +243,9 @@ TEST_F(ForwardCommandControllerTest, DropInfiniteCommandCallbackTest)
   ASSERT_EQ(joint_2_pos_cmd_->get_optional().value(), 2.1);
   ASSERT_EQ(joint_3_pos_cmd_->get_optional().value(), 3.1);
 
-  auto node_state = controller_->configure();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
-  node_state = controller_->get_node()->activate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   // send a new command
   rclcpp::Node test_node("test_node");
@@ -303,8 +285,7 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
   ASSERT_EQ(joint_2_pos_cmd_->get_optional().value(), 2.1);
   ASSERT_EQ(joint_3_pos_cmd_->get_optional().value(), 3.1);
 
-  auto node_state = controller_->configure();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // check interface configuration
   auto cmd_if_conf = controller_->command_interface_configuration();
@@ -314,8 +295,7 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
   ASSERT_THAT(state_if_conf.names, IsEmpty());
   EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::NONE);
 
-  node_state = controller_->get_node()->activate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   // check interface configuration
   cmd_if_conf = controller_->command_interface_configuration();
@@ -340,8 +320,7 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
   ASSERT_EQ(joint_2_pos_cmd_->get_optional().value(), 20);
   ASSERT_EQ(joint_3_pos_cmd_->get_optional().value(), 30);
 
-  node_state = controller_->get_node()->deactivate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(deactivate_succeeds(controller_));
 
   // check interface configuration
   cmd_if_conf = controller_->command_interface_configuration();
@@ -369,8 +348,7 @@ TEST_F(ForwardCommandControllerTest, ActivateDeactivateCommandsResetSuccess)
       ::testing::Not(::testing::NanSensitiveDoubleEq(std::numeric_limits<double>::quiet_NaN()))));
 
   // Now activate again
-  node_state = controller_->get_node()->activate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   // command ptr should be reset after activation - same check as in `update`
   cmd = controller_->rt_command_.get();

--- a/forward_command_controller/test/test_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_forward_command_controller.hpp
@@ -19,12 +19,17 @@
 #include <string>
 #include <vector>
 
+#include "controller_interface/test_utils.hpp"
 #include "gmock/gmock.h"
 
 #include "forward_command_controller/forward_command_controller.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 using hardware_interface::CommandInterface;
 using hardware_interface::HW_IF_POSITION;

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.cpp
@@ -83,10 +83,8 @@ void MultiInterfaceForwardCommandControllerTest::SetUpController(
 
   if (set_default_params_and_activate)
   {
-    auto node_state = controller_->configure();
-    ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
-    node_state = controller_->get_node()->activate();
-    ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+    ASSERT_TRUE(configure_succeeds(controller_));
+    ASSERT_TRUE(activate_succeeds(controller_));
   }
 }
 
@@ -97,10 +95,7 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, ConfigureParamsSuccess)
             rclcpp::Parameter(
               "interface_names", std::vector<std::string>{"position", "velocity", "effort"})});
 
-  // configure successful
-  ASSERT_EQ(
-    controller_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // check interface configuration
   auto cmd_if_conf = controller_->command_interface_configuration();
@@ -234,8 +229,7 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateDeactivateCommandsRes
   ASSERT_EQ(joint_1_vel_cmd_->get_optional().value(), 20.0);
   ASSERT_EQ(joint_1_eff_cmd_->get_optional().value(), 30.0);
 
-  auto node_state = controller_->get_node()->deactivate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(deactivate_succeeds(controller_));
 
   // check interface configuration
   cmd_if_conf = controller_->command_interface_configuration();
@@ -263,8 +257,7 @@ TEST_F(MultiInterfaceForwardCommandControllerTest, ActivateDeactivateCommandsRes
       ::testing::Not(::testing::NanSensitiveDoubleEq(std::numeric_limits<double>::quiet_NaN()))));
 
   // Now activate again
-  node_state = controller_->get_node()->activate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   // command ptr should be reset after activation - same check as in `update`
   cmd = controller_->rt_command_.get();

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
@@ -21,12 +21,17 @@
 #include <string>
 #include <vector>
 
+#include "controller_interface/test_utils.hpp"
 #include "gmock/gmock.h"
 
 #include "forward_command_controller/multi_interface_forward_command_controller.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 using hardware_interface::CommandInterface;
 using hardware_interface::HW_IF_EFFORT;

--- a/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.cpp
@@ -40,11 +40,6 @@ using hardware_interface::LoanedStateInterface;
 using testing::IsEmpty;
 using testing::SizeIs;
 
-namespace
-{
-constexpr auto NODE_SUCCESS = controller_interface::CallbackReturn::SUCCESS;
-}  // namespace
-
 void IMUSensorBroadcasterTest::SetUpTestCase() {}
 
 void IMUSensorBroadcasterTest::TearDownTestCase() {}
@@ -135,7 +130,7 @@ TEST_F(IMUSensorBroadcasterTest, SensorName_Configure_Success)
   imu_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
   // configure passed
-  ASSERT_EQ(imu_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(imu_broadcaster_));
 
   // check interface configuration
   auto cmd_if_conf = imu_broadcaster_->command_interface_configuration();
@@ -155,8 +150,8 @@ TEST_F(IMUSensorBroadcasterTest, SensorName_Activate_Success)
   imu_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
   // configure and activate success
-  ASSERT_EQ(imu_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(imu_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(imu_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(imu_broadcaster_));
 
   // check interface configuration
   auto cmd_if_conf = imu_broadcaster_->command_interface_configuration();
@@ -167,7 +162,7 @@ TEST_F(IMUSensorBroadcasterTest, SensorName_Activate_Success)
   EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
   // deactivate passed
-  ASSERT_EQ(imu_broadcaster_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(deactivate_succeeds(imu_broadcaster_));
 
   // check interface configuration
   cmd_if_conf = imu_broadcaster_->command_interface_configuration();
@@ -186,8 +181,8 @@ TEST_F(IMUSensorBroadcasterTest, SensorName_Update_Success)
   imu_broadcaster_->get_node()->set_parameter({"sensor_name", sensor_name_});
   imu_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
-  ASSERT_EQ(imu_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(imu_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(imu_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(imu_broadcaster_));
 
   ASSERT_EQ(
     imu_broadcaster_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
@@ -202,8 +197,8 @@ TEST_F(IMUSensorBroadcasterTest, SensorName_Publish_Success)
   imu_broadcaster_->get_node()->set_parameter({"sensor_name", sensor_name_});
   imu_broadcaster_->get_node()->set_parameter({"frame_id", frame_id_});
 
-  ASSERT_EQ(imu_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(imu_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(imu_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(imu_broadcaster_));
 
   sensor_msgs::msg::Imu imu_msg;
   subscribe_and_get_message(imu_msg);
@@ -238,8 +233,8 @@ TEST_F(IMUSensorBroadcasterTest, SensorStatePublishTest_with_rotation_offset)
      rclcpp::Parameter("rotation_offset.pitch", 0.),
      rclcpp::Parameter("rotation_offset.yaw", M_PI_2)});
 
-  ASSERT_EQ(imu_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(imu_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(imu_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(imu_broadcaster_));
 
   sensor_msgs::msg::Imu imu_msg;
   subscribe_and_get_message(imu_msg);

--- a/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.hpp
+++ b/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.hpp
@@ -25,7 +25,12 @@
 #include <string>
 #include <vector>
 
+#include "controller_interface/test_utils.hpp"
 #include "imu_sensor_broadcaster/imu_sensor_broadcaster.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 // subclassing and friending so we can access member variables
 class FriendIMUSensorBroadcaster : public imu_sensor_broadcaster::IMUSensorBroadcaster

--- a/mecanum_drive_controller/test/test_mecanum_drive_controller.cpp
+++ b/mecanum_drive_controller/test/test_mecanum_drive_controller.cpp
@@ -56,7 +56,7 @@ TEST_F(MecanumDriveControllerTest, when_controller_is_configured_expect_all_para
   ASSERT_TRUE(controller_->params_.rear_right_wheel_state_joint_name.empty());
   ASSERT_TRUE(controller_->params_.rear_left_wheel_state_joint_name.empty());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   ASSERT_EQ(controller_->params_.reference_timeout, 0.9);
   ASSERT_EQ(controller_->params_.kinematics.wheels_radius, 0.5);
@@ -94,7 +94,7 @@ TEST_F(MecanumDriveControllerTest, when_controller_configured_expect_properly_ex
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // check command itfs configuration
   auto command_intefaces = controller_->command_interface_configuration();
@@ -143,7 +143,7 @@ TEST_F(MecanumDriveControllerTest, configure_succeeds_tf_prefix_false_covariance
 
   SetUpController("test_mecanum_drive_controller", node_options);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto odometry_message = controller_->odom_state_msg_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -178,7 +178,7 @@ TEST_F(MecanumDriveControllerTest, configure_succeeds_tf_prefix_no_namespace)
 
   SetUpController("test_mecanum_drive_controller", node_options);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto odometry_message = controller_->odom_state_msg_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -203,7 +203,7 @@ TEST_F(MecanumDriveControllerTest, configure_succeeds_tf_blank_prefix_no_namespa
 
   SetUpController("test_mecanum_drive_controller", node_options);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto odometry_message = controller_->odom_state_msg_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -230,7 +230,7 @@ TEST_F(MecanumDriveControllerTest, configure_succeeds_tf_prefix_set_namespace)
 
   SetUpController("test_mecanum_drive_controller", node_options, test_namespace);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto odometry_message = controller_->odom_state_msg_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -256,7 +256,7 @@ TEST_F(MecanumDriveControllerTest, configure_succeeds_tf_tilde_prefix_set_namesp
 
   SetUpController("test_mecanum_drive_controller", node_options, test_namespace);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto odometry_message = controller_->odom_state_msg_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -272,8 +272,8 @@ TEST_F(MecanumDriveControllerTest, when_controller_is_activated_expect_reference
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   // check that the message is reset
   auto msg = controller_->input_ref_.get();
@@ -285,8 +285,8 @@ TEST_F(MecanumDriveControllerTest, when_controller_active_and_update_called_expe
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   ASSERT_EQ(
     controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
@@ -297,9 +297,9 @@ TEST_F(MecanumDriveControllerTest, when_active_controller_is_deactivated_expect_
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
+  ASSERT_TRUE(deactivate_succeeds(controller_));
 }
 
 TEST_F(
@@ -308,12 +308,12 @@ TEST_F(
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_EQ(controller_->command_interfaces_[NR_CMD_ITFS - 4].get_optional().value(), 101.101);
-  ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(deactivate_succeeds(controller_));
   ASSERT_TRUE(std::isnan(controller_->command_interfaces_[NR_CMD_ITFS - 4].get_optional().value()));
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_TRUE(std::isnan(controller_->command_interfaces_[NR_CMD_ITFS - 4].get_optional().value()));
 
   ASSERT_EQ(
@@ -327,8 +327,8 @@ TEST_F(MecanumDriveControllerTest, when_update_is_called_expect_status_message)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   controller_->reference_interfaces_[0] = 1.5;
 
@@ -349,8 +349,8 @@ TEST_F(
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
   // no reference_msg sent
   ASSERT_EQ(
     controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
@@ -393,8 +393,8 @@ TEST_F(MecanumDriveControllerTest, when_reference_msg_is_too_old_expect_unset_re
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   auto reference = controller_->input_ref_.get();
   auto old_timestamp = reference.header.stamp;
@@ -424,8 +424,8 @@ TEST_F(
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   auto reference = controller_->input_ref_.get();
   auto old_timestamp = reference.header.stamp;
@@ -459,8 +459,8 @@ TEST_F(MecanumDriveControllerTest, when_message_has_valid_timestamp_expect_refer
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   auto reference = controller_->input_ref_.get();
   EXPECT_TRUE(std::isnan(reference.twist.linear.x));
@@ -493,9 +493,9 @@ TEST_F(
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(false);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_FALSE(controller_->is_in_chained_mode());
 
   for (const auto & interface : controller_->reference_interfaces_)
@@ -591,9 +591,9 @@ TEST_F(
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_TRUE(controller_->is_in_chained_mode());
 
   for (const auto & interface : controller_->reference_interfaces_)
@@ -647,8 +647,8 @@ TEST_F(
   SetUpController();
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   // set command statically
   joint_command_values_[controller_->get_rear_left_wheel_index()] = command_lin_x;
@@ -694,8 +694,8 @@ TEST_F(
   SetUpController();
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   auto reference = controller_->input_ref_.get();
   EXPECT_TRUE(std::isnan(reference.twist.linear.x));
@@ -725,7 +725,7 @@ TEST_F(MecanumDriveControllerTest, SideToSideAndRotationOdometryTest)
   SetUpController("test_mecanum_drive_controller_with_rotation");
 
   // Configure
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   // Check on the base frame offset is set by the params
   EXPECT_EQ(controller_->odometry_.getBaseFrameOffset()[0], 1.0);
@@ -734,7 +734,7 @@ TEST_F(MecanumDriveControllerTest, SideToSideAndRotationOdometryTest)
 
   // Activate in chained mode
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_EQ(controller_->is_in_chained_mode(), true);
 
   // Setup reference interfaces for side to side motion
@@ -813,12 +813,12 @@ TEST_F(MecanumDriveControllerTest, odometry_set_service)
 {
   // 0. Initialize and activate
   SetUpController();
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->get_node()->trigger_transition(
     rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE));
 
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   controller_->get_node()->trigger_transition(
     rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE));
   ASSERT_EQ(
@@ -883,9 +883,9 @@ TEST_F(MecanumDriveControllerTest, test_no_speed_limiter_when_not_configured)
   // Use the default config which has no velocity limits set
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_TRUE(controller_->is_in_chained_mode());
 
   // Fill the queue with zero velocity
@@ -931,9 +931,9 @@ TEST_F(MecanumDriveControllerTest, test_speed_limiter_linear_x)
 {
   SetUpController("test_mecanum_drive_controller_with_limits");
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_TRUE(controller_->is_in_chained_mode());
 
   // Fill the speed limiter queue with zero velocity
@@ -1117,9 +1117,9 @@ TEST_F(MecanumDriveControllerTest, test_speed_limiter_linear_y)
 {
   SetUpController("test_mecanum_drive_controller_with_limits");
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_TRUE(controller_->is_in_chained_mode());
 
   // Fill the speed limiter queue with zero velocity
@@ -1173,9 +1173,9 @@ TEST_F(MecanumDriveControllerTest, test_speed_limiter_angular_z)
 {
   SetUpController("test_mecanum_drive_controller_with_limits");
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_TRUE(controller_->is_in_chained_mode());
 
   // Fill the speed limiter queue with zero velocity
@@ -1228,9 +1228,9 @@ TEST_F(MecanumDriveControllerTest, test_reset_buffers_clears_limiter_state)
 {
   SetUpController("test_mecanum_drive_controller_with_limits");
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   // Dirty all buffers that reset_buffers() is responsible for clearing.
   controller_->reference_interfaces_[0] = 1.0;
@@ -1271,9 +1271,9 @@ TEST_F(MecanumDriveControllerTest, test_lifecycle_transitions_reset_limiter_buff
 {
   SetUpController("test_mecanum_drive_controller_with_limits");
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   const double dt = 0.001;
   const double wheels_radius = 0.5;
@@ -1296,11 +1296,11 @@ TEST_F(MecanumDriveControllerTest, test_lifecycle_transitions_reset_limiter_buff
   EXPECT_NEAR(linear, controller_->previous_two_commands_.back()[0], 1e-3);
 
   // Deactivate then re-activate: limiter history must be reset to zero.
-  ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(deactivate_succeeds(controller_));
   EXPECT_EQ(controller_->previous_two_commands_.front(), (std::array<double, 3>{{0.0, 0.0, 0.0}}));
   EXPECT_EQ(controller_->previous_two_commands_.back(), (std::array<double, 3>{{0.0, 0.0, 0.0}}));
 
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   EXPECT_EQ(controller_->previous_two_commands_.front(), (std::array<double, 3>{{0.0, 0.0, 0.0}}));
   EXPECT_EQ(controller_->previous_two_commands_.back(), (std::array<double, 3>{{0.0, 0.0, 0.0}}));
 
@@ -1333,9 +1333,9 @@ TEST_F(MecanumDriveControllerTest, test_speed_limiter_runtime_update)
 
   SetUpController("test_mecanum_drive_controller_with_limits");
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_TRUE(controller_->is_in_chained_mode());
 
   const double dt = 0.001;

--- a/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
+++ b/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "controller_interface/test_utils.hpp"
 #include "gmock/gmock.h"
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
@@ -38,18 +39,15 @@
 #include "rclcpp/utilities.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
+
 using ControllerStateMsg = mecanum_drive_controller::MecanumDriveController::ControllerStateMsg;
 using ControllerReferenceMsg =
   mecanum_drive_controller::MecanumDriveController::ControllerReferenceMsg;
 using TfStateMsg = mecanum_drive_controller::MecanumDriveController::TfStateMsg;
 using OdomStateMsg = mecanum_drive_controller::MecanumDriveController::OdomStateMsg;
-
-namespace
-{
-constexpr auto NODE_SUCCESS = controller_interface::CallbackReturn::SUCCESS;
-constexpr auto NODE_ERROR = controller_interface::CallbackReturn::ERROR;
-}  // namespace
-// namespace
 
 // subclassing and friending so we can access member variables
 class TestableMecanumDriveController : public mecanum_drive_controller::MecanumDriveController

--- a/mecanum_drive_controller/test/test_mecanum_drive_controller_preceding.cpp
+++ b/mecanum_drive_controller/test/test_mecanum_drive_controller_preceding.cpp
@@ -44,7 +44,7 @@ TEST_F(MecanumDriveControllerTest, when_controller_is_configured_expect_all_para
   ASSERT_TRUE(controller_->params_.rear_right_wheel_state_joint_name.empty());
   ASSERT_TRUE(controller_->params_.rear_left_wheel_state_joint_name.empty());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   ASSERT_EQ(controller_->params_.reference_timeout, 0.1);
 
@@ -72,7 +72,7 @@ TEST_F(MecanumDriveControllerTest, when_controller_configured_expect_properly_ex
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto command_intefaces = controller_->command_interface_configuration();
   ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());

--- a/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
+++ b/range_sensor_broadcaster/test/test_range_sensor_broadcaster.cpp
@@ -59,16 +59,13 @@ controller_interface::return_type RangeSensorBroadcasterTest::init_broadcaster(
   return result;
 }
 
-controller_interface::CallbackReturn RangeSensorBroadcasterTest::configure_broadcaster(
-  std::vector<rclcpp::Parameter> & parameters)
+void RangeSensorBroadcasterTest::configure_broadcaster(std::vector<rclcpp::Parameter> & parameters)
 {
   // Configure the broadcaster
   for (auto parameter : parameters)
   {
     range_broadcaster_->get_node()->set_parameter(parameter);
   }
-
-  return range_broadcaster_->on_configure(rclcpp_lifecycle::State());
 }
 
 void RangeSensorBroadcasterTest::subscribe_and_get_message(sensor_msgs::msg::Range & range_msg)
@@ -128,7 +125,8 @@ TEST_F(RangeSensorBroadcasterTest, Configure_RangeBroadcaster_Error_1)
   std::vector<rclcpp::Parameter> parameters;
   // explicitly give an empty sensor name to generate an error
   parameters.emplace_back(rclcpp::Parameter("sensor_name", ""));
-  ASSERT_EQ(configure_broadcaster(parameters), controller_interface::CallbackReturn::ERROR);
+  configure_broadcaster(parameters);
+  ASSERT_FALSE(configure_succeeds(range_broadcaster_));
 }
 
 TEST_F(RangeSensorBroadcasterTest, Configure_RangeBroadcaster_Error_2)
@@ -139,7 +137,8 @@ TEST_F(RangeSensorBroadcasterTest, Configure_RangeBroadcaster_Error_2)
   std::vector<rclcpp::Parameter> parameters;
   // explicitly give an empty frame_id to generate an error
   parameters.emplace_back(rclcpp::Parameter("frame_id", ""));
-  ASSERT_EQ(configure_broadcaster(parameters), controller_interface::CallbackReturn::ERROR);
+  configure_broadcaster(parameters);
+  ASSERT_FALSE(configure_succeeds(range_broadcaster_));
 }
 
 TEST_F(RangeSensorBroadcasterTest, Configure_RangeBroadcaster_Success)
@@ -147,9 +146,7 @@ TEST_F(RangeSensorBroadcasterTest, Configure_RangeBroadcaster_Success)
   // Third Test without sensor_name SUCCESS Expected
   init_broadcaster("test_range_sensor_broadcaster");
 
-  ASSERT_EQ(
-    range_broadcaster_->on_configure(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(range_broadcaster_));
 
   // check interface configuration
   auto cmd_if_conf = range_broadcaster_->command_interface_configuration();
@@ -162,11 +159,9 @@ TEST_F(RangeSensorBroadcasterTest, ActivateDeactivate_RangeBroadcaster_Success)
 {
   init_broadcaster("test_range_sensor_broadcaster");
 
-  range_broadcaster_->on_configure(rclcpp_lifecycle::State());
+  ASSERT_TRUE(configure_succeeds(range_broadcaster_));
 
-  ASSERT_EQ(
-    range_broadcaster_->on_activate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(activate_succeeds(range_broadcaster_));
 
   // check interface configuration
   auto cmd_if_conf = range_broadcaster_->command_interface_configuration();
@@ -176,9 +171,7 @@ TEST_F(RangeSensorBroadcasterTest, ActivateDeactivate_RangeBroadcaster_Success)
   ASSERT_THAT(state_if_conf.names, SizeIs(1lu));
   ASSERT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  ASSERT_EQ(
-    range_broadcaster_->on_deactivate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(deactivate_succeeds(range_broadcaster_));
 
   // check interface configuration
   cmd_if_conf = range_broadcaster_->command_interface_configuration();
@@ -193,10 +186,9 @@ TEST_F(RangeSensorBroadcasterTest, Update_RangeBroadcaster_Success)
 {
   init_broadcaster("test_range_sensor_broadcaster");
 
-  range_broadcaster_->on_configure(rclcpp_lifecycle::State());
-  ASSERT_EQ(
-    range_broadcaster_->on_activate(rclcpp_lifecycle::State()),
-    controller_interface::CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(range_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(range_broadcaster_));
+
   auto result = range_broadcaster_->update(
     range_broadcaster_->get_node()->get_clock()->now(), rclcpp::Duration::from_seconds(0.01));
 
@@ -207,8 +199,8 @@ TEST_F(RangeSensorBroadcasterTest, Publish_RangeBroadcaster_Success)
 {
   init_broadcaster("test_range_sensor_broadcaster");
 
-  range_broadcaster_->on_configure(rclcpp_lifecycle::State());
-  range_broadcaster_->on_activate(rclcpp_lifecycle::State());
+  ASSERT_TRUE(configure_succeeds(range_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(range_broadcaster_));
 
   sensor_msgs::msg::Range range_msg;
   subscribe_and_get_message(range_msg);
@@ -228,8 +220,8 @@ TEST_F(RangeSensorBroadcasterTest, Publish_Bandaries_RangeBroadcaster_Success)
 {
   init_broadcaster("test_range_sensor_broadcaster");
 
-  range_broadcaster_->on_configure(rclcpp_lifecycle::State());
-  range_broadcaster_->on_activate(rclcpp_lifecycle::State());
+  ASSERT_TRUE(configure_succeeds(range_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(range_broadcaster_));
 
   sensor_msgs::msg::Range range_msg;
 
@@ -264,8 +256,8 @@ TEST_F(RangeSensorBroadcasterTest, Publish_OutOfBandaries_RangeBroadcaster_Succe
 {
   init_broadcaster("test_range_sensor_broadcaster");
 
-  range_broadcaster_->on_configure(rclcpp_lifecycle::State());
-  range_broadcaster_->on_activate(rclcpp_lifecycle::State());
+  ASSERT_TRUE(configure_succeeds(range_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(range_broadcaster_));
 
   sensor_msgs::msg::Range range_msg;
 

--- a/range_sensor_broadcaster/test/test_range_sensor_broadcaster.hpp
+++ b/range_sensor_broadcaster/test/test_range_sensor_broadcaster.hpp
@@ -23,9 +23,14 @@
 #include <string>
 #include <vector>
 
+#include "controller_interface/test_utils.hpp"
 #include "gmock/gmock.h"
 
 #include "range_sensor_broadcaster/range_sensor_broadcaster.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 class RangeSensorBroadcasterTest : public ::testing::Test
 {
@@ -53,8 +58,7 @@ protected:
   std::unique_ptr<range_sensor_broadcaster::RangeSensorBroadcaster> range_broadcaster_;
 
   controller_interface::return_type init_broadcaster(std::string broadcaster_name);
-  controller_interface::CallbackReturn configure_broadcaster(
-    std::vector<rclcpp::Parameter> & parameters);
+  void configure_broadcaster(std::vector<rclcpp::Parameter> & parameters);
   void subscribe_and_get_message(sensor_msgs::msg::Range & range_msg);
 };
 


### PR DESCRIPTION
Partial fix for https://github.com/ros-controls/ros2_controllers/issues/1660, utilize test utility functions to call appropriate lifecycle transitions and evaluate expected state.
This PR covers:
forward_command_controller
range_sensor_broadcaster
mecanum_drive_controller
imu_sensor_broadcaster