### PR TITLE
fix: correct test_load_controller tests for motion_primitives and pid_controller

### DIFF
--- a/motion_primitives_controllers/CMakeLists.txt
+++ b/motion_primitives_controllers/CMakeLists.txt
@@ -84,6 +84,8 @@ if(BUILD_TESTING)
   find_package(hardware_interface REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+
   ament_add_gmock(
     test_load_motion_primitives_forward_controller
     test/test_load_motion_primitives_forward_controller.cpp
@@ -91,6 +93,8 @@ if(BUILD_TESTING)
   target_link_libraries(test_load_motion_primitives_forward_controller
     ${PROJECT_NAME}
     controller_manager::controller_manager
+  )
+  target_link_libraries(test_load_motion_primitives_forward_controller
     ros2_control_test_assets::ros2_control_test_assets
   )
 
@@ -103,6 +107,8 @@ if(BUILD_TESTING)
     ${PROJECT_NAME}
     controller_interface::controller_interface
     hardware_interface::hardware_interface
+  )
+  target_link_libraries(test_motion_primitives_forward_controller
     ros2_control_test_assets::ros2_control_test_assets
   )
 endif()

--- a/motion_primitives_controllers/test/test_load_motion_primitives_forward_controller.cpp
+++ b/motion_primitives_controllers/test/test_load_motion_primitives_forward_controller.cpp
@@ -32,9 +32,13 @@ TEST(TestLoadMotionPrimitivesForwardController, load_controller)
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
 
-  ASSERT_NO_THROW(cm.load_controller(
-    "test_motion_primitives_forward_controller",
-    "motion_primitives_controllers/MotionPrimitivesForwardController"));
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/motion_primitives_forward_controller_params.yaml";
+  cm.set_parameter({"test_motion_primitives_forward_controller.params_file", test_file_path});
+  cm.set_parameter(
+    {"test_motion_primitives_forward_controller.type",
+     "motion_primitives_controllers/MotionPrimitivesForwardController"});
+  ASSERT_NE(cm.load_controller("test_motion_primitives_forward_controller"), nullptr);
 
   rclcpp::shutdown();
 }

--- a/pid_controller/CMakeLists.txt
+++ b/pid_controller/CMakeLists.txt
@@ -67,6 +67,8 @@ if(BUILD_TESTING)
   find_package(controller_manager REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+
   add_rostest_with_parameters_gmock(
     test_pid_controller
     test/test_pid_controller.cpp

--- a/pid_controller/test/test_load_pid_controller.cpp
+++ b/pid_controller/test/test_load_pid_controller.cpp
@@ -35,7 +35,11 @@ TEST(TestLoadPidController, load_controller)
   controller_manager::ControllerManager cm(
     executor, ros2_control_test_assets::minimal_robot_urdf, true, "test_controller_manager");
 
-  ASSERT_NO_THROW(cm.load_controller("test_pid_controller", "pid_controller/PidController"));
+  const std::string test_file_path =
+    std::string(TEST_FILES_DIRECTORY) + "/pid_controller_params.yaml";
+  cm.set_parameter({"test_pid_controller.params_file", test_file_path});
+  cm.set_parameter({"test_pid_controller.type", "pid_controller/PidController"});
+  ASSERT_NE(cm.load_controller("test_pid_controller"), nullptr);
 
   rclcpp::shutdown();
 }


### PR DESCRIPTION
Fixes #1258

## Problem
The `test_load_controller` tests in `motion_primitives_controllers` and `pid_controller` were using `ASSERT_NO_THROW` to check that loading the controller does not throw an exception, but never verified that the controller actually loaded successfully. Additionally, neither test was setting a `params_file` or `type` parameter via `set_parameter`, so the controllers were not being validated against their expected configuration. This meant the tests would pass even if the controller failed to load and returned `nullptr`.

## Fix
Updated both tests to set the `params_file` and `type` parameters explicitly using `cm.set_parameter(...)`, then changed the assertion to `ASSERT_NE(cm.load_controller(...), nullptr)` so the test correctly verifies that the controller loads successfully with the provided configuration. This follows the same pattern already used in `admittance_controller` and `range_sensor_broadcaster`.

## Is this user-facing behavior change?
no

## Did you use Generative AI?
no