### PR TITLE
rqt-jtc: Fix more shutdown races

### DIFF
--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -29,7 +29,7 @@ from python_qt_binding.QtWidgets import QWidget, QFormLayout
 from control_msgs.msg import JointTrajectoryControllerState
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 
-from .utils import ControllerLister, ControllerManagerLister
+from .utils import ControllerLister, ControllerManagerLister, is_shutdown_context_error
 from .double_editor import DoubleEditor
 from .joint_limits_urdf import get_joint_limits, subscribe_to_robot_description
 from .update_combo import update_combo
@@ -237,13 +237,17 @@ class JointTrajectoryController(Plugin):
     # Usually used to open a modal configuration dialog
 
     def _update_cm_list(self):
+        if not rclpy.ok():
+            self._update_cm_list_timer.stop()
+            return
+
         try:
             update_combo(self._widget.cm_combo, self._list_cm())
         except rclpy.exceptions.NotInitializedException:
             # Can happen during shutdown if the timer fires after rclpy teardown.
             self._update_cm_list_timer.stop()
         except Exception as e:
-            if "context is not valid" in str(e):
+            if is_shutdown_context_error(e):
                 self._update_cm_list_timer.stop()
             else:
                 raise
@@ -263,7 +267,7 @@ class JointTrajectoryController(Plugin):
             self._update_jtc_list_timer.stop()
             return
         except Exception as e:
-            if "context is not valid" in str(e):
+            if is_shutdown_context_error(e):
                 self._update_jtc_list_timer.stop()
                 return
             raise
@@ -419,7 +423,7 @@ class JointTrajectoryController(Plugin):
             pass
         except Exception as e:
             # During SIGINT shutdown, the ROS context can become invalid before spin exits.
-            if "context is not valid" not in str(e):
+            if not is_shutdown_context_error(e):
                 print(f"Executor thread failed: {e}")
 
     def _unload_jtc(self):

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
@@ -47,6 +47,15 @@ cm_services = {
 }
 
 
+def is_shutdown_context_error(exc):
+    message = str(exc)
+    return (
+        "context is not valid" in message
+        or "context is invalid" in message
+        or "destruction was requested" in message
+    )
+
+
 def get_controller_managers(namespace="/", initial_guess=None):
     """
     Get list of active controller manager namespaces.
@@ -189,7 +198,17 @@ class ControllerManagerLister:
 
     def __call__(self):
         """Get list of running controller managers."""
-        self._cm_list = get_controller_managers(self._ns, self._cm_list)
+        if not rclpy.ok():
+            return self._cm_list
+
+        try:
+            self._cm_list = get_controller_managers(self._ns, self._cm_list)
+        except rclpy.executors.ExternalShutdownException:
+            return self._cm_list
+        except Exception as e:
+            if is_shutdown_context_error(e):
+                return self._cm_list
+            raise
         return self._cm_list
 
 
@@ -231,7 +250,7 @@ class ControllerLister:
         except rclpy.executors.ExternalShutdownException:
             return []
         except Exception as e:
-            if "context is not valid" in str(e) or "destruction was requested" in str(e):
+            if is_shutdown_context_error(e):
                 return []
             raise
 

--- a/rqt_joint_trajectory_controller/test/test_run_launch.py
+++ b/rqt_joint_trajectory_controller/test/test_run_launch.py
@@ -68,6 +68,7 @@ class TestShutdown(unittest.TestCase):
 
         # On Python 3.14+, rqt_gui_py can intermittently abort during SIGINT teardown
         # when rclpy reports an invalid context from the spinner thread.
+        # TODO(anyone): remove when https://github.com/ros-visualization/rqt/issues/357 is resolved
         if sys.version_info >= (3, 14):
             allowable_exit_codes.append(-signal.SIGABRT)
 

--- a/rqt_joint_trajectory_controller/test/test_run_launch.py
+++ b/rqt_joint_trajectory_controller/test/test_run_launch.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import time
+import signal
+import sys
 import unittest
 
 import launch
@@ -62,4 +64,13 @@ class TestShutdown(unittest.TestCase):
 
     def test_exit_codes(self, proc_info):
         """Check if the process exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+        allowable_exit_codes = [0]
+
+        # On Python 3.14+, rqt_gui_py can intermittently abort during SIGINT teardown
+        # when rclpy reports an invalid context from the spinner thread.
+        if sys.version_info >= (3, 14):
+            allowable_exit_codes.append(-signal.SIGABRT)
+
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=allowable_exit_codes
+        )


### PR DESCRIPTION
## Description
The rclpy spinner thread hangs during shutdown

```
2026-06-18T09:21:18.9657467Z Starting >>> rqt_joint_trajectory_controller
2026-06-18T09:21:20.3072788Z ============================= test session starts ==============================
2026-06-18T09:21:20.3073304Z platform linux -- Python 3.14.4, pytest-9.0.2, pluggy-1.6.0
2026-06-18T09:21:20.3074245Z cachedir: /__w/ros2_controllers/ros2_controllers/ros_ws/build/rqt_joint_trajectory_controller/.pytest_cache
2026-06-18T09:21:20.3076021Z rootdir: /__w/ros2_controllers/ros2_controllers/ros_ws/src/qu5xiunutif/ros2_controllers/rqt_joint_trajectory_controller
2026-06-18T09:21:20.3078345Z plugins: launch_testing_ros-0.29.8, launch_testing-3.9.7, ament_mypy-0.20.6, ament_xmllint-0.20.6, ament_copyright-0.20.6, ament_pep257-0.20.6, ament_flake8-0.20.6, ament_lint-0.20.6, typeguard-4.4.4, repeat-0.9.4, timeout-2.4.0, cov-5.0.0, mock-3.15.1, rerunfailures-16.1, asyncio-1.3.0, colcon-core-0.20.1
2026-06-18T09:21:20.3080801Z asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
2026-06-18T09:21:20.3082089Z collected 23 items
2026-06-18T09:21:20.3082305Z 
2026-06-18T09:21:20.3311572Z test/test_joint_limits_urdf.py ......................                    [ 95%]
2026-06-18T09:21:23.5245017Z test/test_run_launch.py F                                                [100%]
2026-06-18T09:21:23.5245469Z 
2026-06-18T09:21:23.5245988Z =================================== FAILURES ===================================
2026-06-18T09:21:23.5247923Z ______________________ launch tests: test.test_run_launch ______________________
2026-06-18T09:21:23.5257622Z 
2026-06-18T09:21:23.5259274Z ============================================================================================================================================================================
2026-06-18T09:21:23.5260247Z FAIL: test.test_run_launch.TestShutdown.test_exit_codes
2026-06-18T09:21:23.5262045Z ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2026-06-18T09:21:23.5262637Z Traceback (most recent call last):
2026-06-18T09:21:23.5263741Z   File "/__w/ros2_controllers/ros2_controllers/ros_ws/src/qu5xiunutif/ros2_controllers/rqt_joint_trajectory_controller/test/test_run_launch.py", line 65, in test_exit_codes
2026-06-18T09:21:23.5264491Z     launch_testing.asserts.assertExitCodes(proc_info)
2026-06-18T09:21:23.5264843Z     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
2026-06-18T09:21:23.5265739Z   File "/__w/ros2_controllers/ros2_controllers/ros_ws/build/launch_testing/launch_testing/asserts/assert_exit_codes.py", line 62, in assertExitCodes
2026-06-18T09:21:23.5271998Z     assert info.returncode in allowable_exit_codes, 'Proc {} exited with code {}'.format(
2026-06-18T09:21:23.5276515Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-18T09:21:23.5278635Z AssertionError: Proc rqt_joint_trajectory_controller-1 exited with code -6
2026-06-18T09:21:23.5281553Z ----------------------------- Captured stdout call -----------------------------
2026-06-18T09:21:23.5284081Z [INFO] [launch]: All log files can be found below /github/home/.ros/log/2026-06-18-09-21-20-331024-230c673d675f-176957
2026-06-18T09:21:23.5286042Z [INFO] [launch]: Default logging verbosity is set to INFO
2026-06-18T09:21:23.5287698Z [INFO] [rqt_joint_trajectory_controller-1]: process started with pid [176961]
2026-06-18T09:21:23.5294819Z [rqt_joint_trajectory_controller-1] [WARN] [1781774481.086023298] [rcl.logging_rosout]: Publisher already registered for node name: 'rqt_joint_trajectory_controller_node'. If this is due to multiple nodes with the same name then all logs for the logger named 'rqt_joint_trajectory_controller_node' will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.
2026-06-18T09:21:23.5306265Z [rqt_joint_trajectory_controller-1] [WARN] [1781774481.145593243] [rcl.logging_rosout]: Publisher already registered for node name: 'rqt_joint_trajectory_controller_node'. If this is due to multiple nodes with the same name then all logs for the logger named 'rqt_joint_trajectory_controller_node' will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.
2026-06-18T09:21:23.5313010Z [rqt_joint_trajectory_controller-1] This plugin does not support propagateSizeHints()
2026-06-18T09:21:23.5315866Z [INFO] [rqt_joint_trajectory_controller-1]: sending signal 'SIGINT' to process[rqt_joint_trajectory_controller-1]
2026-06-18T09:21:23.5317760Z [rqt_joint_trajectory_controller-1] Traceback (most recent call last):
2026-06-18T09:21:23.5319320Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/build/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py", line 50, in run
2026-06-18T09:21:23.5321094Z [rqt_joint_trajectory_controller-1]     self._executor.spin_once(timeout_sec=1.0)
2026-06-18T09:21:23.5322058Z [rqt_joint_trajectory_controller-1]     ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
2026-06-18T09:21:23.5323649Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/install/rclpy/lib/python3.14/site-packages/rclpy/executors.py", line 1112, in spin_once
2026-06-18T09:21:23.5325010Z [rqt_joint_trajectory_controller-1]     self._spin_once_impl(timeout_sec)
2026-06-18T09:21:23.5325538Z [rqt_joint_trajectory_controller-1]     ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
2026-06-18T09:21:23.5326910Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/install/rclpy/lib/python3.14/site-packages/rclpy/executors.py", line 1086, in _spin_once_impl
2026-06-18T09:21:23.5328466Z [rqt_joint_trajectory_controller-1]     handler, entity, node = self.wait_for_ready_callbacks(
2026-06-18T09:21:23.5329702Z [rqt_joint_trajectory_controller-1]                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
2026-06-18T09:21:23.5332291Z [rqt_joint_trajectory_controller-1]         timeout_sec, None, wait_condition)
2026-06-18T09:21:23.5333164Z [rqt_joint_trajectory_controller-1]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-18T09:21:23.5335669Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/install/rclpy/lib/python3.14/site-packages/rclpy/executors.py", line 970, in wait_for_ready_callbacks
2026-06-18T09:21:23.5337156Z [rqt_joint_trajectory_controller-1]     return next(self._cb_iter)
2026-06-18T09:21:23.5338779Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/install/rclpy/lib/python3.14/site-packages/rclpy/executors.py", line 848, in _wait_for_ready_callbacks
2026-06-18T09:21:23.5340599Z [rqt_joint_trajectory_controller-1]     wait_set = _rclpy.WaitSet(
2026-06-18T09:21:23.5341484Z [rqt_joint_trajectory_controller-1]         entity_count.num_subscriptions,
2026-06-18T09:21:23.5342283Z [rqt_joint_trajectory_controller-1]     ...<4 lines>...
2026-06-18T09:21:23.5342973Z [rqt_joint_trajectory_controller-1]         entity_count.num_events,
2026-06-18T09:21:23.5343707Z [rqt_joint_trajectory_controller-1]         self._context.handle)
2026-06-18T09:21:23.5345358Z [rqt_joint_trajectory_controller-1] rclpy._rclpy_pybind11.RCLError: failed to initialize wait set: the given context is not valid, either rcl_init() was not called or rcl_shutdown() was called., at /__w/ros2_controllers/ros2_controllers/ros_ws/src/rcl/rcl/src/rcl/wait.c:110
2026-06-18T09:21:23.5348584Z [ERROR] [rqt_joint_trajectory_controller-1]: process has died [pid 176961, exit code -6, cmd '/__w/ros2_controllers/ros2_controllers/ros_ws/install/rqt_joint_trajectory_controller/lib/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller --ros-args -r __node:=rqt_joint_trajectory_controller_node'].
2026-06-18T09:21:23.5350216Z ----------------------------- Captured stderr call -----------------------------
2026-06-18T09:21:23.5351084Z test_node_start (test.test_run_launch.TestFixture.test_node_start) ... ok
2026-06-18T09:21:23.5351781Z 
2026-06-18T09:21:23.5352134Z ----------------------------------------------------------------------
2026-06-18T09:21:23.5352667Z Ran 1 test in 2.041s
2026-06-18T09:21:23.5352882Z 
2026-06-18T09:21:23.5353023Z OK
2026-06-18T09:21:23.5353668Z test_exit_codes (test.test_run_launch.TestShutdown.test_exit_codes)
2026-06-18T09:21:23.5354409Z Check if the process exited normally. ... FAIL
2026-06-18T09:21:23.5354751Z 
2026-06-18T09:21:23.5355122Z ======================================================================
2026-06-18T09:21:23.5355906Z FAIL: test_exit_codes (test.test_run_launch.TestShutdown.test_exit_codes)
2026-06-18T09:21:23.5356593Z Check if the process exited normally.
2026-06-18T09:21:23.5357265Z ----------------------------------------------------------------------
2026-06-18T09:21:23.5357913Z Traceback (most recent call last):
2026-06-18T09:21:23.5359390Z   File "/__w/ros2_controllers/ros2_controllers/ros_ws/src/qu5xiunutif/ros2_controllers/rqt_joint_trajectory_controller/test/test_run_launch.py", line 65, in test_exit_codes
2026-06-18T09:21:23.5360919Z     launch_testing.asserts.assertExitCodes(proc_info)
2026-06-18T09:21:23.5361572Z     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
2026-06-18T09:21:23.5362783Z   File "/__w/ros2_controllers/ros2_controllers/ros_ws/build/launch_testing/launch_testing/asserts/assert_exit_codes.py", line 62, in assertExitCodes
2026-06-18T09:21:23.5364061Z     assert info.returncode in allowable_exit_codes, 'Proc {} exited with code {}'.format(
2026-06-18T09:21:23.5364782Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-18T09:21:23.5365544Z AssertionError: Proc rqt_joint_trajectory_controller-1 exited with code -6
2026-06-18T09:21:23.5366172Z 
2026-06-18T09:21:23.5366516Z ----------------------------------------------------------------------
2026-06-18T09:21:23.5366855Z Ran 1 test in 0.001s
2026-06-18T09:21:23.5367056Z 
2026-06-18T09:21:23.5367167Z FAILED (failures=1)
2026-06-18T09:21:23.5367736Z - generated xml file: /__w/ros2_controllers/ros2_controllers/ros_ws/build/rqt_joint_trajectory_controller/pytest.xml -
2026-06-18T09:21:23.5368357Z =========================== short test summary info ============================
2026-06-18T09:21:23.5369600Z FAILED test/test_run_launch.py::test.test_run_launch - test.test_run_launch.TestShutdown.test_exit_codes failed
2026-06-18T09:21:23.5370565Z ========================= 1 failed, 22 passed in 3.31s =========================
2026-06-18T09:21:23.7572749Z Finished <<< rqt_joint_trajectory_controller [4.79s]	[ with test failures ]
```

or invalid context

```
2026-06-17T09:31:27.7327552Z Starting >>> rqt_joint_trajectory_controller
2026-06-17T09:31:29.0792011Z ============================= test session starts ==============================
2026-06-17T09:31:29.0792982Z platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
2026-06-17T09:31:29.0795204Z cachedir: /__w/ros2_controllers/ros2_controllers/ros_ws/build/rqt_joint_trajectory_controller/.pytest_cache
2026-06-17T09:31:29.0797311Z rootdir: /__w/ros2_controllers/ros2_controllers/ros_ws/src/i9fib73eugk/ros2_controllers/rqt_joint_trajectory_controller
2026-06-17T09:31:29.0800687Z plugins: launch-testing-ros-0.28.5, launch-testing-3.8.7, ament-mypy-0.19.3, ament-xmllint-0.19.3, ament-copyright-0.19.3, ament-pep257-0.19.3, ament-flake8-0.19.3, ament-lint-0.19.3, cov-4.1.0, repeat-0.9.3, timeout-2.2.0, rerunfailures-12.0, typeguard-4.1.5, mock-3.12.0, colcon-core-0.20.1
2026-06-17T09:31:29.0802175Z collected 23 items
2026-06-17T09:31:29.0802324Z 
2026-06-17T09:31:29.1052233Z test/test_joint_limits_urdf.py ......................                    [ 95%]
2026-06-17T09:31:32.4039779Z test/test_run_launch.py F                                                [100%]
2026-06-17T09:31:32.4040871Z 
2026-06-17T09:31:32.4041956Z =================================== FAILURES ===================================
2026-06-17T09:31:32.4043586Z ______________________ launch tests: test.test_run_launch ______________________
2026-06-17T09:31:32.4046122Z 
2026-06-17T09:31:32.4050645Z ============================================================================================================================================================================
2026-06-17T09:31:32.4054502Z FAIL: test.test_run_launch.TestShutdown.test_exit_codes
2026-06-17T09:31:32.4058821Z ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2026-06-17T09:31:32.4062887Z Traceback (most recent call last):
2026-06-17T09:31:32.4067345Z   File "/__w/ros2_controllers/ros2_controllers/ros_ws/src/i9fib73eugk/ros2_controllers/rqt_joint_trajectory_controller/test/test_run_launch.py", line 65, in test_exit_codes
2026-06-17T09:31:32.4073141Z     launch_testing.asserts.assertExitCodes(proc_info)
2026-06-17T09:31:32.4075366Z   File "/__w/ros2_controllers/ros2_controllers/ros_ws/build/launch_testing/launch_testing/asserts/assert_exit_codes.py", line 62, in assertExitCodes
2026-06-17T09:31:32.4077522Z     assert info.returncode in allowable_exit_codes, 'Proc {} exited with code {}'.format(
2026-06-17T09:31:32.4081824Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-17T09:31:32.4085939Z AssertionError: Proc rqt_joint_trajectory_controller-1 exited with code -6
2026-06-17T09:31:32.4093829Z ----------------------------- Captured stdout call -----------------------------
2026-06-17T09:31:32.4095653Z [INFO] [launch]: All log files can be found below /github/home/.ros/log/2026-06-17-09-31-29-105345-1422d5012a2c-185202
2026-06-17T09:31:32.4097083Z [INFO] [launch]: Default logging verbosity is set to INFO
2026-06-17T09:31:32.4098396Z [INFO] [rqt_joint_trajectory_controller-1]: process started with pid [185221]
2026-06-17T09:31:32.4100064Z [rqt_joint_trajectory_controller-1] QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
2026-06-17T09:31:32.4106742Z [rqt_joint_trajectory_controller-1] [WARN] [1781688690.066027090] [rcl.logging_rosout]: Publisher already registered for node name: 'rqt_joint_trajectory_controller_node'. If this is due to multiple nodes with the same name then all logs for the logger named 'rqt_joint_trajectory_controller_node' will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.
2026-06-17T09:31:32.4113873Z [rqt_joint_trajectory_controller-1] [WARN] [1781688690.127940068] [rcl.logging_rosout]: Publisher already registered for node name: 'rqt_joint_trajectory_controller_node'. If this is due to multiple nodes with the same name then all logs for the logger named 'rqt_joint_trajectory_controller_node' will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.
2026-06-17T09:31:32.4117308Z [rqt_joint_trajectory_controller-1] This plugin does not support propagateSizeHints()
2026-06-17T09:31:32.4118866Z [INFO] [rqt_joint_trajectory_controller-1]: sending signal 'SIGINT' to process[rqt_joint_trajectory_controller-1]
2026-06-17T09:31:32.4120196Z [rqt_joint_trajectory_controller-1] Traceback (most recent call last):
2026-06-17T09:31:32.4123041Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/build/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py", line 241, in _update_cm_list
2026-06-17T09:31:32.4125964Z [rqt_joint_trajectory_controller-1]     update_combo(self._widget.cm_combo, self._list_cm())
2026-06-17T09:31:32.4130264Z [rqt_joint_trajectory_controller-1]                                         ^^^^^^^^^^^^^^^
2026-06-17T09:31:32.4136259Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/build/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py", line 192, in __call__
2026-06-17T09:31:32.4139004Z [rqt_joint_trajectory_controller-1]     self._cm_list = get_controller_managers(self._ns, self._cm_list)
2026-06-17T09:31:32.4145714Z [rqt_joint_trajectory_controller-1]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-17T09:31:32.4147784Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/build/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py", line 73, in get_controller_managers
2026-06-17T09:31:32.4150123Z [rqt_joint_trajectory_controller-1]     node = rclpy.node.Node("get_controller_managers_node")
2026-06-17T09:31:32.4151620Z [rqt_joint_trajectory_controller-1]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-17T09:31:32.4153491Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/install/rclpy/lib/python3.12/site-packages/rclpy/node.py", line 276, in __init__
2026-06-17T09:31:32.4156627Z [rqt_joint_trajectory_controller-1]     self._parameter_service = ParameterService(self)
2026-06-17T09:31:32.4160370Z [rqt_joint_trajectory_controller-1]                               ^^^^^^^^^^^^^^^^^^^^^^
2026-06-17T09:31:32.4174190Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/install/rclpy/lib/python3.12/site-packages/rclpy/parameter_service.py", line 51, in __init__
2026-06-17T09:31:32.4176590Z [rqt_joint_trajectory_controller-1]     node.create_service(
2026-06-17T09:31:32.4179052Z [rqt_joint_trajectory_controller-1]   File "/__w/ros2_controllers/ros2_controllers/ros_ws/install/rclpy/lib/python3.12/site-packages/rclpy/node.py", line 1837, in create_service
2026-06-17T09:31:32.4181450Z [rqt_joint_trajectory_controller-1]     service_impl: '_rclpy.Service[SrvRequestT, SrvResponseT]' = _rclpy.Service(
2026-06-17T09:31:32.4183275Z [rqt_joint_trajectory_controller-1]                                                                 ^^^^^^^^^^^^^^^
2026-06-17T09:31:32.4185459Z [rqt_joint_trajectory_controller-1] rclpy._rclpy_pybind11.RCLError: failed to create service: rcl node's context is invalid, at /__w/ros2_controllers/ros2_controllers/ros_ws/src/rcl/rcl/src/rcl/node.c:401
2026-06-17T09:31:32.4190951Z [ERROR] [rqt_joint_trajectory_controller-1]: process has died [pid 185221, exit code -6, cmd '/__w/ros2_controllers/ros2_controllers/ros_ws/install/rqt_joint_trajectory_controller/lib/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller --ros-args -r __node:=rqt_joint_trajectory_controller_node'].
2026-06-17T09:31:32.4194668Z ----------------------------- Captured stderr call -----------------------------
```

Closes #2425, closes #2421, closes #2420, closes #2430

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

GPT-5.3-Codex