### PR TITLE
rqt-jtc: Make continuous sending opt-in and add Send Once button

### DIFF
--- a/rqt_joint_trajectory_controller/CHANGELOG.rst
+++ b/rqt_joint_trajectory_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rqt_joint_trajectory_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* rqt-jtc: Make continuous sending opt-in and add Send Once button, adjustable ``time_from_start`` and publish frequency (`#1579 <https://github.com/ros-controls/ros2_controllers/issues/1579>`_)
+* Contributors: Shaochang TAN
+
 6.8.0 (2026-07-01)
 ------------------
 * rqt-jtc: Fix more shutdown races (`#2431 <https://github.com/ros-controls/ros2_controllers/issues/2431>`_)

--- a/rqt_joint_trajectory_controller/doc/userdoc.rst
+++ b/rqt_joint_trajectory_controller/doc/userdoc.rst
@@ -32,4 +32,3 @@ Instead, sending is explicit and configurable:
 * **continuous send**: when checked, republishes the command at ``pub freq`` (Hz). Off by default.
 * **start time (ms)**: overrides the trajectory ``time_from_start``. Set to ``0`` to auto-compute the duration from the joint velocity limits and the speed scaling.
 * **pub freq (Hz)**: rate at which commands are republished while ``continuous send`` is active.
-

--- a/rqt_joint_trajectory_controller/doc/userdoc.rst
+++ b/rqt_joint_trajectory_controller/doc/userdoc.rst
@@ -19,3 +19,17 @@ The interface allows you to:
 * Control the motion speed using the speed scaling slider.
 * Activate the trajectory execution with the central power button.
 * Visualize current joint configurations in real-time.
+
+Trajectory / publish settings
+-----------------------------
+
+Enabling (arming) a controller with the power button does **not** send commands automatically.
+This avoids the erratic joint movement that occurs when a trajectory with a fixed ``time_from_start`` is republished at a high rate (see `#1579 <https://github.com/ros-controls/ros2_controllers/issues/1579>`_).
+
+Instead, sending is explicit and configurable:
+
+* **Send Once**: publishes a single trajectory with the current joint targets. Available whenever the controller is armed.
+* **continuous send**: when checked, republishes the command at ``pub freq`` (Hz). Off by default.
+* **start time (ms)**: overrides the trajectory ``time_from_start``. Set to ``0`` to auto-compute the duration from the joint velocity limits and the speed scaling.
+* **pub freq (Hz)**: rate at which commands are republished while ``continuous send`` is active.
+

--- a/rqt_joint_trajectory_controller/resource/joint_trajectory_controller.ui
+++ b/rqt_joint_trajectory_controller/resource/joint_trajectory_controller.ui
@@ -214,7 +214,7 @@
         <item row="0" column="1">
          <widget class="QDoubleSpinBox" name="start_time_spin">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&lt;body&gt;&lt;p&gt;0 = auto-compute duration from joint velocity limits.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&lt;body&gt;&lt;p&gt;0 = auto-compute duration from joint velocity limits and speed scaling.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="decimals">
            <number>2</number>

--- a/rqt_joint_trajectory_controller/resource/joint_trajectory_controller.ui
+++ b/rqt_joint_trajectory_controller/resource/joint_trajectory_controller.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>336</width>
-    <height>317</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -190,12 +190,119 @@
      <layout class="QVBoxLayout" name="speed_scaling_layout"/>
     </widget>
    </item>
+   <item>
+    <widget class="QGroupBox" name="traj_settings_group">
+     <property name="title">
+      <string>trajectory / publish settings</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="start_time_label">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&lt;body&gt;&lt;p&gt;Time (ms) to reach the target position (time_from_start). 0 = auto-compute from joint velocity limits and speed scaling.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>start time (ms)</string>
+          </property>
+          <property name="buddy">
+           <cstring>start_time_spin</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QDoubleSpinBox" name="start_time_spin">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&lt;body&gt;&lt;p&gt;0 = auto-compute duration from joint velocity limits.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="decimals">
+           <number>2</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>60000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="pub_freq_label">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&lt;body&gt;&lt;p&gt;Publish frequency (Hz) used while &amp;quot;continuous send&amp;quot; is active.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>pub freq (Hz)</string>
+          </property>
+          <property name="buddy">
+           <cstring>pub_freq_spin</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QDoubleSpinBox" name="pub_freq_spin">
+          <property name="decimals">
+           <number>1</number>
+          </property>
+          <property name="minimum">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.500000000000000</double>
+          </property>
+          <property name="value">
+           <double>10.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="auto_send_checkbox">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&lt;body&gt;&lt;p&gt;When checked, continuously publish commands at &amp;quot;pub freq&amp;quot;. When unchecked (default), nothing is sent automatically -- use &amp;quot;Send Once&amp;quot; to publish a single command on demand. Only available while the controller is enabled (armed).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>continuous send</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="send_once_button">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&lt;body&gt;&lt;p&gt;Publish the current joint targets once. Available whenever the controller is enabled (armed), independently of the &amp;quot;continuous send&amp;quot; checkbox.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Send Once</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>cm_combo</tabstop>
   <tabstop>jtc_combo</tabstop>
   <tabstop>enable_button</tabstop>
+  <tabstop>start_time_spin</tabstop>
+  <tabstop>pub_freq_spin</tabstop>
+  <tabstop>auto_send_checkbox</tabstop>
+  <tabstop>send_once_button</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -69,11 +69,19 @@ class JointTrajectoryController(Plugin):
           in monitor mode for safety reasons.
 
         2. B{Control mode} Joint displays update the control command that is
-        sent to the controller. Commands are sent periodically evan if the
-        displays are not being updated by the user.
+        sent to the controller.
 
     To control the aggressiveness of the motions, the maximum speed of the
     sent commands can be scaled down using the C{Speed scaling control}
+
+    While in control mode (armed via the enable button), commands are
+    I{not} sent automatically. Continuous sending only starts once the
+    C{continuous send} checkbox is turned on (off by default), at the rate
+    set by C{pub freq}. Independently of that checkbox, the C{Send Once}
+    button publishes a single command on demand. The time to reach the
+    target position (C{start time}) can also be adjusted manually from the
+    UI; when set to 0 the duration is auto-computed from the joint velocity
+    limits and speed scaling.
 
     This plugin is able to detect and keep track of all active controller
     managers, as well as the JointTrajectoryControllers that are I{running}
@@ -92,10 +100,10 @@ class JointTrajectoryController(Plugin):
     available in the C{joint_trajectory_controller} ROS package.
     """
 
-    _cmd_pub_freq = 10.0  # Hz
+    _default_cmd_pub_freq = 10.0  # Hz
     _widget_update_freq = 30.0  # Hz
     _ctrlrs_update_freq = 1  # Hz
-    _min_traj_dur = 5.0 / _cmd_pub_freq  # Minimum trajectory duration
+    _min_traj_dur = 5.0 / _default_cmd_pub_freq  # Minimum trajectory duration
 
     jointStateChanged = Signal([dict])
 
@@ -158,6 +166,10 @@ class JointTrajectoryController(Plugin):
         self._joint_names = []  # Ordered list of selected controller joints
         self._robot_joint_limits = {}  # Lazily evaluated on first use
 
+        # Manually adjustable trajectory / publish settings
+        self._cmd_pub_freq = self._widget.pub_freq_spin.value()
+        self._start_time_override_ms = self._widget.start_time_spin.value()
+
         # Timer for sending commands to active controller
         self._update_cmd_timer = QTimer(self)
         self._update_cmd_timer.setInterval(int(1000.0 / self._cmd_pub_freq))
@@ -189,6 +201,15 @@ class JointTrajectoryController(Plugin):
         w.enable_button.toggled.connect(self._on_jtc_enabled)
         w.jtc_combo.currentTextChanged.connect(self._on_jtc_change)
         w.cm_combo.currentTextChanged.connect(self._on_cm_change)
+        w.pub_freq_spin.valueChanged.connect(self._on_pub_freq_change)
+        w.start_time_spin.valueChanged.connect(self._on_start_time_change)
+        w.auto_send_checkbox.toggled.connect(self._on_auto_send_toggled)
+        w.send_once_button.clicked.connect(self._on_send_once)
+
+        # Sending (continuous or single-shot) requires the controller to be
+        # enabled (armed) first
+        w.auto_send_checkbox.setEnabled(False)
+        w.send_once_button.setEnabled(False)
 
         self._cmd_pub = None  # Controller command publisher
         self._state_sub = None  # Controller state subscriber
@@ -296,6 +317,36 @@ class JointTrajectoryController(Plugin):
     def _on_speed_scaling_change(self, val):
         self._speed_scale = val / self._speed_scaling_widget.slider.maximum()
 
+    def _on_pub_freq_change(self, val):
+        self._cmd_pub_freq = val
+        if self._update_cmd_timer.isActive():
+            self._update_cmd_timer.setInterval(int(1000.0 / self._cmd_pub_freq))
+
+    def _on_start_time_change(self, val):
+        self._start_time_override_ms = val
+
+    def _on_auto_send_toggled(self, val):
+        if val and self._widget.enable_button.isChecked():
+            self._update_cmd_timer.setInterval(int(1000.0 / self._cmd_pub_freq))
+            self._update_cmd_timer.start()
+        else:
+            self._update_cmd_timer.stop()
+
+    def _on_send_once(self):
+        # Nothing selected, or ROS interfaces not set up yet
+        if not self._jtc_name or self._cmd_pub is None or not rclpy.ok():
+            return
+        traj = self._build_trajectory_msg()
+        if traj is None:
+            return
+        try:
+            self._cmd_pub.publish(traj)
+        except Exception as e:
+            # Ignore teardown races on Ctrl+C where context/publisher may vanish mid-callback.
+            if "context is not valid" in str(e) or "destruction was requested" in str(e):
+                return
+            raise
+
     def _on_joint_state_change(self, current_pos):
         assert len(current_pos) == len(self._joint_pos)
         for name in current_pos.keys():
@@ -359,13 +410,22 @@ class JointTrajectoryController(Plugin):
         # Enable/disable speed scaling
         self._speed_scaling_widget.setEnabled(val)
 
+        # Sending (continuous or single-shot) is only allowed while armed.
+        # Enabling does NOT start continuous sending by itself -- the user
+        # has to explicitly turn on "continuous send" (default off), or use
+        # "Send Once" to publish a single command on demand. This avoids the
+        # erratic joint movement reported in #1579, which was caused by
+        # repeatedly republishing a trajectory with a fixed time_from_start.
+        self._widget.auto_send_checkbox.setEnabled(val)
+        self._widget.send_once_button.setEnabled(val)
+
         if val:
-            # Widgets send reference position commands to controller
+            # Widgets accept reference position commands from the user
             self._update_act_pos_timer.stop()
-            self._update_cmd_timer.start()
         else:
             # Controller updates widgets with feedback position
             self._update_cmd_timer.stop()
+            self._widget.auto_send_checkbox.setChecked(False)
             self._update_act_pos_timer.start()
 
     def _load_jtc(self):
@@ -496,10 +556,16 @@ class JointTrajectoryController(Plugin):
     def _update_single_cmd_cb(self, val, name):
         self._joint_pos[name]["command"] = val
 
-    def _update_cmd_cb(self):
-        # Timer events can still arrive during shutdown after publishers are destroyed.
-        if self._cmd_pub is None or not self._joint_names or not rclpy.ok():
-            return
+    def _build_trajectory_msg(self):
+        """Build a JointTrajectory message from the current joint targets.
+
+        The time to reach the target (time_from_start) is either the
+        user-specified start time override (if > 0), or auto-computed from
+        the joint velocity limits and speed scaling, same as the upstream
+        rqt_joint_trajectory_controller.
+        """
+        if not self._joint_names:
+            return None
 
         dur = []
         traj = JointTrajectory()
@@ -515,9 +581,24 @@ class JointTrajectoryController(Plugin):
             max_vel = self._robot_joint_limits[name]["max_velocity"]
             dur.append(max(abs(cmd - pos) / max_vel, self._min_traj_dur))
             point.positions.append(cmd)
-        duration = rclpy.duration.Duration(seconds=(max(dur) / self._speed_scale))
+
+        if self._start_time_override_ms > 0.0:
+            duration = rclpy.duration.Duration(seconds=self._start_time_override_ms / 1000.0)
+        else:
+            duration = rclpy.duration.Duration(seconds=(max(dur) / self._speed_scale))
         point.time_from_start = duration.to_msg()
         traj.points.append(point)
+
+        return traj
+
+    def _update_cmd_cb(self):
+        # Timer events can still arrive during shutdown after publishers are destroyed.
+        if self._cmd_pub is None or not self._joint_names or not rclpy.ok():
+            return
+
+        traj = self._build_trajectory_msg()
+        if traj is None:
+            return
 
         try:
             self._cmd_pub.publish(traj)

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -568,7 +568,8 @@ class JointTrajectoryController(Plugin):
         self._joint_pos[name]["command"] = val
 
     def _build_trajectory_msg(self):
-        """Build a JointTrajectory message from the current joint targets.
+        """
+        Build a JointTrajectory message from the current joint targets.
 
         The time to reach the target (time_from_start) is either the
         user-specified start time override (if > 0), or auto-computed from


### PR DESCRIPTION

The rqt_joint_trajectory_controller repeatedly republishes a trajectory with a big time_from_start (~1.0 s) at 10 Hz as soon as the controller is enabled. Because the joint has already moved between successive sends, each new trajectory is re-interpolated from a slightly different current position, producing jitter in the reference and erratic joint movement on both hardware and simulation.

Changes:
- Enabling (arming) a controller no longer starts continuous sending automatically. A new "continuous send" checkbox (off by default) must be ticked to republish commands periodically, restoring the old behaviour on demand.
- Add a "Send Once" button that publishes a single trajectory on demand, independently of the continuous-send checkbox.
- Add an adjustable "start time (ms)" spin box that overrides time_from_start when > 0; 0 keeps the auto-computed duration from joint velocity limits and speed scaling.
- Add an adjustable "pub freq (Hz)" spin box for the continuous-send rate.
- Refactor trajectory building into _build_trajectory_msg() shared by both the timer callback and Send Once.
- Document the new controls in userdoc.rst and add a CHANGELOG entry.

<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1579 

### Is this user-facing behavior change?

Yes,new components are added in the GUI allowing user to set time_from_start + publish freqency mannuly.
<img width="778" height="798" alt="image" src="https://github.com/user-attachments/assets/00581b10-dd6d-463a-aa28-6735c82a2bc1" />


### Did you use Generative AI?

Yes, I am using GLM5.2 within opencode.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

