### PR TITLE
Final test cleanup - call appropriate lifecycle transitions

### DIFF
--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -60,13 +60,6 @@ using controller_interface::deactivate_succeeds;
 namespace
 {
 const double COMMON_THRESHOLD = 0.001;
-
-constexpr auto NODE_SUCCESS =
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-constexpr auto NODE_FAILURE =
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
-constexpr auto NODE_ERROR =
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
 }  // namespace
 
 // subclassing and friending so we can access member variables

--- a/chained_filter_controller/test/test_chained_filter.cpp
+++ b/chained_filter_controller/test/test_chained_filter.cpp
@@ -25,7 +25,6 @@
 #include "chained_filter_controller/chained_filter.hpp"
 
 using chained_filter_controller::ChainedFilter;
-using controller_interface::CallbackReturn;
 using testing::SizeIs;
 
 using hardware_interface::LoanedStateInterface;

--- a/chained_filter_controller/test/test_multiple_chained_filter.cpp
+++ b/chained_filter_controller/test/test_multiple_chained_filter.cpp
@@ -25,7 +25,6 @@
 #include "chained_filter_controller/chained_filter.hpp"
 
 using chained_filter_controller::ChainedFilter;
-using controller_interface::CallbackReturn;
 using testing::SizeIs;
 
 using hardware_interface::LoanedStateInterface;
@@ -70,11 +69,9 @@ TEST_F(MultipleChainedFilterTest, ActivateReturnsSuccessWithoutError)
 {
   SetUpController();
 
-  auto configure_result = controller_->on_configure(rclcpp_lifecycle::State());
-  EXPECT_EQ(configure_result, CallbackReturn::SUCCESS);
+  EXPECT_TRUE(configure_succeeds(controller_));
 
-  auto activate_result = controller_->on_activate(rclcpp_lifecycle::State());
-  EXPECT_EQ(activate_result, CallbackReturn::SUCCESS);
+  EXPECT_TRUE(activate_succeeds(controller_));
 
   ASSERT_FALSE(controller_->is_in_chained_mode())
     << "No controller is claiming the reference interfaces (it has none).";
@@ -86,7 +83,7 @@ TEST_F(
 {
   SetUpController();
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   auto state_if_conf = controller_->state_interface_configuration();
   ASSERT_THAT(state_if_conf.names, SizeIs(2u));
@@ -117,8 +114,8 @@ TEST_F(
 TEST_F(MultipleChainedFilterTest, UpdateFilter_multiple_interfaces)
 {
   SetUpController();
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   ASSERT_EQ(
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),
@@ -154,8 +151,8 @@ TEST_F(MultipleChainedFilterTest, UpdateFilter_multiple_interfaces)
 TEST_F(MultipleChainedFilterTest, UpdateFilter_multiple_interfaces_config_per_input)
 {
   SetUpController("test_chained_filter_multiple_interfaces_config_per_input");
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   ASSERT_EQ(
     controller_->update_and_write_commands(rclcpp::Time(), rclcpp::Duration::from_seconds(0.1)),

--- a/chained_filter_controller/test/test_multiple_chained_filter.hpp
+++ b/chained_filter_controller/test/test_multiple_chained_filter.hpp
@@ -19,12 +19,16 @@
 #include <string>
 #include <vector>
 
+#include "controller_interface/test_utils.hpp"
 #include "gmock/gmock.h"
 
 #include "chained_filter_controller/chained_filter.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
 
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::StateInterface;

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -28,7 +28,6 @@
 #include "rclcpp/executor.hpp"
 #include "rclcpp/executors.hpp"
 
-using CallbackReturn = controller_interface::CallbackReturn;
 using controller_interface::activate_succeeds;
 using controller_interface::cleanup_succeeds;
 using controller_interface::configure_succeeds;
@@ -461,9 +460,9 @@ TEST_F(TestDiffDriveController, activate_succeeds_with_open_loop_assigned)
       {rclcpp::Parameter("open_loop", rclcpp::ParameterValue(true))}),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   assignResourcesNoFeedback();
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
 }
 
 TEST_F(TestDiffDriveController, test_speed_limiter)
@@ -841,9 +840,9 @@ TEST_F(TestDiffDriveController, activate_silently_ignores_with_unnecessary_resou
        rclcpp::Parameter("position_feedback", rclcpp::ParameterValue(false))}),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
 }
 
 TEST_F(TestDiffDriveController, activate_silently_ignores_with_unnecessary_resources_assigned_2)
@@ -855,9 +854,9 @@ TEST_F(TestDiffDriveController, activate_silently_ignores_with_unnecessary_resou
        rclcpp::Parameter("position_feedback", rclcpp::ParameterValue(true))}),
     controller_interface::return_type::OK);
 
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(controller_));
   assignResourcesVelFeedback();
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), CallbackReturn::SUCCESS);
+  ASSERT_TRUE(activate_succeeds(controller_));
 }
 
 TEST_F(TestDiffDriveController, cleanup)
@@ -1313,15 +1312,13 @@ TEST_F(TestDiffDriveController, odometry_set_service)
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  auto state = controller_->configure();
+  ASSERT_TRUE(configure_succeeds(controller_));
   assignResourcesPosFeedback();
 
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
   EXPECT_EQ(0.01, left_wheel_vel_cmd_->get_optional().value());
   EXPECT_EQ(0.02, right_wheel_vel_cmd_->get_optional().value());
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   rclcpp::Time test_time(0, 0, RCL_ROS_TIME);
   rclcpp::Duration period = rclcpp::Duration::from_seconds(0.1);
@@ -1366,10 +1363,9 @@ TEST_F(TestDiffDriveController, odometry_set_service)
 
   // 4. Deactivate and cleanup
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+  ASSERT_TRUE(deactivate_succeeds(controller_));
+  ASSERT_TRUE(cleanup_succeeds(controller_));
+
   executor.cancel();
 }
 
@@ -1390,13 +1386,11 @@ TEST_F(TestDiffDriveController, test_open_loop_odometry_with_clamped_input)
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  auto state = controller_->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   assignResourcesNoFeedback();
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -1432,10 +1426,8 @@ TEST_F(TestDiffDriveController, test_open_loop_odometry_with_clamped_input)
 
   // Safely spin down the lifecycle
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  ASSERT_TRUE(deactivate_succeeds(controller_));
+  ASSERT_TRUE(cleanup_succeeds(controller_));
   executor.cancel();
 }
 
@@ -1451,13 +1443,11 @@ TEST_F(TestDiffDriveController, test_open_loop_odometry_with_unclamped_input)
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
 
-  auto state = controller_->configure();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
+  ASSERT_TRUE(configure_succeeds(controller_));
 
   assignResourcesNoFeedback();
 
-  state = controller_->get_node()->activate();
-  ASSERT_EQ(State::PRIMARY_STATE_ACTIVE, state.id());
+  ASSERT_TRUE(activate_succeeds(controller_));
 
   waitForSetup(executor);
 
@@ -1493,10 +1483,8 @@ TEST_F(TestDiffDriveController, test_open_loop_odometry_with_unclamped_input)
 
   // Safely spin down the lifecycle
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  state = controller_->get_node()->deactivate();
-  ASSERT_EQ(State::PRIMARY_STATE_INACTIVE, state.id());
-  state = controller_->get_node()->cleanup();
-  ASSERT_EQ(State::PRIMARY_STATE_UNCONFIGURED, state.id());
+  ASSERT_TRUE(deactivate_succeeds(controller_));
+  ASSERT_TRUE(cleanup_succeeds(controller_));
   executor.cancel();
 }
 

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.cpp
@@ -34,12 +34,6 @@ using hardware_interface::LoanedStateInterface;
 using testing::IsEmpty;
 using testing::SizeIs;
 
-namespace
-{
-constexpr auto NODE_SUCCESS = controller_interface::CallbackReturn::SUCCESS;
-constexpr auto NODE_ERROR = controller_interface::CallbackReturn::ERROR;
-}  // namespace
-
 void ForceTorqueSensorBroadcasterTest::SetUpTestCase() {}
 
 void ForceTorqueSensorBroadcasterTest::TearDownTestCase() {}

--- a/gpio_controllers/test/test_gpio_command_controller.cpp
+++ b/gpio_controllers/test/test_gpio_command_controller.cpp
@@ -47,7 +47,6 @@ const auto minimal_robot_urdf_with_gpio = std::string(ros2_control_test_assets::
                                           std::string(ros2_control_test_assets::urdf_tail);
 }  // namespace
 
-using CallbackReturn = controller_interface::CallbackReturn;
 using hardware_interface::LoanedCommandInterface;
 using hardware_interface::LoanedStateInterface;
 using CmdType = control_msgs::msg::DynamicInterfaceGroupValues;

--- a/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
+++ b/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
@@ -37,8 +37,6 @@ using controller_interface::activate_succeeds;
 using controller_interface::configure_succeeds;
 using hardware_interface::LoanedStateInterface;
 using lifecycle_msgs::msg::State;
-using callback_return_type =
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 namespace
 {

--- a/magnetometer_broadcaster/test/test_magnetometer_broadcaster.cpp
+++ b/magnetometer_broadcaster/test/test_magnetometer_broadcaster.cpp
@@ -31,9 +31,11 @@
 #include <rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp>
 #include <ros2_control_test_assets/descriptions.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
+#include "controller_interface/test_utils.hpp"
 
-using callback_return_type =
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+using controller_interface::activate_succeeds;
+using controller_interface::configure_succeeds;
+using controller_interface::deactivate_succeeds;
 
 namespace
 {
@@ -58,7 +60,7 @@ class MagnetometerBroadcasterTest : public ::testing::Test
 public:
   void SetUp()
   {
-    broadcaster = std::make_shared<magnetometer_broadcaster::MagnetometerBroadcaster>();
+    broadcaster = std::make_unique<magnetometer_broadcaster::MagnetometerBroadcaster>();
   }
 
   void TearDown() { broadcaster.reset(); }
@@ -117,7 +119,7 @@ protected:
     std::make_shared<hardware_interface::StateInterface>(
       sensor_name_, "magnetic_field.z", &sensor_values_[2]);
 
-  controller_interface::ControllerInterfaceSharedPtr broadcaster = nullptr;
+  std::unique_ptr<magnetometer_broadcaster::MagnetometerBroadcaster> broadcaster;
 };
 
 TEST_F(MagnetometerBroadcasterTest, whenNoParamsAreSetThenInitShouldFail)
@@ -144,8 +146,8 @@ TEST_F(
   const auto result = broadcaster->init(
     create_ctrl_params(node_options, ros2_control_test_assets::minimal_robot_urdf));
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(broadcaster->on_configure(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
-  ASSERT_EQ(broadcaster->on_activate(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(broadcaster));
+  ASSERT_TRUE(activate_succeeds(broadcaster));
 }
 
 TEST_F(MagnetometerBroadcasterTest, whenBroadcasterIsActiveShouldPublishWithCovarianceSetToZero)
@@ -155,9 +157,9 @@ TEST_F(MagnetometerBroadcasterTest, whenBroadcasterIsActiveShouldPublishWithCova
   const auto result = broadcaster->init(
     create_ctrl_params(node_options, ros2_control_test_assets::minimal_robot_urdf));
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(broadcaster->on_configure(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(broadcaster));
   setup_broadcaster();
-  ASSERT_EQ(broadcaster->on_activate(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+  ASSERT_TRUE(activate_succeeds(broadcaster));
 
   const auto msg = subscribe_and_get_message();
   EXPECT_EQ(msg.header.frame_id, frame_id_);
@@ -182,9 +184,9 @@ TEST_F(
   const auto result = broadcaster->init(
     create_ctrl_params(node_options, ros2_control_test_assets::minimal_robot_urdf));
   ASSERT_EQ(result, controller_interface::return_type::OK);
-  ASSERT_EQ(broadcaster->on_configure(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+  ASSERT_TRUE(configure_succeeds(broadcaster));
   setup_broadcaster();
-  ASSERT_EQ(broadcaster->on_activate(rclcpp_lifecycle::State()), callback_return_type::SUCCESS);
+  ASSERT_TRUE(activate_succeeds(broadcaster));
 
   const auto msg = subscribe_and_get_message();
   EXPECT_EQ(msg.header.frame_id, frame_id_);

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
@@ -54,11 +54,8 @@ using controller_interface::deactivate_succeeds;
 
 namespace
 {
-constexpr auto NODE_SUCCESS = controller_interface::CallbackReturn::SUCCESS;
-constexpr auto NODE_ERROR = controller_interface::CallbackReturn::ERROR;
 const double COMMON_THRESHOLD = 1e-6;
 }  // namespace
-// namespace
 
 // subclassing and friending so we can access member variables
 class TestableTricycleSteeringController


### PR DESCRIPTION
Final fix for https://github.com/ros-controls/ros2_controllers/issues/1660, utilize test utility functions to call appropriate lifecycle transitions and evaluate expected state. Also cleanup unused symbols related to the change.

- magnetometer_broadcaster: 
changed definition in test to use unique_ptr as test util functions require

- cleanup previously missed changes
search all files (test*) under ros2_controllers directory for ->on_*, ->activate, ->configure, ->deactivate, ->cleanup, CallbackReturn
and made changes accordingly

- leave tricycle_controller alone