### PR TITLE
Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering

### DIFF
--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.cpp
@@ -28,7 +28,7 @@ TEST_F(BicycleSteeringControllerTest, all_parameters_set_configure_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
   ASSERT_THAT(
     controller_->params_.traction_joints_names, testing::ElementsAreArray(traction_joints_names_));
@@ -45,7 +45,7 @@ TEST_F(BicycleSteeringControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
   auto cmd_if_conf = controller_->command_interface_configuration();
   ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());
@@ -85,8 +85,8 @@ TEST_F(BicycleSteeringControllerTest, activate_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   // check that the message is reset
   auto msg = controller_->input_ref_.get();
@@ -102,8 +102,8 @@ TEST_F(BicycleSteeringControllerTest, update_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01)),
@@ -114,20 +114,20 @@ TEST_F(BicycleSteeringControllerTest, deactivate_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
+  EXPECT_TRUE(activate_succeeds(controller_));
+  EXPECT_TRUE(deactivate_succeeds(controller_));
 }
 
 TEST_F(BicycleSteeringControllerTest, reactivate_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
+  EXPECT_TRUE(activate_succeeds(controller_));
+  EXPECT_TRUE(deactivate_succeeds(controller_));
   ASSERT_TRUE(std::isnan(controller_->command_interfaces_[0].get_optional().value()));
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(activate_succeeds(controller_));
   ASSERT_TRUE(std::isnan(controller_->command_interfaces_[0].get_optional().value()));
 
   ASSERT_EQ(
@@ -141,9 +141,9 @@ TEST_F(BicycleSteeringControllerTest, test_update_logic)
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(false);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(activate_succeeds(controller_));
   ASSERT_FALSE(controller_->is_in_chained_mode());
 
   // set command statically
@@ -178,9 +178,9 @@ TEST_F(BicycleSteeringControllerTest, test_update_logic_chained)
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
   controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(activate_succeeds(controller_));
   ASSERT_TRUE(controller_->is_in_chained_mode());
 
   controller_->reference_interfaces_[0] = 0.1;
@@ -209,8 +209,8 @@ TEST_F(BicycleSteeringControllerTest, publish_status_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01)),
@@ -226,8 +226,8 @@ TEST_F(BicycleSteeringControllerTest, receive_message_and_publish_updated_status
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01)),

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -24,12 +24,17 @@
 #include <vector>
 
 #include "bicycle_steering_controller/bicycle_steering_controller.hpp"
+#include "controller_interface/test_utils.hpp"
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "rclcpp/executor.hpp"
 #include "rclcpp/executors.hpp"
 #include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 using ControllerStateMsg =
   steering_controllers_library::SteeringControllersLibrary::SteeringControllerStateMsg;
@@ -46,12 +51,9 @@ using bicycle_steering_controller::CMD_TRACTION_WHEEL;
 
 namespace
 {
-constexpr auto NODE_SUCCESS = controller_interface::CallbackReturn::SUCCESS;
-constexpr auto NODE_ERROR = controller_interface::CallbackReturn::ERROR;
 const double COMMON_THRESHOLD = 1e-6;
 
 }  // namespace
-// namespace
 
 // subclassing and friending so we can access member variables
 class TestableBicycleSteeringController

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller_preceding.cpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller_preceding.cpp
@@ -28,7 +28,7 @@ TEST_F(BicycleSteeringControllerTest, all_parameters_set_configure_success)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
   ASSERT_THAT(
     controller_->params_.traction_joints_names,
@@ -47,7 +47,7 @@ TEST_F(BicycleSteeringControllerTest, check_exported_interfaces)
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
   auto cmd_if_conf = controller_->command_interface_configuration();
   ASSERT_EQ(cmd_if_conf.names.size(), joint_command_values_.size());

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -44,12 +44,6 @@ using testing::ElementsAreArray;
 using testing::IsEmpty;
 using testing::SizeIs;
 
-namespace
-{
-constexpr auto NODE_SUCCESS = controller_interface::CallbackReturn::SUCCESS;
-constexpr auto NODE_ERROR = controller_interface::CallbackReturn::ERROR;
-}  // namespace
-
 void JointStateBroadcasterTest::SetUpTestCase() { rclcpp::init(0, nullptr); }
 
 void JointStateBroadcasterTest::TearDownTestCase() { rclcpp::shutdown(); }
@@ -172,9 +166,9 @@ TEST_F(JointStateBroadcasterTest, ActivateEmptyTest)
 
   SetUpStateBroadcaster();
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = joint_names_.size();
 
@@ -207,9 +201,9 @@ TEST_F(JointStateBroadcasterTest, ReactivateTheControllerWithDifferentInterfaces
 
   SetUpStateBroadcaster();
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = joint_names_.size();
 
@@ -236,11 +230,11 @@ TEST_F(JointStateBroadcasterTest, ReactivateTheControllerWithDifferentInterfaces
 
   // Now deactivate and activate with only 2 set of joints and interfaces (to create as in one of
   // the interface is unavailable)
-  ASSERT_EQ(state_broadcaster_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(deactivate_succeeds(state_broadcaster_));
   const std::vector<std::string> JOINT_NAMES = {"joint1", "joint2"};
   assign_state_interfaces(JOINT_NAMES, interface_names_);
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS_WITH_ONE_DEACTIVATED = JOINT_NAMES.size();
 
@@ -273,9 +267,9 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutJointsParameter)
   SetUpStateBroadcaster(JOINT_NAMES, IF_NAMES);
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = joint_names_.size();
 
@@ -309,7 +303,7 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutJointsParameterInvalidURDF)
   assign_state_interfaces(JOINT_NAMES, IF_NAMES);
 
   // URDF mode (joints empty) with an unparsable robot description must fail at configure
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
+  ASSERT_FALSE(configure_succeeds(state_broadcaster_));
 }
 
 TEST_F(JointStateBroadcasterTest, ActivateTestWithoutJointsParameterWithRobotDescription)
@@ -325,9 +319,9 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutJointsParameterWithRobotDes
   assign_state_interfaces(JOINT_NAMES, IF_NAMES);
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = joint_in_urdf.size();
 
@@ -364,9 +358,9 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithJointsAndNoInterfaces)
   assign_state_interfaces(JOINT_NAMES, IF_NAMES);
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = joint_in_urdf.size();
 
@@ -402,9 +396,9 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithJointsAndInterfaces)
   assign_state_interfaces(JOINT_NAMES, IF_NAMES);
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = JOINT_NAMES.size();
 
@@ -434,9 +428,9 @@ TEST_F(JointStateBroadcasterTest, ActivateTestWithoutInterfacesParameter)
   SetUpStateBroadcaster(JOINT_NAMES, IF_NAMES);
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = joint_names_.size();
 
@@ -469,9 +463,9 @@ TEST_F(JointStateBroadcasterTest, ActivateDeactivateTestTwoJointsOneInterface)
   SetUpStateBroadcaster(JOINT_NAMES, IF_NAMES);
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = JOINT_NAMES.size();
 
@@ -503,7 +497,8 @@ TEST_F(JointStateBroadcasterTest, ActivateDeactivateTestTwoJointsOneInterface)
   }
 
   // deactivate
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(deactivate_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   // check interface configuration
   cmd_if_conf = state_broadcaster_->command_interface_configuration();
@@ -522,9 +517,9 @@ TEST_F(JointStateBroadcasterTest, ActivateTestOneJointTwoInterfaces)
   SetUpStateBroadcaster(JOINT_NAMES, IF_NAMES);
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = JOINT_NAMES.size();
 
@@ -564,10 +559,14 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesAllMissing)
   // assign_state_interfaces(JOINT_NAMES, {interface_names_[2]});
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
   // is none of requested interfaces do not exist, the controller will not be activated
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_ERROR);
+  EXPECT_THAT(
+    [this]() { activate_succeeds(state_broadcaster_); },
+    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
+      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
+                                                                 // then Unconfigured(1)
 }
 
 TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing)
@@ -588,10 +587,10 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing)
   state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
   // here a warning output is expected!
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = JOINT_NAMES.size();
 
@@ -628,9 +627,9 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceWithoutMapping)
   SetUpStateBroadcaster(JOINT_NAMES, IF_NAMES);
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   // check interface configuration
   auto cmd_if_conf = state_broadcaster_->command_interface_configuration();
@@ -662,9 +661,9 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceMapping)
       std::string("map_interface_to_joint_state.") + HW_IF_POSITION, custom_interface_name_)});
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = JOINT_NAMES.size();
 
@@ -707,7 +706,7 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceMappingIgnoredWhenVelocityI
       std::string("map_interface_to_joint_state.") + HW_IF_VELOCITY, custom_velocity_interface)});
 
   // configure ok; a warning is expected because the custom velocity mapping is ignored
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
   const auto velocity_mapping =
     state_broadcaster_->map_interface_to_joint_state_.find(HW_IF_VELOCITY);
@@ -715,7 +714,7 @@ TEST_F(JointStateBroadcasterTest, TestCustomInterfaceMappingIgnoredWhenVelocityI
   EXPECT_EQ(velocity_mapping->second, HW_IF_VELOCITY);
   EXPECT_EQ(state_broadcaster_->map_interface_to_joint_state_.count(custom_velocity_interface), 0u);
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   const size_t NUM_JOINTS = JOINT_NAMES.size();
 
@@ -780,9 +779,8 @@ TEST_F(JointStateBroadcasterTest, UpdateTest)
 {
   SetUpStateBroadcaster();
 
-  auto node_state = state_broadcaster_->configure();
-  node_state = state_broadcaster_->get_node()->activate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
   ASSERT_EQ(
     state_broadcaster_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
@@ -902,9 +900,8 @@ TEST_F(JointStateBroadcasterTest, UpdatePerformanceTest)
 
   state_broadcaster_->assign_interfaces({}, std::move(state_interfaces));
 
-  auto node_state = state_broadcaster_->configure();
-  node_state = state_broadcaster_->get_node()->activate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   if (!realtime_tools::configure_sched_fifo(50))
   {
@@ -945,11 +942,8 @@ TEST_F(JointStateBroadcasterTest, UpdatePerformanceTest)
 void JointStateBroadcasterTest::activate_and_get_joint_state_message(
   const std::string & topic, sensor_msgs::msg::JointState & joint_state_msg)
 {
-  auto node_state = state_broadcaster_->configure();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
-
-  node_state = state_broadcaster_->get_node()->activate();
-  ASSERT_EQ(node_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   sensor_msgs::msg::JointState::SharedPtr received_msg;
   rclcpp::Node test_node("test_node");
@@ -1029,9 +1023,9 @@ TEST_F(JointStateBroadcasterTest, ExtraJointStatePublishTest)
   SetUpStateBroadcaster({}, {}, {rclcpp::Parameter("extra_joints", extra_joint_names)});
 
   // configure ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   std::vector<std::string> all_joint_names = joint_names_;
   all_joint_names.insert(all_joint_names.end(), extra_joint_names.begin(), extra_joint_names.end());
@@ -1059,8 +1053,8 @@ TEST_F(JointStateBroadcasterTest, NoThrowWithBooleanInterfaceTest)
   state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
 
   // configure and activate ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   // update should not throw
   ASSERT_NO_THROW(
@@ -1083,8 +1077,8 @@ TEST_F(JointStateBroadcasterTest, NoThrowWithBooleanAndDoubleInterfaceTest)
   state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
 
   // configure and activate ok
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   // update should not throw
   ASSERT_NO_THROW(
@@ -1124,8 +1118,8 @@ TEST_F(JointStateBroadcasterTest, CorrectMappingWhenInterfaceReadFailsTest)
   state_ifs.emplace_back(j3);
   state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
 
-  ASSERT_EQ(state_broadcaster_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(state_broadcaster_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
   ASSERT_THAT(
     state_broadcaster_->joint_state_msg_.name,

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -562,11 +562,22 @@ TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesAllMissing)
   ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
   // is none of requested interfaces do not exist, the controller will not be activated
-  EXPECT_THAT(
-    [this]() { activate_succeeds(state_broadcaster_); },
-    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
-      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
-                                                                 // then Unconfigured(1)
+  try
+  {
+    activate_succeeds(state_broadcaster_);
+    FAIL() << "Expected std::runtime_error to be thrown";
+  }
+  catch (const std::runtime_error & e)
+  {
+    EXPECT_STREQ(
+      e.what(),
+      "Unexpected controller state in activate_succeeds: 1");  // State goes to ErrorProcessing then
+                                                               // Unconfigured(1)
+  }
+  catch (...)
+  {
+    FAIL() << "Expected std::runtime_error, but a different exception was thrown";
+  }
 }
 
 TEST_F(JointStateBroadcasterTest, ActivateTestTwoJointTwoInterfacesOneMissing)

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -21,9 +21,15 @@
 #include <string>
 #include <vector>
 
+#include "controller_interface/test_utils.hpp"
+
 #include "joint_state_broadcaster/joint_state_broadcaster.hpp"
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::HW_IF_POSITION;

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -82,7 +82,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_trajectory_controller
     test/test_trajectory_controller.cpp)
-  set_tests_properties(test_trajectory_controller PROPERTIES TIMEOUT 220)
+  set_tests_properties(test_trajectory_controller PROPERTIES TIMEOUT 240)
   target_link_libraries(test_trajectory_controller
     joint_trajectory_controller
     ros2_control_test_assets::ros2_control_test_assets

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -1159,7 +1159,7 @@ TEST_P(TestTrajectoryActionsTestParameterized, deactivate_controller_aborts_acti
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
       }
       RCLCPP_INFO(node_->get_logger(), "Controller hardware thread finished");
-      traj_controller_->get_node()->deactivate();
+      EXPECT_TRUE(deactivate_succeeds(traj_controller_));
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     });
 

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -2753,11 +2753,22 @@ TEST_F(
   ASSERT_TRUE(configure_succeeds(traj_controller_));
 
   AssignInterfaces();
-  EXPECT_THAT(
-    [this]() { activate_succeeds(traj_controller_); },
-    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
-      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
-                                                                 // then Unconfigured(1)
+  try
+  {
+    activate_succeeds(traj_controller_);
+    FAIL() << "Expected std::runtime_error to be thrown";
+  }
+  catch (const std::runtime_error & e)
+  {
+    EXPECT_STREQ(
+      e.what(),
+      "Unexpected controller state in activate_succeeds: 1");  // State goes to ErrorProcessing then
+                                                               // Unconfigured(1)
+  }
+  catch (...)
+  {
+    FAIL() << "Expected std::runtime_error, but a different exception was thrown";
+  }
 }
 
 TEST_F(
@@ -2774,11 +2785,22 @@ TEST_F(
   ASSERT_TRUE(configure_succeeds(traj_controller_));
 
   AssignInterfaces();
-  EXPECT_THAT(
-    [this]() { activate_succeeds(traj_controller_); },
-    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
-      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
-                                                                 // then Unconfigured(1)
+  try
+  {
+    activate_succeeds(traj_controller_);
+    FAIL() << "Expected std::runtime_error to be thrown";
+  }
+  catch (const std::runtime_error & e)
+  {
+    EXPECT_STREQ(
+      e.what(),
+      "Unexpected controller state in activate_succeeds: 1");  // State goes to ErrorProcessing then
+                                                               // Unconfigured(1)
+  }
+  catch (...)
+  {
+    FAIL() << "Expected std::runtime_error, but a different exception was thrown";
+  }
 }
 
 TEST_F(TrajectoryControllerTest, scaling_state_interface_sets_value)

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -59,8 +59,7 @@ TEST_P(TrajectoryControllerTestParameterized, check_interface_names)
   rclcpp::executors::MultiThreadedExecutor executor;
   SetUpTrajectoryController(executor);
 
-  const auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
 
   compare_joints(joint_names_, joint_names_);
 }
@@ -72,8 +71,7 @@ TEST_P(TrajectoryControllerTestParameterized, check_interface_names_with_command
   const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names_);
   SetUpTrajectoryController(executor, {command_joint_names_param});
 
-  const auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
 
   compare_joints(joint_names_, command_joint_names_);
 }
@@ -90,8 +88,7 @@ TEST_P(
   const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
   SetUpTrajectoryController(executor, {command_joint_names_param});
 
-  const auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
 
   compare_joints(joint_names_, command_joint_names);
 }
@@ -106,8 +103,7 @@ TEST_P(
   const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
   SetUpTrajectoryController(executor, {command_joint_names_param});
 
-  const auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_FALSE(configure_succeeds(traj_controller_));
 }
 
 TEST_P(
@@ -120,8 +116,7 @@ TEST_P(
   const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
   SetUpTrajectoryController(executor, {command_joint_names_param});
 
-  const auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_FALSE(configure_succeeds(traj_controller_));
 }
 
 TEST_P(TrajectoryControllerTestParameterized, activate)
@@ -129,8 +124,7 @@ TEST_P(TrajectoryControllerTestParameterized, activate)
   rclcpp::executors::MultiThreadedExecutor executor;
   SetUpTrajectoryController(executor);
 
-  auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
 
   auto cmd_if_conf = traj_controller_->command_interface_configuration();
   ASSERT_EQ(cmd_if_conf.names.size(), joint_names_.size() * command_interface_types_.size());
@@ -140,8 +134,8 @@ TEST_P(TrajectoryControllerTestParameterized, activate)
   ASSERT_EQ(state_if_conf.names.size(), joint_names_.size() * state_interface_types_.size());
   EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  state = ActivateTrajectoryController();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
+  AssignInterfaces();
+  ASSERT_TRUE(activate_succeeds(traj_controller_));
 
   executor.cancel();
 }
@@ -169,8 +163,7 @@ TEST_P(TrajectoryControllerTestParameterized, cleanup)
 
   DeactivateTrajectoryController();
 
-  auto state = traj_controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  ASSERT_TRUE(cleanup_succeeds(traj_controller_));
 
   executor.cancel();
 }
@@ -181,12 +174,10 @@ TEST_P(TrajectoryControllerTestParameterized, cleanup_after_configure)
   SetUpTrajectoryController(executor);
 
   // configure controller
-  auto state = traj_controller_->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
 
   // cleanup controller
-  state = traj_controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  ASSERT_TRUE(cleanup_succeeds(traj_controller_));
 
   executor.cancel();
 }
@@ -200,11 +191,10 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   traj_controller_->get_node()->set_parameter(rclcpp::Parameter("update_rate", 10));
 
   // This call is replacing the way parameters are set via launch
-  auto state = traj_controller_->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
 
-  state = ActivateTrajectoryController();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  AssignInterfaces();
+  ASSERT_TRUE(activate_succeeds(traj_controller_));
   EXPECT_EQ(INITIAL_POS_JOINT1, joint_pos_[0]);
   EXPECT_EQ(INITIAL_POS_JOINT2, joint_pos_[1]);
   EXPECT_EQ(INITIAL_POS_JOINT3, joint_pos_[2]);
@@ -249,8 +239,8 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   // wait so controller would have processed the third point when reactivated -> but it shouldn't
   std::this_thread::sleep_for(std::chrono::milliseconds(3000));
 
-  state = ActivateTrajectoryController(false, deactivated_positions);
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
+  AssignInterfaces(false, deactivated_positions);
+  ASSERT_TRUE(activate_succeeds(traj_controller_));
 
   // it should still be holding the position at time of deactivation
   // i.e., active but trivial trajectory (one point only)
@@ -2667,8 +2657,7 @@ TEST_F(TrajectoryControllerTest, incorrect_initialization_using_interface_parame
   command_interface_types_ = {"velocity"};
   state_interface_types_ = {"position"};
   EXPECT_EQ(SetUpTrajectoryControllerLocal(), controller_interface::return_type::OK);
-  auto state = traj_controller_->configure();
-  EXPECT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_FALSE(configure_succeeds(traj_controller_));
   state_interface_types_ = {"velocity"};
   EXPECT_EQ(SetUpTrajectoryControllerLocal(), controller_interface::return_type::ERROR);
 
@@ -2676,8 +2665,7 @@ TEST_F(TrajectoryControllerTest, incorrect_initialization_using_interface_parame
   command_interface_types_ = {"effort"};
   state_interface_types_ = {"position"};
   EXPECT_EQ(SetUpTrajectoryControllerLocal(), controller_interface::return_type::OK);
-  state = traj_controller_->configure();
-  EXPECT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_FALSE(configure_succeeds(traj_controller_));
   state_interface_types_ = {"velocity"};
   EXPECT_EQ(SetUpTrajectoryControllerLocal(), controller_interface::return_type::ERROR);
 
@@ -2685,8 +2673,7 @@ TEST_F(TrajectoryControllerTest, incorrect_initialization_using_interface_parame
   command_interface_types_ = {"effort", "position"};
   state_interface_types_ = {"position"};
   EXPECT_EQ(SetUpTrajectoryControllerLocal(), controller_interface::return_type::OK);
-  state = traj_controller_->configure();
-  EXPECT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_FALSE(configure_succeeds(traj_controller_));
   state_interface_types_ = {"velocity"};
   EXPECT_EQ(SetUpTrajectoryControllerLocal(), controller_interface::return_type::ERROR);
 }
@@ -2763,11 +2750,14 @@ TEST_F(
   };
   SetUpTrajectoryController(executor, params);
 
-  auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
 
-  state = ActivateTrajectoryController();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  AssignInterfaces();
+  EXPECT_THAT(
+    [this]() { activate_succeeds(traj_controller_); },
+    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
+      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
+                                                                 // then Unconfigured(1)
 }
 
 TEST_F(
@@ -2781,11 +2771,14 @@ TEST_F(
   };
   SetUpTrajectoryController(executor, params);
 
-  auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
 
-  state = ActivateTrajectoryController();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  AssignInterfaces();
+  EXPECT_THAT(
+    [this]() { activate_succeeds(traj_controller_); },
+    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
+      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
+                                                                 // then Unconfigured(1)
 }
 
 TEST_F(TrajectoryControllerTest, scaling_state_interface_sets_value)
@@ -2871,8 +2864,7 @@ TEST_F(TrajectoryControllerTest, activate_with_scaling_interfaces)
   };
   SetUpTrajectoryController(executor, params);
 
-  auto state = traj_controller_->configure();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
 
   auto cmd_if_conf = traj_controller_->command_interface_configuration();
   ASSERT_EQ(cmd_if_conf.names.size(), joint_names_.size() * command_interface_types_.size() + 1);
@@ -2882,8 +2874,8 @@ TEST_F(TrajectoryControllerTest, activate_with_scaling_interfaces)
   ASSERT_EQ(state_if_conf.names.size(), joint_names_.size() * state_interface_types_.size() + 1);
   EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
 
-  state = ActivateTrajectoryController();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_ACTIVE);
+  AssignInterfaces();
+  ASSERT_TRUE(activate_succeeds(traj_controller_));
 
   executor.cancel();
 }
@@ -3171,7 +3163,7 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_velocity_command_ra
 
   // separate_cmd_and_state_values=true: position/velocity commands write to joint_pos_/
   // joint_vel_; state interfaces read from joint_state_pos_/joint_state_vel_.
-  // ActivateTrajectoryController initialises joint_state_vel_ to INITIAL_VEL_JOINTS (0.0),
+  // AssignInterfaces initialises joint_state_vel_ to INITIAL_VEL_JOINTS (0.0),
   // so we set it manually to initial_vel after activation.
   SetUpAndActivateTrajectoryController(
     executor, params, true, 0.0, 1.0, INITIAL_POS_JOINTS, initial_vel);

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "controller_interface/test_utils.hpp"
 #include "gmock/gmock.h"
 
 #include "control_msgs/msg/joint_trajectory_controller_state.hpp"
@@ -29,6 +30,11 @@
 #include "joint_trajectory_controller/tolerances.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::cleanup_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 namespace
 {
@@ -272,7 +278,7 @@ public:
     const std::vector<rclcpp::Parameter> & parameters = {},
     const std::string & urdf = ros2_control_test_assets::minimal_robot_urdf)
   {
-    traj_controller_ = std::make_shared<TestableJointTrajectoryController>();
+    traj_controller_ = std::make_unique<TestableJointTrajectoryController>();
 
     auto node_options = rclcpp::NodeOptions();
     std::vector<rclcpp::Parameter> parameter_overrides;
@@ -335,14 +341,16 @@ public:
 
     // set pid parameters before configure
     SetPidParameters(k_p, ff);
-    traj_controller_->configure();
+    ASSERT_TRUE(configure_succeeds(traj_controller_));
 
-    ActivateTrajectoryController(
+    AssignInterfaces(
       separate_cmd_and_state_values, initial_pos_joints, initial_vel_joints, initial_acc_joints,
       initial_eff_joints);
+
+    ASSERT_TRUE(activate_succeeds(traj_controller_));
   }
 
-  rclcpp_lifecycle::State ActivateTrajectoryController(
+  void AssignInterfaces(
     bool separate_cmd_and_state_values = false,
     const std::vector<double> initial_pos_joints = INITIAL_POS_JOINTS,
     const std::vector<double> initial_vel_joints = INITIAL_VEL_JOINTS,
@@ -420,7 +428,6 @@ public:
     loaned_command_ifs.emplace_back(gpio_command_interfaces_.back(), nullptr);
 
     traj_controller_->assign_interfaces(std::move(loaned_command_ifs), std::move(loaned_state_ifs));
-    return traj_controller_->get_node()->activate();
   }
 
   void DeactivateTrajectoryController()
@@ -429,9 +436,7 @@ public:
     {
       if (traj_controller_->get_lifecycle_id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
       {
-        EXPECT_EQ(
-          traj_controller_->get_node()->deactivate().id(),
-          lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+        ASSERT_TRUE(deactivate_succeeds(traj_controller_));
         traj_controller_->release_interfaces();
       }
     }
@@ -802,7 +807,7 @@ public:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr trajectory_publisher_;
 
-  std::shared_ptr<TestableJointTrajectoryController> traj_controller_;
+  std::unique_ptr<TestableJointTrajectoryController> traj_controller_;
   rclcpp::Subscription<control_msgs::msg::JointTrajectoryControllerState>::SharedPtr
     state_subscriber_;
   mutable std::mutex state_mutex_;

--- a/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.cpp
+++ b/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.cpp
@@ -43,14 +43,14 @@ TEST_F(OmniWheelDriveControllerTest, configure_fails_with_less_than_three_wheels
     InitController({"first_wheel_joint", "second_wheel_joint"}),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_ERROR);
+  EXPECT_FALSE(configure_succeeds(controller_));
 }
 
 TEST_F(OmniWheelDriveControllerTest, when_controller_configured_expect_properly_exported_interfaces)
 {
   ASSERT_EQ(InitController(), controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
   // Check command interfaces configuration
   auto command_interfaces = controller_->command_interface_configuration();
@@ -102,7 +102,7 @@ TEST_F(OmniWheelDriveControllerTest, configure_succeeds_tf_prefix_no_namespace)
        rclcpp::Parameter("base_frame_id", rclcpp::ParameterValue(base_link_id))}),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
   nav_msgs::msg::Odometry odometry_message = controller_->odometry_message_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -128,7 +128,7 @@ TEST_F(OmniWheelDriveControllerTest, configure_succeeds_tf_blank_prefix_no_names
        rclcpp::Parameter("base_frame_id", rclcpp::ParameterValue(base_link_id))}),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
   nav_msgs::msg::Odometry odometry_message = controller_->odometry_message_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -157,7 +157,7 @@ TEST_F(OmniWheelDriveControllerTest, configure_succeeds_tf_prefix_set_namespace)
       test_namespace),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
   nav_msgs::msg::Odometry odometry_message = controller_->odometry_message_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -185,7 +185,7 @@ TEST_F(OmniWheelDriveControllerTest, configure_succeeds_tf_tilde_prefix_set_name
       test_namespace),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
   nav_msgs::msg::Odometry odometry_message = controller_->odometry_message_;
   std::string test_odom_frame_id = odometry_message.header.frame_id;
@@ -201,17 +201,21 @@ TEST_F(OmniWheelDriveControllerTest, activate_fails_without_resources_assigned)
 {
   ASSERT_EQ(InitController(), controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_ERROR);
+  EXPECT_TRUE(configure_succeeds(controller_));
+  EXPECT_THAT(
+    [this]() { activate_succeeds(controller_); },
+    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
+      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
+                                                                 // then Unconfigured(1)
 }
 
 TEST_F(OmniWheelDriveControllerTest, activate_succeeds_with_pos_resources_assigned)
 {
   ASSERT_EQ(InitController(), controller_interface::return_type::OK);
   // We implicitly test that by default position feedback is required
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(activate_succeeds(controller_));
 }
 
 TEST_F(OmniWheelDriveControllerTest, activate_succeeds_with_vel_resources_assigned)
@@ -221,9 +225,9 @@ TEST_F(OmniWheelDriveControllerTest, activate_succeeds_with_vel_resources_assign
       wheel_names_, 0.0, {rclcpp::Parameter("position_feedback", rclcpp::ParameterValue(false))}),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesVelFeedback();
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(activate_succeeds(controller_));
 }
 
 TEST_F(OmniWheelDriveControllerTest, activate_fails_with_wrong_resources_assigned_1)
@@ -233,9 +237,13 @@ TEST_F(OmniWheelDriveControllerTest, activate_fails_with_wrong_resources_assigne
       wheel_names_, 0.0, {rclcpp::Parameter("position_feedback", rclcpp::ParameterValue(false))}),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_ERROR);
+  EXPECT_THAT(
+    [this]() { activate_succeeds(controller_); },
+    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
+      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
+                                                                 // then Unconfigured(1)
 }
 
 TEST_F(OmniWheelDriveControllerTest, activate_fails_with_wrong_resources_assigned_2)
@@ -245,9 +253,13 @@ TEST_F(OmniWheelDriveControllerTest, activate_fails_with_wrong_resources_assigne
       wheel_names_, 0.0, {rclcpp::Parameter("position_feedback", rclcpp::ParameterValue(true))}),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesVelFeedback();
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_ERROR);
+  EXPECT_THAT(
+    [this]() { activate_succeeds(controller_); },
+    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
+      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
+                                                                 // then Unconfigured(1)
 }
 
 // When not in chained mode, we want to test that
@@ -266,12 +278,10 @@ TEST_F(OmniWheelDriveControllerTest, chainable_controller_unchained_mode)
   ASSERT_TRUE(controller_->set_chained_mode(false));
   ASSERT_FALSE(controller_->is_in_chained_mode());
 
-  auto state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -319,23 +329,20 @@ TEST_F(OmniWheelDriveControllerTest, chainable_controller_unchained_mode)
 
   // Now check that the command interfaces are set to 0.0 on deactivation
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
   for (size_t i = 0; i < command_itfs_.size(); i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
   // cleanup
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  EXPECT_TRUE(cleanup_succeeds(controller_));
   for (size_t i = 0; i < command_itfs_.size(); i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
-  state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   executor.cancel();
 }
 
@@ -354,12 +361,10 @@ TEST_F(OmniWheelDriveControllerTest, chainable_controller_chained_mode)
   ASSERT_TRUE(controller_->set_chained_mode(true));
   ASSERT_TRUE(controller_->is_in_chained_mode());
 
-  auto state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -390,23 +395,20 @@ TEST_F(OmniWheelDriveControllerTest, chainable_controller_chained_mode)
 
   // Now check that the command interfaces are set to 0.0 on deactivation
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
   for (size_t i = 0; i < command_itfs_.size(); i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
   // cleanup
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  EXPECT_TRUE(cleanup_succeeds(controller_));
   for (size_t i = 0; i < command_itfs_.size(); i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
-  state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   executor.cancel();
 }
 
@@ -422,12 +424,10 @@ TEST_F(OmniWheelDriveControllerTest, deactivate_then_activate)
 
   ASSERT_TRUE(controller_->set_chained_mode(false));
 
-  auto state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -460,8 +460,7 @@ TEST_F(OmniWheelDriveControllerTest, deactivate_then_activate)
   // Now check that the command interfaces are set to 0.0 on deactivation
   // (despite calls to update())
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
   ASSERT_EQ(
     controller_->update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
@@ -471,8 +470,7 @@ TEST_F(OmniWheelDriveControllerTest, deactivate_then_activate)
   }
 
   // Activate again
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -500,10 +498,8 @@ TEST_F(OmniWheelDriveControllerTest, deactivate_then_activate)
 
   // Deactivate again and cleanup
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
+  EXPECT_TRUE(cleanup_succeeds(controller_));
   executor.cancel();
 }
 
@@ -516,12 +512,10 @@ TEST_F(OmniWheelDriveControllerTest, command_with_zero_timestamp_is_accepted_wit
 
   ASSERT_TRUE(controller_->set_chained_mode(false));
 
-  auto state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -541,10 +535,8 @@ TEST_F(OmniWheelDriveControllerTest, command_with_zero_timestamp_is_accepted_wit
 
   // Deactivate and cleanup
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
+  EXPECT_TRUE(cleanup_succeeds(controller_));
   executor.cancel();
 }
 
@@ -556,15 +548,13 @@ TEST_F(OmniWheelDriveControllerTest, 3_wheel_test)
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  auto state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   wheels_pos_states_ = {1, 1, 1};
   wheels_vel_states_ = {1, 1, 1};
   wheels_vel_cmds_ = {0.1, 0.2, 0.3};
   assignResourcesPosFeedback({"wheel_1", "wheel_2", "wheel_3"});
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -595,23 +585,20 @@ TEST_F(OmniWheelDriveControllerTest, 3_wheel_test)
 
   // Now check that the command interfaces are set to 0.0 on deactivation
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
   for (size_t i = 0; i < 3; i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
   // cleanup
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  EXPECT_TRUE(cleanup_succeeds(controller_));
   for (size_t i = 0; i < 3; i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
-  state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   executor.cancel();
 }
 
@@ -624,15 +611,13 @@ TEST_F(OmniWheelDriveControllerTest, 3_wheel_rot_test)
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  auto state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   wheels_pos_states_ = {1, 1, 1};
   wheels_vel_states_ = {1, 1, 1};
   wheels_vel_cmds_ = {0.1, 0.2, 0.3};
   assignResourcesPosFeedback({"wheel_1", "wheel_2", "wheel_3"});
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -663,23 +648,20 @@ TEST_F(OmniWheelDriveControllerTest, 3_wheel_rot_test)
 
   // Now check that the command interfaces are set to 0.0 on deactivation
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
   for (size_t i = 0; i < 3; i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
   // cleanup
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  EXPECT_TRUE(cleanup_succeeds(controller_));
   for (size_t i = 0; i < 3; i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
-  state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   executor.cancel();
 }
 
@@ -692,15 +674,13 @@ TEST_F(OmniWheelDriveControllerTest, 4_wheel_rot_test)
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  auto state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   wheels_pos_states_ = {1, 1, 1, 1};
   wheels_vel_states_ = {1, 1, 1, 1};
   wheels_vel_cmds_ = {0.1, 0.2, 0.3, 0.4};
   assignResourcesPosFeedback({"wheel_1", "wheel_2", "wheel_3", "wheel_4"});
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -731,23 +711,20 @@ TEST_F(OmniWheelDriveControllerTest, 4_wheel_rot_test)
 
   // Now check that the command interfaces are set to 0.0 on deactivation
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
   for (size_t i = 0; i < 4; i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
   // cleanup
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  EXPECT_TRUE(cleanup_succeeds(controller_));
   for (size_t i = 0; i < 4; i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
-  state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   executor.cancel();
 }
 
@@ -760,15 +737,13 @@ TEST_F(OmniWheelDriveControllerTest, 5_wheel_test)
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  auto state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   wheels_pos_states_ = {1, 1, 1, 1, 1};
   wheels_vel_states_ = {1, 1, 1, 1, 1};
   wheels_vel_cmds_ = {0.1, 0.2, 0.3, 0.4, 0.5};
   assignResourcesPosFeedback({"wheel_1", "wheel_2", "wheel_3", "wheel_4", "wheel_5"});
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -799,23 +774,20 @@ TEST_F(OmniWheelDriveControllerTest, 5_wheel_test)
 
   // Now check that the command interfaces are set to 0.0 on deactivation
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
   for (size_t i = 0; i < 5; i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
   // cleanup
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  EXPECT_TRUE(cleanup_succeeds(controller_));
   for (size_t i = 0; i < 5; i++)
   {
     EXPECT_EQ(command_itfs_[i]->get_optional().value(), 0.0);
   }
 
-  state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   executor.cancel();
 }
 
@@ -827,12 +799,10 @@ TEST_F(OmniWheelDriveControllerTest, odometry_set_service)
   // chained mode needed to write directly to reference interfaces
   controller_->set_chained_mode(true);
 
-  auto state = controller_->get_node()->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   const double dt = 0.01;  // 100 Hz
   rclcpp::Time test_time(0, 0, RCL_ROS_TIME);
@@ -879,8 +849,7 @@ TEST_F(OmniWheelDriveControllerTest, odometry_set_service)
   EXPECT_GT(controller_->odometry_.getY(), start_y);
 
   // 4. Cleanup
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(deactivate_succeeds(controller_));
 }
 
 int main(int argc, char ** argv)

--- a/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.cpp
+++ b/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.cpp
@@ -202,11 +202,22 @@ TEST_F(OmniWheelDriveControllerTest, activate_fails_without_resources_assigned)
   ASSERT_EQ(InitController(), controller_interface::return_type::OK);
 
   EXPECT_TRUE(configure_succeeds(controller_));
-  EXPECT_THAT(
-    [this]() { activate_succeeds(controller_); },
-    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
-      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
-                                                                 // then Unconfigured(1)
+  try
+  {
+    activate_succeeds(controller_);
+    FAIL() << "Expected std::runtime_error to be thrown";
+  }
+  catch (const std::runtime_error & e)
+  {
+    EXPECT_STREQ(
+      e.what(),
+      "Unexpected controller state in activate_succeeds: 1");  // State goes to ErrorProcessing then
+                                                               // Unconfigured(1)
+  }
+  catch (...)
+  {
+    FAIL() << "Expected std::runtime_error, but a different exception was thrown";
+  }
 }
 
 TEST_F(OmniWheelDriveControllerTest, activate_succeeds_with_pos_resources_assigned)
@@ -239,11 +250,22 @@ TEST_F(OmniWheelDriveControllerTest, activate_fails_with_wrong_resources_assigne
 
   EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
-  EXPECT_THAT(
-    [this]() { activate_succeeds(controller_); },
-    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
-      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
-                                                                 // then Unconfigured(1)
+  try
+  {
+    activate_succeeds(controller_);
+    FAIL() << "Expected std::runtime_error to be thrown";
+  }
+  catch (const std::runtime_error & e)
+  {
+    EXPECT_STREQ(
+      e.what(),
+      "Unexpected controller state in activate_succeeds: 1");  // State goes to ErrorProcessing then
+                                                               // Unconfigured(1)
+  }
+  catch (...)
+  {
+    FAIL() << "Expected std::runtime_error, but a different exception was thrown";
+  }
 }
 
 TEST_F(OmniWheelDriveControllerTest, activate_fails_with_wrong_resources_assigned_2)
@@ -255,11 +277,22 @@ TEST_F(OmniWheelDriveControllerTest, activate_fails_with_wrong_resources_assigne
 
   EXPECT_TRUE(configure_succeeds(controller_));
   assignResourcesVelFeedback();
-  EXPECT_THAT(
-    [this]() { activate_succeeds(controller_); },
-    testing::ThrowsMessage<std::runtime_error>(testing::StrEq(
-      "Unexpected controller state in activate_succeeds: 1")));  // State goes to ErrorProcessing
-                                                                 // then Unconfigured(1)
+  try
+  {
+    activate_succeeds(controller_);
+    FAIL() << "Expected std::runtime_error to be thrown";
+  }
+  catch (const std::runtime_error & e)
+  {
+    EXPECT_STREQ(
+      e.what(),
+      "Unexpected controller state in activate_succeeds: 1");  // State goes to ErrorProcessing then
+                                                               // Unconfigured(1)
+  }
+  catch (...)
+  {
+    FAIL() << "Expected std::runtime_error, but a different exception was thrown";
+  }
 }
 
 // When not in chained mode, we want to test that

--- a/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.hpp
+++ b/omni_wheel_drive_controller/test/test_omni_wheel_drive_controller.hpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "controller_interface/test_utils.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
@@ -34,13 +35,16 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp/utilities.hpp"
 
+using controller_interface::activate_succeeds;
+using controller_interface::cleanup_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
+
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::HW_IF_VELOCITY;
 
 namespace
 {
-constexpr auto NODE_SUCCESS = controller_interface::CallbackReturn::SUCCESS;
-constexpr auto NODE_ERROR = controller_interface::CallbackReturn::ERROR;
 std::vector<std::string> wheel_names_ = {
   "front_wheel_joint", "left_wheel_joint", "back_wheel_joint", "right_wheel_joint"};
 }  // namespace


### PR DESCRIPTION
Partial fix for https://github.com/ros-controls/ros2_controllers/issues/1660, utilize test utility functions to call appropriate lifecycle transitions and evaluate expected state.
This PR covers:
joint_trajectory_controller
joint_state_broadcaster
omni_wheel_drive_controller
bicycle_steering_controller

Hi @christophfroehlich, please take a look at the PR specifically:

- joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
traj_controller is now declared as unique_ptr since the test util functions accept unique_ptr as parameter. Is there any specific reason this could not be a unique_ptr? other controller tests declare the controller/broadcaster using the same.

- joint_trajectory_controller/CMakeLists.txt
Increase test timeout as I was seeing test failure due to timeout (~236 seconds) when running in my local machine, not sure the same can be observed in CI