### PR TITLE
ROS2 Humble imu_sensor_broadcaster.cpp Reinterpret Data Type

### DIFF
--- a/imu_sensor_broadcaster/src/imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/src/imu_sensor_broadcaster.cpp
@@ -16,6 +16,7 @@
  * Authors: Subhas Das, Denis Stogl, Victor Lopez
  */
 
+// THIS IS A TEST COMMENT
 #include "imu_sensor_broadcaster/imu_sensor_broadcaster.hpp"
 
 #include <memory>

--- a/imu_sensor_broadcaster/src/imu_sensor_broadcaster.cpp
+++ b/imu_sensor_broadcaster/src/imu_sensor_broadcaster.cpp
@@ -16,14 +16,21 @@
  * Authors: Subhas Das, Denis Stogl, Victor Lopez
  */
 
-// THIS IS A TEST COMMENT
 #include "imu_sensor_broadcaster/imu_sensor_broadcaster.hpp"
 
 #include <memory>
 #include <string>
+#include <cstring>
 
 namespace imu_sensor_broadcaster
 {
+// Helper function to convert uint32 bits to float32
+inline float uint32_to_float32(uint32_t value)
+{
+  float result;
+  std::memcpy(&result, &value, sizeof(float));
+  return result;
+}
 controller_interface::CallbackReturn IMUSensorBroadcaster::on_init()
 {
   try
@@ -117,6 +124,34 @@ controller_interface::return_type IMUSensorBroadcaster::update(
   {
     realtime_publisher_->msg_.header.stamp = time;
     imu_sensor_->get_values_as_message(realtime_publisher_->msg_);
+    
+    // Convert uint32 bit patterns to float32 for all sensor data
+    // Angular velocity
+    realtime_publisher_->msg_.angular_velocity.x = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.angular_velocity.x));
+    realtime_publisher_->msg_.angular_velocity.y = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.angular_velocity.y));
+    realtime_publisher_->msg_.angular_velocity.z = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.angular_velocity.z));
+    
+    // Linear acceleration
+    realtime_publisher_->msg_.linear_acceleration.x = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.linear_acceleration.x));
+    realtime_publisher_->msg_.linear_acceleration.y = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.linear_acceleration.y));
+    realtime_publisher_->msg_.linear_acceleration.z = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.linear_acceleration.z));
+    
+    // Orientation (quaternion)
+    realtime_publisher_->msg_.orientation.x = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.orientation.x));
+    realtime_publisher_->msg_.orientation.y = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.orientation.y));
+    realtime_publisher_->msg_.orientation.z = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.orientation.z));
+    realtime_publisher_->msg_.orientation.w = 
+      uint32_to_float32(static_cast<uint32_t>(realtime_publisher_->msg_.orientation.w));
+    
     realtime_publisher_->unlockAndPublish();
   }
 


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

I have forked the ros2_controllers repo for the use of the imu_sensor_broadcaster node. During testing, the IMU sensor values outputted by the node were weirdly large (obviously wrong data type). This is thus not related to any existing issue. I use SE1 and SE8 IMUs, which send all numerical sensor values as IEEE 754 single-precision floats encoded in uint32 bit patterns over EtherCAT PDOs. These are stored as 'uint32' integers. Then, when they are promoted to 'double' (which ros2_control state interfaces use) the original float is mispresented, which results in weirdly large values. The fix is to reinterpret the IMU data as a float, which results in the imu_sensor_broadcaster node outputting physically meaningful and correct IMU data (linear acceleration, angular velocity and orientation data).


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!--
Fixes # (issue)
-->

### Is this user-facing behavior change?

Yes, the data will be presenting physically meaningful values, enabling the user to read the data.


### Did you use Generative AI?

I have used 'claude haiku 4.5' within VSC to generate the new parts (the helper function uint32_to_float32() and the implementation of this function, reinterpreting the data type of the IMU data).

### Additional Information

I have tested the data reading capabilities of this custom imu_sensor_broadcaster.cpp node and the test results look like (included only two iterations in terminal, IMU SE8, lying flat on the table):

```
header:
  stamp:
    sec: 1782988914
    nanosec: 571238902
  frame_id: imu_sensor_frame
orientation:
  x: -0.01242675632238388
  y: 0.017282795161008835
  z: 0.110955148935318
  w: 0.9935974478721619
orientation_covariance:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
angular_velocity:
  x: -0.005334616173058748
  y: 0.00019799917936325073
  z: 6.0908496379852295e-05
angular_velocity_covariance:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
linear_acceleration:
  x: -0.30163684487342834
  y: -0.06893157213926315
  z: 9.813352584838867
linear_acceleration_covariance:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
---
header:
  stamp:
    sec: 1782988914
    nanosec: 581237327
  frame_id: imu_sensor_frame
orientation:
  x: -0.012424114160239697
  y: 0.017280220985412598
  z: 0.1109686940908432
  w: 0.9935959577560425
orientation_covariance:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
angular_velocity:
  x: -0.004515796899795532
  y: -0.00012815000081900507
  z: 0.00033248215913772583
angular_velocity_covariance:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
linear_acceleration:
  x: -0.3117557168006897
  y: -0.0802839994430542
  z: 9.845605850219727
linear_acceleration_covariance:
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
- 0.0
---
```

Besides this, note that I have done the `colcon test` and `pre-commit run` test successfully.


## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
