### PR TITLE
fix: update admittance_controller load test for humble backport

### DIFF
--- a/admittance_controller/CMakeLists.txt
+++ b/admittance_controller/CMakeLists.txt
@@ -66,6 +66,8 @@ if(BUILD_TESTING)
   # Dynamically loaded during test
   find_package(kinematics_interface_kdl REQUIRED)
 
+  add_definitions(-DTEST_FILES_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/test")
+
   # test loading admittance controller
   add_rostest_with_parameters_gmock(test_load_admittance_controller
     test/test_load_admittance_controller.cpp

--- a/admittance_controller/test/test_load_admittance_controller.cpp
+++ b/admittance_controller/test/test_load_admittance_controller.cpp
@@ -15,6 +15,7 @@
 #include <gmock/gmock.h>
 
 #include <memory>
+#include <string>
 
 #include "controller_manager/controller_manager.hpp"
 #include "hardware_interface/resource_manager.hpp"
@@ -23,15 +24,113 @@
 #include "rclcpp/utilities.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
+const std::string & get_urdf()
+{
+  static const std::string urdf = R"(
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="MinimalRobot">
+  <link name="world"/>
+  <joint name="base_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="base_link"/>
+  </joint>
+  <link name="base_link">
+    <inertial>
+      <mass value="0.01"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+    </inertial>
+  </link>
+  <joint name="joint1" type="revolute">
+    <origin rpy="-1.57079632679 0 0" xyz="0 0 0.2"/>
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
+  </joint>
+  <link name="link1">
+    <inertial>
+      <mass value="0.01"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+    </inertial>
+  </link>
+  <joint name="joint2" type="revolute">
+    <origin rpy="1.57079632679 0 0" xyz="0 0 0.9"/>
+    <parent link="link1"/>
+    <child link="link2"/>
+    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
+  </joint>
+  <link name="link2">
+    <inertial>
+      <mass value="0.01"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+    </inertial>
+  </link>
+  <joint name="tool_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 1"/>
+    <parent link="link2"/>
+    <child link="tool_link"/>
+  </joint>
+  <link name="tool_link">
+  </link>
+
+  <ros2_control name="TestActuatorHardware" type="actuator">
+    <hardware>
+      <plugin>test_hardware_components/TestSingleJointActuator</plugin>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+  </ros2_control>
+  <ros2_control name="TestSensorHardware" type="sensor">
+    <hardware>
+      <plugin>test_hardware_components/TestForceTorqueSensor</plugin>
+    </hardware>
+    <sensor name="sensor1">
+      <state_interface name="fx"/>
+      <state_interface name="fy"/>
+      <state_interface name="fz"/>
+      <state_interface name="tx"/>
+      <state_interface name="ty"/>
+      <state_interface name="tz"/>
+    </sensor>
+  </ros2_control>
+  <ros2_control name="TestSystemHardware" type="system">
+    <hardware>
+      <plugin>test_hardware_components/TestTwoJointSystem</plugin>
+    </hardware>
+    <joint name="joint2">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+    <joint name="joint3">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+  </ros2_control>
+</robot>
+)";
+  return urdf;
+}
+
 TEST(TestLoadAdmittanceController, load_controller)
 {
   std::shared_ptr<rclcpp::Executor> executor =
     std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
+  rclcpp::NodeOptions options;
+  options.allow_undeclared_parameters(true);
+  options.automatically_declare_parameters_from_overrides(true);
+
   controller_manager::ControllerManager cm(
-    std::make_unique<hardware_interface::ResourceManager>(
-      ros2_control_test_assets::minimal_robot_urdf),
-    executor, "test_controller_manager");
+    std::make_unique<hardware_interface::ResourceManager>(get_urdf()), executor,
+    "test_controller_manager", "", options);
+
+  const std::string test_file_path = std::string(TEST_FILES_DIRECTORY) + "/test_params.yaml";
 
   cm.set_parameter({"load_admittance_controller.params_file", test_file_path});
   cm.set_parameter(
@@ -43,7 +142,24 @@ TEST(TestLoadAdmittanceController, load_controller)
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
-  rclcpp::init(argc, argv);
+
+  std::vector<std::string> args;
+  for (int i = 0; i < argc; ++i)
+  {
+    args.push_back(argv[i]);
+  }
+  args.push_back("--ros-args");
+  args.push_back("-p");
+  args.push_back("robot_description:=" + get_urdf());
+
+  std::vector<char *> custom_argv;
+  for (const auto & arg : args)
+  {
+    custom_argv.push_back(const_cast<char *>(arg.c_str()));
+  }
+  int custom_argc = custom_argv.size();
+
+  rclcpp::init(custom_argc, custom_argv.data());
   int result = RUN_ALL_TESTS();
   rclcpp::shutdown();
   return result;


### PR DESCRIPTION
## Description

This PR fixes the `test_load_admittance_controller` test failure in the `humble` backport branch (`mergify/bp/humble/pr-2264`) for #2340. 

The load test was failing due to three issues:
1. The preprocessor macro `TEST_FILES_DIRECTORY` was missing from `admittance_controller/CMakeLists.txt` in the `humble` branch.
2. The URDF mock description in the test referenced generic rolling-specific test plugins (e.g., `test_hardware_components/TestActuatorHardware`) which do not exist on Humble. This has been updated to use existing Humble mock plugins (`TestSingleJointActuator`, `TestForceTorqueSensor`, and `TestTwoJointSystem`) with their expected interfaces.
3. In ROS 2 Humble, the controller manager does not automatically forward local parameter overrides (like `robot_description`) to dynamically loaded controller lifecycle nodes. We resolved this by passing the URDF as a process-wide command-line argument parameter override to `rclcpp::init`.

This resolves the CI test failures on the backport PR.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

Verified locally that both the build and tests pass successfully:
```bash
colcon build --packages-select admittance_controller
colcon test --packages-select admittance_controller --event-handlers console_direct+