### PR TITLE
Deliver abort action result before destroying goal handle on preemption

### DIFF
--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -116,7 +116,7 @@ Preemption policy [#f1]_
 
 Only one action goal can be active at any moment, or none if the topic interface is used. Path and goal tolerances are checked only for the trajectory segments of the active goal.
 
-When an active action goal is preempted by another command coming from the action interface, the goal is canceled and the client is notified. The trajectory is replaced in a defined way, see :ref:`trajectory replacement <joint_trajectory_controller_trajectory_replacement>`.
+When an active action goal is preempted by another command coming from the action interface, the goal is aborted and the client is notified. The trajectory is replaced in a defined way, see :ref:`trajectory replacement <joint_trajectory_controller_trajectory_replacement>`.
 
 Sending an empty trajectory message from the topic interface (not the action interface) will override the current action goal and not abort the action.
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1822,8 +1822,10 @@ void JointTrajectoryController::preempt_active_goal()
   {
     auto action_res = std::make_shared<FollowJTrajAction::Result>();
     action_res->set__error_code(FollowJTrajAction::Result::INVALID_GOAL);
-    action_res->set__error_string("Current goal cancelled due to new incoming action.");
-    active_goal->setCanceled(action_res);
+    action_res->set__error_string("Current goal preempted by new incoming action.");
+    active_goal->setAborted(action_res);
+    // Deliver result now; the old goal_handle_timer_ is destroyed after this returns.
+    active_goal->runNonRealtime();
     rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
   }
 }

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -707,17 +707,13 @@ TEST_F(TestTrajectoryActions, preempted_goal_receives_aborted_result)
     std::vector<JointTrajectoryPoint> points(1);
     points[0].time_from_start = rclcpp::Duration::from_seconds(2.0);
     points[0].positions = {4.0, 5.0, 6.0};
-    control_msgs::action::FollowJointTrajectory_Goal goal_a;
-    goal_a.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
-    goal_a.trajectory.joint_names = joint_names_;
-    goal_a.trajectory.points = points;
     GoalOptions opts_a;
     opts_a.result_callback = [&result_a, &error_code_a](const GoalHandle::WrappedResult & r)
     {
       result_a = r.code;
       error_code_a = r.result->error_code;
     };
-    action_client_->async_send_goal(goal_a, opts_a);
+    sendActionGoal(points, 1.0, opts_a);
   }
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
@@ -726,11 +722,7 @@ TEST_F(TestTrajectoryActions, preempted_goal_receives_aborted_result)
     std::vector<JointTrajectoryPoint> points(1);
     points[0].time_from_start = rclcpp::Duration::from_seconds(0.1);
     points[0].positions = {1.0, 2.0, 3.0};
-    control_msgs::action::FollowJointTrajectory_Goal goal_b;
-    goal_b.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
-    goal_b.trajectory.joint_names = joint_names_;
-    goal_b.trajectory.points = points;
-    action_client_->async_send_goal(goal_b, goal_options_);
+    sendActionGoal(points, 1.0, goal_options_);
   }
 
   controller_hw_thread_.join();

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -696,6 +696,50 @@ TEST_F(TestTrajectoryActions, test_tolerances_via_actions)
   }
 }
 
+TEST_F(TestTrajectoryActions, preempted_goal_receives_aborted_result)
+{
+  SetUpExecutor();
+  SetUpControllerHardware();
+
+  rclcpp_action::ResultCode result_a = rclcpp_action::ResultCode::UNKNOWN;
+  int error_code_a = -1;
+  {
+    std::vector<JointTrajectoryPoint> points(1);
+    points[0].time_from_start = rclcpp::Duration::from_seconds(2.0);
+    points[0].positions = {4.0, 5.0, 6.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_a;
+    goal_a.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_a.trajectory.joint_names = joint_names_;
+    goal_a.trajectory.points = points;
+    GoalOptions opts_a;
+    opts_a.result_callback = [&result_a, &error_code_a](const GoalHandle::WrappedResult & r)
+    {
+      result_a = r.code;
+      error_code_a = r.result->error_code;
+    };
+    action_client_->async_send_goal(goal_a, opts_a);
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  // goal B preempts A
+  {
+    std::vector<JointTrajectoryPoint> points(1);
+    points[0].time_from_start = rclcpp::Duration::from_seconds(0.1);
+    points[0].positions = {1.0, 2.0, 3.0};
+    control_msgs::action::FollowJointTrajectory_Goal goal_b;
+    goal_b.goal_time_tolerance = rclcpp::Duration::from_seconds(1.0);
+    goal_b.trajectory.joint_names = joint_names_;
+    goal_b.trajectory.points = points;
+    action_client_->async_send_goal(goal_b, goal_options_);
+  }
+
+  controller_hw_thread_.join();
+
+  EXPECT_EQ(rclcpp_action::ResultCode::ABORTED, result_a);
+  EXPECT_EQ(control_msgs::action::FollowJointTrajectory_Result::INVALID_GOAL, error_code_a);
+  EXPECT_EQ(rclcpp_action::ResultCode::SUCCEEDED, common_resultcode_);
+}
+
 TEST_P(TestTrajectoryActionsTestParameterized, test_state_tolerances_fail)
 {
   // set joint tolerance parameters


### PR DESCRIPTION

## Description

preempt_active_goal() called `setCanceled()`, which only sets an in-memory flag, then immediately destroyed the `goal_handle_timer_` before `runNonRealtime()` could fire. The result message was never sent over the network, leaving the action client waiting forever. Fix: call `runNonRealtime()` explicitly before the timer is reset to guarantee result delivery. Also corrects the result code from CANCELED (client-requested) to ABORTED (server-decided preemption)

### Is this user-facing behavior change?

Yes. Action clients whose goal is preempted by a new incoming trajectory now receive an ABORTED result immediately. 

### Did you use Generative AI?

Yes, Cluade for the test case. 

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
