### PR TITLE
Add option to timestamp joint_states from hardware measurement-time interfaces

### DIFF
--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -37,11 +37,28 @@ Published topics
 
 .. note::
 
-   By default ``header.stamp`` is set to the controller-manager update time. Set the optional
-   ``timestamp_state_interfaces.sec`` and ``timestamp_state_interfaces.nsec`` parameters to the full
-   names of two state interfaces which contain a measurement time reported by the
-   hardware (see the Parameters section below). This measurement time will then be used
-   instead in the stamp.
+   By default ``header.stamp`` is the controller manager update time. Set the optional
+   ``timestamp_state_interfaces.sec`` and ``timestamp_state_interfaces.nsec`` parameters to the
+   full names of two state interfaces that carry a measurement time reported by the hardware,
+   (if the hardware interface writes it). That measurement time is then used for the stamp.
+
+Example:
+
+.. code-block:: yaml
+
+   joint_state_broadcaster:
+     ros__parameters:
+       timestamp_state_interfaces:
+         sec: measurement_clock/measurement_time_sec
+         nsec: measurement_clock/measurement_time_nsec
+
+.. code-block:: xml
+
+   <sensor name="measurement_clock">
+     <!-- type may be of type ``double``, ``int32`` or ``uint32``. -->
+     <state_interface name="measurement_time_sec" data_type="uint32"/>
+     <state_interface name="measurement_time_nsec" data_type="uint32"/>
+   </sensor>
 
 
 Parameters

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -35,6 +35,14 @@ Published topics
    controller’s namespace (e.g., ``/my_state_broadcaster/joint_states``). If ``false`` (default),
    it is published at the root (e.g., ``/joint_states``).
 
+.. note::
+
+   By default ``header.stamp`` is set to the controller-manager update time. Set the optional
+   ``timestamp_state_interfaces.sec`` and ``timestamp_state_interfaces.nsec`` parameters to the full
+   names of two state interfaces which contain a measurement time reported by the
+   hardware (see the Parameters section below). This measurement time will then be used
+   instead in the stamp.
+
 
 Parameters
 ----------

--- a/joint_state_broadcaster/doc/userdoc.rst
+++ b/joint_state_broadcaster/doc/userdoc.rst
@@ -37,10 +37,11 @@ Published topics
 
 .. note::
 
-   By default ``header.stamp`` is the controller manager update time. Set the optional
-   ``timestamp_state_interfaces.sec`` and ``timestamp_state_interfaces.nsec`` parameters to the
-   full names of two state interfaces that carry a measurement time reported by the hardware,
-   (if the hardware interface writes it). That measurement time is then used for the stamp.
+   By default ``header.stamp`` is the controller manager update time. Set both
+   ``timestamp_state_interfaces.sec`` and ``timestamp_state_interfaces.nsec`` to the full names of
+   two state interfaces that the hardware writes a measurement time to, in the controller manager
+   clock domain. That measurement time is then used for the stamp. A seconds value of zero means no
+   measurement time is available.
 
 Example:
 
@@ -55,7 +56,7 @@ Example:
 .. code-block:: xml
 
    <sensor name="measurement_clock">
-     <!-- type may be of type ``double``, ``int32`` or ``uint32``. -->
+     <!-- data_type may be double, int32 or uint32 -->
      <state_interface name="measurement_time_sec" data_type="uint32"/>
      <state_interface name="measurement_time_nsec" data_type="uint32"/>
    </sensor>

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -117,10 +117,9 @@ protected:
   Params params_;
   std::unordered_map<std::string, std::string> map_interface_to_joint_state_;
 
-  // Optional source for header.stamp and the last timestamp read successfully from it.
+  // Optional source for header.stamp.
   std::optional<std::size_t> timestamp_sec_index_;
   std::optional<std::size_t> timestamp_nsec_index_;
-  std::optional<rclcpp::Time> last_valid_measurement_time_;
 
   std::string frame_id_;
 

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -96,13 +96,20 @@ protected:
 
   bool use_urdf_joint_interfaces() const;
 
+  /// \brief Whether both measurement time interfaces are configured.
+  bool use_timestamp_interfaces() const;
+
   /// \brief Whether the given interface is a measurement time interface.
   bool is_timestamp_interface(const std::string & full_interface_name) const;
 
-  /// \brief Read a measurement time component (sec or nsec) as an integer, whether the interface
-  /// is a double, int32 or uint32.
+  /// \brief Read and validate an integer measurement time component.
   /// \return the value, or std::nullopt if it cannot be read.
-  std::optional<int64_t> read_time_component(std::size_t state_interface_index) const;
+  std::optional<int64_t> read_time_component(
+    std::size_t state_interface_index, int64_t minimum, int64_t maximum) const;
+
+  /// \brief Read a valid measurement timestamp from the configured state interfaces.
+  /// \return the timestamp, or std::nullopt if either component is unavailable or invalid.
+  std::optional<rclcpp::Time> read_measurement_time(rcl_clock_type_t clock_type) const;
 
 protected:
   // Optional parameters
@@ -110,10 +117,10 @@ protected:
   Params params_;
   std::unordered_map<std::string, std::string> map_interface_to_joint_state_;
 
-  // Optional source for header.stamp: indices of the configured measurement time sec and nsec
-  // interfaces. When unset, header.stamp uses the controller manager time.
+  // Optional source for header.stamp and the last timestamp read successfully from it.
   std::optional<std::size_t> timestamp_sec_index_;
   std::optional<std::size_t> timestamp_nsec_index_;
+  std::optional<rclcpp::Time> last_valid_measurement_time_;
 
   std::string frame_id_;
 

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -95,6 +95,11 @@ protected:
 
   bool use_urdf_joint_interfaces() const;
 
+  /// \brief Whether \p full_interface_name is one of the configured measurement-time interfaces.
+  /// Such interfaces are the source of header.stamp, not joint state data, and are therefore
+  /// excluded from the joint-state read/publish path.
+  bool is_timestamp_interface(const std::string & full_interface_name) const;
+
 protected:
   // Optional parameters
   std::shared_ptr<ParamListener> param_listener_;

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -16,6 +16,7 @@
 #define JOINT_STATE_BROADCASTER__JOINT_STATE_BROADCASTER_HPP_
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -95,10 +96,13 @@ protected:
 
   bool use_urdf_joint_interfaces() const;
 
-  /// \brief Whether \p full_interface_name is one of the configured measurement-time interfaces.
-  /// Such interfaces are the source of header.stamp, not joint state data, and are therefore
-  /// excluded from the joint-state read/publish path.
+  /// \brief Whether the given interface is a measurement time interface.
   bool is_timestamp_interface(const std::string & full_interface_name) const;
+
+  /// \brief Read a measurement time component (sec or nsec) as an integer, whether the interface
+  /// is a double, int32 or uint32.
+  /// \return the value, or std::nullopt if it cannot be read.
+  std::optional<int64_t> read_time_component(std::size_t state_interface_index) const;
 
 protected:
   // Optional parameters
@@ -106,8 +110,8 @@ protected:
   Params params_;
   std::unordered_map<std::string, std::string> map_interface_to_joint_state_;
 
-  // Optional source for header.stamp: indices into state_interfaces_ of the configured
-  // measurement-time sec/nsec interfaces. Unset -> header.stamp uses the controller-manager time.
+  // Optional source for header.stamp: indices of the configured measurement time sec and nsec
+  // interfaces. When unset, header.stamp uses the controller manager time.
   std::optional<std::size_t> timestamp_sec_index_;
   std::optional<std::size_t> timestamp_nsec_index_;
 

--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -15,7 +15,9 @@
 #ifndef JOINT_STATE_BROADCASTER__JOINT_STATE_BROADCASTER_HPP_
 #define JOINT_STATE_BROADCASTER__JOINT_STATE_BROADCASTER_HPP_
 
+#include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -98,6 +100,11 @@ protected:
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;
   std::unordered_map<std::string, std::string> map_interface_to_joint_state_;
+
+  // Optional source for header.stamp: indices into state_interfaces_ of the configured
+  // measurement-time sec/nsec interfaces. Unset -> header.stamp uses the controller-manager time.
+  std::optional<std::size_t> timestamp_sec_index_;
+  std::optional<std::size_t> timestamp_nsec_index_;
 
   std::string frame_id_;
 

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -23,6 +23,9 @@
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/qos.hpp"
+#include <cmath>
+#include <cstdint>
+
 #include "rclcpp/time.hpp"
 #include "std_msgs/msg/header.hpp"
 
@@ -94,6 +97,14 @@ controller_interface::InterfaceConfiguration JointStateBroadcaster::state_interf
       {
         state_interfaces_config.names.push_back(joint + "/" + interface);
       }
+    }
+    // Also claim the optional measurement-time interfaces (if configured). In ALL mode they are
+    // already included; here (INDIVIDUAL) they must be requested explicitly.
+    if (!params_.timestamp_state_interfaces.sec.empty() &&
+      !params_.timestamp_state_interfaces.nsec.empty())
+    {
+      state_interfaces_config.names.push_back(params_.timestamp_state_interfaces.sec);
+      state_interfaces_config.names.push_back(params_.timestamp_state_interfaces.nsec);
     }
   }
 
@@ -231,6 +242,33 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
 
   init_auxiliary_data();
   init_joint_state_msg();
+
+  // Resolve the optional measurement-time interfaces (source of header.stamp). If configured but
+  // not among the claimed state interfaces, warn once and fall back to the controller-manager time.
+  timestamp_sec_index_.reset();
+  timestamp_nsec_index_.reset();
+  if (!params_.timestamp_state_interfaces.sec.empty() &&
+    !params_.timestamp_state_interfaces.nsec.empty())
+  {
+    for (std::size_t i = 0; i < state_interfaces_.size(); ++i)
+    {
+      const auto name = state_interfaces_[i].get_name();
+      if (name == params_.timestamp_state_interfaces.sec) { timestamp_sec_index_ = i; }
+      else if (name == params_.timestamp_state_interfaces.nsec) { timestamp_nsec_index_ = i; }
+    }
+    if (!timestamp_sec_index_.has_value() || !timestamp_nsec_index_.has_value())
+    {
+      RCLCPP_WARN(
+        get_node()->get_logger(),
+        "timestamp_state_interfaces is set (sec='%s', nsec='%s') but the interface(s) were not "
+        "found among the claimed state interfaces; header.stamp will use the controller-manager "
+        "time.",
+        params_.timestamp_state_interfaces.sec.c_str(),
+        params_.timestamp_state_interfaces.nsec.c_str());
+      timestamp_sec_index_.reset();
+      timestamp_nsec_index_.reset();
+    }
+  }
 
   return CallbackReturn::SUCCESS;
 }
@@ -438,9 +476,25 @@ controller_interface::return_type JointStateBroadcaster::update(
     }
   }
 
+  // header.stamp: get it from the configured measurement-time interfaces when available and
+  // valid. otherwise use the controller-manager time.
+  rclcpp::Time stamp = time;
+  if (timestamp_sec_index_.has_value() && timestamp_nsec_index_.has_value())
+  {
+    const auto sec_opt = state_interfaces_[*timestamp_sec_index_].get_optional(0);
+    const auto nsec_opt = state_interfaces_[*timestamp_nsec_index_].get_optional(0);
+    if (sec_opt.has_value() && nsec_opt.has_value() && std::isfinite(sec_opt.value()) &&
+      std::isfinite(nsec_opt.value()) && sec_opt.value() > 0.0 && nsec_opt.value() >= 0.0)
+    {
+      stamp = rclcpp::Time(
+        static_cast<int32_t>(sec_opt.value()), static_cast<uint32_t>(nsec_opt.value()),
+        time.get_clock_type());
+    }
+  }
+
   if (realtime_joint_state_publisher_)
   {
-    joint_state_msg_.header.stamp = time;
+    joint_state_msg_.header.stamp = stamp;
 
     for (size_t i = 0; i < joint_names_.size(); ++i)
     {

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -23,6 +23,8 @@
 
 #include <cmath>
 #include <cstdint>
+#include <optional>
+#include <type_traits>
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/qos.hpp"
 
@@ -40,6 +42,17 @@ const auto kUninitializedValue = std::numeric_limits<double>::quiet_NaN();
 using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::HW_IF_VELOCITY;
+
+namespace
+{
+/// Check if data type is accepted for the measurement time interfaces.
+bool is_supported_timestamp_data_type(hardware_interface::HandleDataType data_type)
+{
+  return data_type == hardware_interface::HandleDataType::DOUBLE ||
+         data_type == hardware_interface::HandleDataType::INT32 ||
+         data_type == hardware_interface::HandleDataType::UINT32;
+}
+}  // namespace
 
 JointStateBroadcaster::JointStateBroadcaster() {}
 
@@ -100,7 +113,7 @@ controller_interface::InterfaceConfiguration JointStateBroadcaster::state_interf
     }
   }
 
-  // Claim the optional measurement-time interfaces (if configured) in either configuration mode.
+  // Claim the optional measurement time interfaces (if configured).
   if (
     !params_.timestamp_state_interfaces.sec.empty() &&
     !params_.timestamp_state_interfaces.nsec.empty())
@@ -244,8 +257,7 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
   init_auxiliary_data();
   init_joint_state_msg();
 
-  // Resolve the optional measurement-time interfaces (source of header.stamp). If configured but
-  // not among the claimed state interfaces, warn once and fall back to the controller-manager time.
+  // Resolve the optional measurement time interfaces, if configured.
   timestamp_sec_index_.reset();
   timestamp_nsec_index_.reset();
   if (
@@ -264,6 +276,8 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
         timestamp_nsec_index_ = i;
       }
     }
+    // If configured but not claimed, or wrong type for the interface,
+    // warn and fall back to the controller manager time.
     if (!timestamp_sec_index_.has_value() || !timestamp_nsec_index_.has_value())
     {
       RCLCPP_WARN(
@@ -273,6 +287,22 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
         "time.",
         params_.timestamp_state_interfaces.sec.c_str(),
         params_.timestamp_state_interfaces.nsec.c_str());
+      timestamp_sec_index_.reset();
+      timestamp_nsec_index_.reset();
+    }
+    else if (
+      !is_supported_timestamp_data_type(state_interfaces_[*timestamp_sec_index_].get_data_type()) ||
+      !is_supported_timestamp_data_type(state_interfaces_[*timestamp_nsec_index_].get_data_type()))
+    {
+      RCLCPP_WARN(
+        get_node()->get_logger(),
+        "timestamp_state_interfaces have an unsupported data type (sec='%s' is '%s', nsec='%s' is "
+        "'%s'); supported types are double, int32 and uint32. header.stamp will use the "
+        "controller-manager time.",
+        params_.timestamp_state_interfaces.sec.c_str(),
+        state_interfaces_[*timestamp_sec_index_].get_data_type().to_string().c_str(),
+        params_.timestamp_state_interfaces.nsec.c_str(),
+        state_interfaces_[*timestamp_nsec_index_].get_data_type().to_string().c_str());
       timestamp_sec_index_.reset();
       timestamp_nsec_index_.reset();
     }
@@ -304,8 +334,7 @@ bool JointStateBroadcaster::init_joint_data()
     HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
   for (auto si = state_interfaces_.crbegin(); si != state_interfaces_.crend(); si++)
   {
-    // Skip the optional measurement-time interfaces: they are the source of header.stamp, not
-    // joint state data, so they must not be treated as (missing) joint state fields.
+    // Skip the measurement time interfaces: they provide header.stamp, not joint state.
     if (is_timestamp_interface(si->get_name()))
     {
       continue;
@@ -405,8 +434,8 @@ void JointStateBroadcaster::init_auxiliary_data()
   mapped_values_.clear();
   for (auto i = 0u; i < state_interfaces_.size(); ++i)
   {
-    // Measurement-time interfaces are not joint state data. Keep them out of the mapping so the
-    // update() read loop (which skips them too) stays index-aligned with mapped_values_.
+    // Keep the measurement time interfaces out of the mapping so it stays aligned with the read
+    // loop in update(), which skips them too.
     if (is_timestamp_interface(state_interfaces_[i].get_name()))
     {
       continue;
@@ -480,14 +509,53 @@ bool JointStateBroadcaster::is_timestamp_interface(const std::string & full_inte
          full_interface_name == params_.timestamp_state_interfaces.nsec;
 }
 
+std::optional<int64_t> JointStateBroadcaster::read_time_component(
+  std::size_t state_interface_index) const
+{
+  const auto & state_interface = state_interfaces_[state_interface_index];
+
+  // Normalize the value to int64_t and reject a NaN or infinite double.
+  const auto to_int64 = [](const auto & opt) -> std::optional<int64_t>
+  {
+    if (!opt.has_value())
+    {
+      return std::nullopt;
+    }
+    using value_type = std::decay_t<decltype(opt.value())>;
+    if constexpr (std::is_floating_point_v<value_type>)
+    {
+      if (!std::isfinite(opt.value()))
+      {
+        return std::nullopt;
+      }
+    }
+    return static_cast<int64_t>(opt.value());
+  };
+
+  // Read with the accessor that matches the declared type. A typed get_optional throws on a type
+  // mismatch, so dispatch on the data type. Supported types are validated at activation.
+  switch (state_interface.get_data_type())
+  {
+    case hardware_interface::HandleDataType::DOUBLE:
+      return to_int64(state_interface.get_optional<double>(0));
+    case hardware_interface::HandleDataType::INT32:
+      return to_int64(state_interface.get_optional<int32_t>(0));
+    case hardware_interface::HandleDataType::UINT32:
+      return to_int64(state_interface.get_optional<uint32_t>(0));
+    default:
+      // Unsupported type, already handled at activation. Fall back to the controller manager time.
+      return std::nullopt;
+  }
+}
+
 controller_interface::return_type JointStateBroadcaster::update(
   const rclcpp::Time & time, const rclcpp::Duration & /*period*/)
 {
   size_t map_index = 0u;
   for (auto i = 0u; i < state_interfaces_.size(); ++i)
   {
-    // Measurement-time interfaces are handled separately for header.stamp (below). Skip them here
-    // so map_index stays aligned with mapped_values_ (which also excludes them).
+    // The measurement time interfaces feed header.stamp (below). Skip them here so this
+    // stays aligned with the mapping, which excludes them too.
     if (is_timestamp_interface(state_interfaces_[i].get_name()))
     {
       continue;
@@ -508,19 +576,17 @@ controller_interface::return_type JointStateBroadcaster::update(
     }
   }
 
-  // header.stamp: get it from the configured measurement-time interfaces when available and
-  // valid. otherwise use the controller-manager time.
+  // Use the measurement time interfaces for header.stamp when available and valid, otherwise the
+  // controller manager time.
   rclcpp::Time stamp = time;
   if (timestamp_sec_index_.has_value() && timestamp_nsec_index_.has_value())
   {
-    const auto sec_opt = state_interfaces_[*timestamp_sec_index_].get_optional(0);
-    const auto nsec_opt = state_interfaces_[*timestamp_nsec_index_].get_optional(0);
-    if (
-      sec_opt.has_value() && nsec_opt.has_value() && std::isfinite(sec_opt.value()) &&
-      std::isfinite(nsec_opt.value()) && sec_opt.value() > 0.0 && nsec_opt.value() >= 0.0)
+    const auto sec = read_time_component(*timestamp_sec_index_);
+    const auto nsec = read_time_component(*timestamp_nsec_index_);
+    if (sec.has_value() && nsec.has_value() && sec.value() > 0 && nsec.value() >= 0)
     {
       stamp = rclcpp::Time(
-        static_cast<int32_t>(sec_opt.value()), static_cast<uint32_t>(nsec_opt.value()),
+        static_cast<int32_t>(sec.value()), static_cast<uint32_t>(nsec.value()),
         time.get_clock_type());
     }
   }

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -14,6 +14,7 @@
 
 #include "joint_state_broadcaster/joint_state_broadcaster.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <limits>
 #include <memory>
@@ -24,7 +25,6 @@
 #include <cmath>
 #include <cstdint>
 #include <optional>
-#include <type_traits>
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/qos.hpp"
 
@@ -114,9 +114,7 @@ controller_interface::InterfaceConfiguration JointStateBroadcaster::state_interf
   }
 
   // Claim the optional measurement time interfaces (if configured).
-  if (
-    !params_.timestamp_state_interfaces.sec.empty() &&
-    !params_.timestamp_state_interfaces.nsec.empty())
+  if (use_timestamp_interfaces())
   {
     state_interfaces_config.names.push_back(params_.timestamp_state_interfaces.sec);
     state_interfaces_config.names.push_back(params_.timestamp_state_interfaces.nsec);
@@ -129,6 +127,17 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_configure(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
   params_ = param_listener_->get_params();
+
+  const bool timestamp_sec_configured = !params_.timestamp_state_interfaces.sec.empty();
+  const bool timestamp_nsec_configured = !params_.timestamp_state_interfaces.nsec.empty();
+  if (timestamp_sec_configured != timestamp_nsec_configured)
+  {
+    RCLCPP_ERROR(
+      get_node()->get_logger(),
+      "Both 'timestamp_state_interfaces.sec' and 'timestamp_state_interfaces.nsec' must be set, "
+      "or both must be empty.");
+    return CallbackReturn::ERROR;
+  }
 
   if (use_urdf_joint_interfaces())
   {
@@ -260,9 +269,8 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
   // Resolve the optional measurement time interfaces, if configured.
   timestamp_sec_index_.reset();
   timestamp_nsec_index_.reset();
-  if (
-    !params_.timestamp_state_interfaces.sec.empty() &&
-    !params_.timestamp_state_interfaces.nsec.empty())
+  last_valid_measurement_time_.reset();
+  if (use_timestamp_interfaces())
   {
     for (std::size_t i = 0; i < state_interfaces_.size(); ++i)
     {
@@ -283,7 +291,7 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
       RCLCPP_WARN(
         get_node()->get_logger(),
         "timestamp_state_interfaces is set (sec='%s', nsec='%s') but the interface(s) were not "
-        "found among the claimed state interfaces; header.stamp will use the controller-manager "
+        "found among the claimed state interfaces; header.stamp will use the controller manager "
         "time.",
         params_.timestamp_state_interfaces.sec.c_str(),
         params_.timestamp_state_interfaces.nsec.c_str());
@@ -298,7 +306,7 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
         get_node()->get_logger(),
         "timestamp_state_interfaces have an unsupported data type (sec='%s' is '%s', nsec='%s' is "
         "'%s'); supported types are double, int32 and uint32. header.stamp will use the "
-        "controller-manager time.",
+        "controller manager time.",
         params_.timestamp_state_interfaces.sec.c_str(),
         state_interfaces_[*timestamp_sec_index_].get_data_type().to_string().c_str(),
         params_.timestamp_state_interfaces.nsec.c_str(),
@@ -316,6 +324,9 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_deactivate(
 {
   joint_names_.clear();
   name_if_value_mapping_.clear();
+  timestamp_sec_index_.reset();
+  timestamp_nsec_index_.reset();
+  last_valid_measurement_time_.reset();
 
   return CallbackReturn::SUCCESS;
 }
@@ -323,9 +334,12 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_deactivate(
 bool JointStateBroadcaster::init_joint_data()
 {
   joint_names_.clear();
-  if (state_interfaces_.empty())
+  const bool has_joint_state_interface = std::any_of(
+    state_interfaces_.cbegin(), state_interfaces_.cend(), [this](const auto & state_interface)
+    { return !is_timestamp_interface(state_interface.get_name()); });
+  if (!has_joint_state_interface)
   {
-    RCLCPP_ERROR(get_node()->get_logger(), "No state interfaces found to publish.");
+    RCLCPP_ERROR(get_node()->get_logger(), "No joint state interfaces found to publish.");
     return false;
   }
 
@@ -503,6 +517,12 @@ bool JointStateBroadcaster::use_urdf_joint_interfaces() const
   return params_.joints.empty() || params_.interfaces.empty();
 }
 
+bool JointStateBroadcaster::use_timestamp_interfaces() const
+{
+  return !params_.timestamp_state_interfaces.sec.empty() &&
+         !params_.timestamp_state_interfaces.nsec.empty();
+}
+
 bool JointStateBroadcaster::is_timestamp_interface(const std::string & full_interface_name) const
 {
   return full_interface_name == params_.timestamp_state_interfaces.sec ||
@@ -510,26 +530,24 @@ bool JointStateBroadcaster::is_timestamp_interface(const std::string & full_inte
 }
 
 std::optional<int64_t> JointStateBroadcaster::read_time_component(
-  std::size_t state_interface_index) const
+  std::size_t state_interface_index, int64_t minimum, int64_t maximum) const
 {
   const auto & state_interface = state_interfaces_[state_interface_index];
 
-  // Normalize the value to int64_t and reject a NaN or infinite double.
-  const auto to_int64 = [](const auto & opt) -> std::optional<int64_t>
+  const auto to_int64 = [minimum, maximum](const auto & opt) -> std::optional<int64_t>
   {
     if (!opt.has_value())
     {
       return std::nullopt;
     }
-    using value_type = std::decay_t<decltype(opt.value())>;
-    if constexpr (std::is_floating_point_v<value_type>)
+    const long double value = static_cast<long double>(opt.value());
+    if (
+      !std::isfinite(value) || value < static_cast<long double>(minimum) ||
+      value > static_cast<long double>(maximum) || std::trunc(value) != value)
     {
-      if (!std::isfinite(opt.value()))
-      {
-        return std::nullopt;
-      }
+      return std::nullopt;
     }
-    return static_cast<int64_t>(opt.value());
+    return static_cast<int64_t>(value);
   };
 
   // Read with the accessor that matches the declared type. A typed get_optional throws on a type
@@ -546,6 +564,20 @@ std::optional<int64_t> JointStateBroadcaster::read_time_component(
       // Unsupported type, already handled at activation. Fall back to the controller manager time.
       return std::nullopt;
   }
+}
+
+std::optional<rclcpp::Time> JointStateBroadcaster::read_measurement_time(
+  rcl_clock_type_t clock_type) const
+{
+  const auto sec =
+    read_time_component(*timestamp_sec_index_, 1, std::numeric_limits<int32_t>::max());
+  const auto nsec = read_time_component(*timestamp_nsec_index_, 0, 999999999);
+  if (!sec.has_value() || !nsec.has_value())
+  {
+    return std::nullopt;
+  }
+  return rclcpp::Time(
+    static_cast<int32_t>(sec.value()), static_cast<uint32_t>(nsec.value()), clock_type);
 }
 
 controller_interface::return_type JointStateBroadcaster::update(
@@ -576,19 +608,18 @@ controller_interface::return_type JointStateBroadcaster::update(
     }
   }
 
-  // Use the measurement time interfaces for header.stamp when available and valid, otherwise the
-  // controller manager time.
+  // Once configured, header.stamp is the measurement time, keeping the last valid value during
+  // temporary read failures. A zero stamp means no measurement time is available yet.
   rclcpp::Time stamp = time;
   if (timestamp_sec_index_.has_value() && timestamp_nsec_index_.has_value())
   {
-    const auto sec = read_time_component(*timestamp_sec_index_);
-    const auto nsec = read_time_component(*timestamp_nsec_index_);
-    if (sec.has_value() && nsec.has_value() && sec.value() > 0 && nsec.value() >= 0)
+    const auto measurement_time = read_measurement_time(time.get_clock_type());
+    if (measurement_time.has_value())
     {
-      stamp = rclcpp::Time(
-        static_cast<int32_t>(sec.value()), static_cast<uint32_t>(nsec.value()),
-        time.get_clock_type());
+      last_valid_measurement_time_ = measurement_time;
     }
+    stamp = last_valid_measurement_time_.value_or(
+      rclcpp::Time(static_cast<int64_t>(0), time.get_clock_type()));
   }
 
   if (realtime_joint_state_publisher_)

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -269,7 +269,6 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
   // Resolve the optional measurement time interfaces, if configured.
   timestamp_sec_index_.reset();
   timestamp_nsec_index_.reset();
-  last_valid_measurement_time_.reset();
   if (use_timestamp_interfaces())
   {
     for (std::size_t i = 0; i < state_interfaces_.size(); ++i)
@@ -326,7 +325,6 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_deactivate(
   name_if_value_mapping_.clear();
   timestamp_sec_index_.reset();
   timestamp_nsec_index_.reset();
-  last_valid_measurement_time_.reset();
 
   return CallbackReturn::SUCCESS;
 }
@@ -569,13 +567,35 @@ std::optional<int64_t> JointStateBroadcaster::read_time_component(
 std::optional<rclcpp::Time> JointStateBroadcaster::read_measurement_time(
   rcl_clock_type_t clock_type) const
 {
-  const auto sec =
-    read_time_component(*timestamp_sec_index_, 1, std::numeric_limits<int32_t>::max());
+  // Any seconds value is read. The meaning of the value is decided below.
+  const auto sec = read_time_component(
+    *timestamp_sec_index_, std::numeric_limits<int32_t>::min(),
+    std::numeric_limits<int32_t>::max());
   const auto nsec = read_time_component(*timestamp_nsec_index_, 0, 999999999);
   if (!sec.has_value() || !nsec.has_value())
   {
     return std::nullopt;
   }
+
+  // An all-zero stamp means "no measurement time". Hardware writes it deliberately, and it is the
+  // ROS convention for an unset time.
+  if (sec.value() == 0 && nsec.value() == 0)
+  {
+    return std::nullopt;
+  }
+
+  // A negative time cannot be published: rclcpp::Time does not represent one. Treat it as no
+  // measurement time and report it, since it is not how absence is meant to be signalled.
+  if (sec.value() < 0)
+  {
+    RCLCPP_ERROR_THROTTLE(
+      get_node()->get_logger(), *get_node()->get_clock(), 1000,
+      "State interface '%s' holds a negative measurement time (%ld s), which is not a representable "
+      "ROS time. Write an all-zero stamp to signal that no measurement time is available.",
+      params_.timestamp_state_interfaces.sec.c_str(), static_cast<long>(sec.value()));
+    return std::nullopt;
+  }
+
   return rclcpp::Time(
     static_cast<int32_t>(sec.value()), static_cast<uint32_t>(nsec.value()), clock_type);
 }
@@ -608,18 +628,24 @@ controller_interface::return_type JointStateBroadcaster::update(
     }
   }
 
-  // Once configured, header.stamp is the measurement time, keeping the last valid value during
-  // temporary read failures. A zero stamp means no measurement time is available yet.
+  // Once configured, header.stamp is the measurement time and nothing else. Without one there is no
+  // honest stamp for this cycle's data, so the cycle is skipped rather than published with a
+  // substitute or with an older measurement time that no longer describes the data.
   rclcpp::Time stamp = time;
   if (timestamp_sec_index_.has_value() && timestamp_nsec_index_.has_value())
   {
     const auto measurement_time = read_measurement_time(time.get_clock_type());
-    if (measurement_time.has_value())
+    if (!measurement_time.has_value())
     {
-      last_valid_measurement_time_ = measurement_time;
+      RCLCPP_ERROR_THROTTLE(
+        get_node()->get_logger(), *get_node()->get_clock(), 1000,
+        "State interfaces '%s' and '%s' carry no valid measurement time. Not publishing joint "
+        "states until they do.",
+        params_.timestamp_state_interfaces.sec.c_str(),
+        params_.timestamp_state_interfaces.nsec.c_str());
+      return controller_interface::return_type::OK;
     }
-    stamp = last_valid_measurement_time_.value_or(
-      rclcpp::Time(static_cast<int64_t>(0), time.get_clock_type()));
+    stamp = *measurement_time;
   }
 
   if (realtime_joint_state_publisher_)

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -98,15 +98,15 @@ controller_interface::InterfaceConfiguration JointStateBroadcaster::state_interf
         state_interfaces_config.names.push_back(joint + "/" + interface);
       }
     }
-    // Also claim the optional measurement-time interfaces (if configured). In ALL mode they are
-    // already included; here (INDIVIDUAL) they must be requested explicitly.
-    if (
-      !params_.timestamp_state_interfaces.sec.empty() &&
-      !params_.timestamp_state_interfaces.nsec.empty())
-    {
-      state_interfaces_config.names.push_back(params_.timestamp_state_interfaces.sec);
-      state_interfaces_config.names.push_back(params_.timestamp_state_interfaces.nsec);
-    }
+  }
+
+  // Claim the optional measurement-time interfaces (if configured) in either configuration mode.
+  if (
+    !params_.timestamp_state_interfaces.sec.empty() &&
+    !params_.timestamp_state_interfaces.nsec.empty())
+  {
+    state_interfaces_config.names.push_back(params_.timestamp_state_interfaces.sec);
+    state_interfaces_config.names.push_back(params_.timestamp_state_interfaces.nsec);
   }
 
   return state_interfaces_config;

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -21,10 +21,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "rclcpp/qos.hpp"
 #include <cmath>
 #include <cstdint>
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rclcpp/qos.hpp"
 
 #include "rclcpp/time.hpp"
 #include "std_msgs/msg/header.hpp"
@@ -100,7 +100,8 @@ controller_interface::InterfaceConfiguration JointStateBroadcaster::state_interf
     }
     // Also claim the optional measurement-time interfaces (if configured). In ALL mode they are
     // already included; here (INDIVIDUAL) they must be requested explicitly.
-    if (!params_.timestamp_state_interfaces.sec.empty() &&
+    if (
+      !params_.timestamp_state_interfaces.sec.empty() &&
       !params_.timestamp_state_interfaces.nsec.empty())
     {
       state_interfaces_config.names.push_back(params_.timestamp_state_interfaces.sec);
@@ -247,14 +248,21 @@ controller_interface::CallbackReturn JointStateBroadcaster::on_activate(
   // not among the claimed state interfaces, warn once and fall back to the controller-manager time.
   timestamp_sec_index_.reset();
   timestamp_nsec_index_.reset();
-  if (!params_.timestamp_state_interfaces.sec.empty() &&
+  if (
+    !params_.timestamp_state_interfaces.sec.empty() &&
     !params_.timestamp_state_interfaces.nsec.empty())
   {
     for (std::size_t i = 0; i < state_interfaces_.size(); ++i)
     {
       const auto name = state_interfaces_[i].get_name();
-      if (name == params_.timestamp_state_interfaces.sec) { timestamp_sec_index_ = i; }
-      else if (name == params_.timestamp_state_interfaces.nsec) { timestamp_nsec_index_ = i; }
+      if (name == params_.timestamp_state_interfaces.sec)
+      {
+        timestamp_sec_index_ = i;
+      }
+      else if (name == params_.timestamp_state_interfaces.nsec)
+      {
+        timestamp_nsec_index_ = i;
+      }
     }
     if (!timestamp_sec_index_.has_value() || !timestamp_nsec_index_.has_value())
     {
@@ -483,7 +491,8 @@ controller_interface::return_type JointStateBroadcaster::update(
   {
     const auto sec_opt = state_interfaces_[*timestamp_sec_index_].get_optional(0);
     const auto nsec_opt = state_interfaces_[*timestamp_nsec_index_].get_optional(0);
-    if (sec_opt.has_value() && nsec_opt.has_value() && std::isfinite(sec_opt.value()) &&
+    if (
+      sec_opt.has_value() && nsec_opt.has_value() && std::isfinite(sec_opt.value()) &&
       std::isfinite(nsec_opt.value()) && sec_opt.value() > 0.0 && nsec_opt.value() >= 0.0)
     {
       stamp = rclcpp::Time(

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -304,6 +304,12 @@ bool JointStateBroadcaster::init_joint_data()
     HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
   for (auto si = state_interfaces_.crbegin(); si != state_interfaces_.crend(); si++)
   {
+    // Skip the optional measurement-time interfaces: they are the source of header.stamp, not
+    // joint state data, so they must not be treated as (missing) joint state fields.
+    if (is_timestamp_interface(si->get_name()))
+    {
+      continue;
+    }
     if (si->get_data_type() != hardware_interface::HandleDataType::DOUBLE)
     {
       RCLCPP_WARN(
@@ -399,6 +405,12 @@ void JointStateBroadcaster::init_auxiliary_data()
   mapped_values_.clear();
   for (auto i = 0u; i < state_interfaces_.size(); ++i)
   {
+    // Measurement-time interfaces are not joint state data. Keep them out of the mapping so the
+    // update() read loop (which skips them too) stays index-aligned with mapped_values_.
+    if (is_timestamp_interface(state_interfaces_[i].get_name()))
+    {
+      continue;
+    }
     if (state_interfaces_[i].get_data_type() != hardware_interface::HandleDataType::DOUBLE)
     {
       continue;
@@ -462,12 +474,24 @@ bool JointStateBroadcaster::use_urdf_joint_interfaces() const
   return params_.joints.empty() || params_.interfaces.empty();
 }
 
+bool JointStateBroadcaster::is_timestamp_interface(const std::string & full_interface_name) const
+{
+  return full_interface_name == params_.timestamp_state_interfaces.sec ||
+         full_interface_name == params_.timestamp_state_interfaces.nsec;
+}
+
 controller_interface::return_type JointStateBroadcaster::update(
   const rclcpp::Time & time, const rclcpp::Duration & /*period*/)
 {
   size_t map_index = 0u;
   for (auto i = 0u; i < state_interfaces_.size(); ++i)
   {
+    // Measurement-time interfaces are handled separately for header.stamp (below). Skip them here
+    // so map_index stays aligned with mapped_values_ (which also excludes them).
+    if (is_timestamp_interface(state_interfaces_[i].get_name()))
+    {
+      continue;
+    }
     if (state_interfaces_[i].get_data_type() == hardware_interface::HandleDataType::DOUBLE)
     {
       // no retries, just try to get the latest value once

--- a/joint_state_broadcaster/src/joint_state_broadcaster_parameters.yaml
+++ b/joint_state_broadcaster/src/joint_state_broadcaster_parameters.yaml
@@ -64,3 +64,20 @@ joint_state_broadcaster:
     read_only: true,
     description: "The frame_id to be used in the published joint states. This parameter allows rviz2 to visualize the effort of the joints."
   }
+  timestamp_state_interfaces:
+    sec: {
+      type: string,
+      default_value: "",
+      read_only: true,
+      description: "[Optional] Full name of a state interface (e.g. 'measurement_clock/measurement_time_sec')
+      whose value is the integer seconds of a measurement time. When both sec and nsec are set and the
+      interfaces are available, the published header.stamp is sourced from them instead of the
+      controller-manager time. Empty (default) or unset preserves the standard behaviour (header.stamp = time)."
+    }
+    nsec: {
+      type: string,
+      default_value: "",
+      read_only: true,
+      description: "[Optional] Full name of a state interface holding the nanoseconds part of the
+      measurement time. See timestamp_state_interfaces.sec."
+    }

--- a/joint_state_broadcaster/src/joint_state_broadcaster_parameters.yaml
+++ b/joint_state_broadcaster/src/joint_state_broadcaster_parameters.yaml
@@ -70,12 +70,13 @@ joint_state_broadcaster:
       default_value: "",
       read_only: true,
       description: "[Optional] Full name of a state interface (e.g. 'measurement_clock/measurement_time_sec')
-      whose value is seconds of measurement time. The interface may be of type double,
-      int32 or uint32 and must contain an integer from 1 through INT32_MAX. Zero means that no
-      measurement time is available. Both timestamp interface parameters must be set together.
-      When the interfaces are available, the published header.stamp
-      is sourced from them instead of the controller manager time. Empty (default) keeps the standard
-      behavior (header.stamp = controller time)."
+      whose value is seconds of measurement time. When set, header.stamp is sourced from it instead of
+      the controller manager time. Empty (default) keeps the standard behavior. Must be set together
+      with nsec. The interface may be of type double, int32 or uint32 and must hold an integer.
+      An all-zero stamp, and only that, means no measurement time is available. Negative values are
+      rejected with an error. A cycle with no measurement time is not published at all, since no stamp
+      would describe its data. Hardware that wants the cycle published regardless can write any
+      timestamp it considers valid for it, including the controller time."
     }
     nsec: {
       type: string,

--- a/joint_state_broadcaster/src/joint_state_broadcaster_parameters.yaml
+++ b/joint_state_broadcaster/src/joint_state_broadcaster_parameters.yaml
@@ -71,14 +71,16 @@ joint_state_broadcaster:
       read_only: true,
       description: "[Optional] Full name of a state interface (e.g. 'measurement_clock/measurement_time_sec')
       whose value is seconds of measurement time. The interface may be of type double,
-      int32 or uint32. When both sec and nsec are set and the interfaces are available, the published
-      header.stamp is sourced from them instead of the controller manager time. Empty (default) or
-      unset keeps the standard behaviour (header.stamp = controller time)."
+      int32 or uint32 and must contain an integer from 1 through INT32_MAX. Zero means that no
+      measurement time is available. Both timestamp interface parameters must be set together.
+      When the interfaces are available, the published header.stamp
+      is sourced from them instead of the controller manager time. Empty (default) keeps the standard
+      behavior (header.stamp = controller time)."
     }
     nsec: {
       type: string,
       default_value: "",
       read_only: true,
-      description: "[Optional] Full name of a state interface holding the nanoseconds part of the
-      measurement time. See timestamp_state_interfaces.sec."
+      description: "[Optional] Full name of a state interface holding the integer nanoseconds part
+      of the measurement time, from 0 through 999999999. See timestamp_state_interfaces.sec."
     }

--- a/joint_state_broadcaster/src/joint_state_broadcaster_parameters.yaml
+++ b/joint_state_broadcaster/src/joint_state_broadcaster_parameters.yaml
@@ -70,9 +70,10 @@ joint_state_broadcaster:
       default_value: "",
       read_only: true,
       description: "[Optional] Full name of a state interface (e.g. 'measurement_clock/measurement_time_sec')
-      whose value is the integer seconds of a measurement time. When both sec and nsec are set and the
-      interfaces are available, the published header.stamp is sourced from them instead of the
-      controller-manager time. Empty (default) or unset preserves the standard behaviour (header.stamp = time)."
+      whose value is seconds of measurement time. The interface may be of type double,
+      int32 or uint32. When both sec and nsec are set and the interfaces are available, the published
+      header.stamp is sourced from them instead of the controller manager time. Empty (default) or
+      unset keeps the standard behaviour (header.stamp = controller time)."
     }
     nsec: {
       type: string,

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -199,7 +199,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp)
   // With timestamp_state_interfaces set and the interfaces present, header.stamp is taken from
   // them, not from the controller-manager `time` passed to update().
   init_broadcaster_and_set_parameters(
-    "", {}, {},
+    kThreeJointURDF, {}, {},
     {rclcpp::Parameter("timestamp_state_interfaces.sec", "measurement_clock/measurement_time_sec"),
      rclcpp::Parameter(
        "timestamp_state_interfaces.nsec", "measurement_clock/measurement_time_nsec")});
@@ -227,7 +227,8 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp)
     controller_interface::return_type::OK);
 
   const auto & stamp = state_broadcaster_->joint_state_msg_.header.stamp;
-  EXPECT_EQ(stamp.sec, 1234) << "header.stamp should come from measurement_time_sec, not the CM time";
+  EXPECT_EQ(stamp.sec, 1234)
+    << "header.stamp should come from measurement_time_sec, not the CM time";
   EXPECT_EQ(stamp.nanosec, 567000000u);
 }
 

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -320,6 +320,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesClaimedInUrdfFilterMod
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesPartialConfigurationRejected)
 {
+  // Setting only one of sec or nsec must fail configuration.
   for (const auto & parameter :
        {rclcpp::Parameter("timestamp_state_interfaces.sec", kTimestampSecInterface),
         rclcpp::Parameter("timestamp_state_interfaces.nsec", kTimestampNsecInterface)})
@@ -347,6 +348,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesClaimedInExplicitMode)
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUnsupportedTypeUsesControllerTime)
 {
+  // An unsupported interface data type falls back to the controller manager time.
   auto unsupported_sec = std::make_shared<hardware_interface::StateInterface>(
     "measurement_clock", "measurement_time_sec", "bool", "true");
   init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
@@ -362,6 +364,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUnsupportedTypeUsesCon
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesDoNotMaskMissingJointInterfaces)
 {
+  // Activation fails when only timestamp interfaces are present and no joint interfaces.
   init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
 
   std::vector<LoanedStateInterface> state_ifs;
@@ -376,6 +379,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesDoNotMaskMissingJointI
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesInvalidValuesAreSafe)
 {
+  // Invalid values are rejected without throwing, keeping the last valid stamp or zero.
   init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
   assign_state_interfaces_with_timestamp(measurement_sec_state_, measurement_nsec_state_);
   ASSERT_TRUE(configure_succeeds(state_broadcaster_));
@@ -424,6 +428,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesInvalidValuesAreSafe)
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUint32OverflowIsSafe)
 {
+  // A uint32 seconds value above INT32_MAX is rejected, keeping a zero stamp.
   hardware_interface::InterfaceInfo sec_info;
   sec_info.name = "measurement_time_sec";
   sec_info.data_type = "uint32";
@@ -477,6 +482,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesZeroUntilFirstValidMea
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesRetainLastValidStamp)
 {
+  // A transient read failure keeps the last valid stamp.
   init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
   assign_state_interfaces_with_timestamp(measurement_sec_state_, measurement_nsec_state_);
   ASSERT_TRUE(configure_succeeds(state_broadcaster_));

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -25,6 +25,7 @@
 
 #include "gmock/gmock.h"
 
+#include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
@@ -196,8 +197,7 @@ TEST_F(JointStateBroadcasterTest, ActivateEmptyTest)
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp)
 {
-  // With timestamp_state_interfaces set and the interfaces present, header.stamp is taken from
-  // them, not from the controller-manager `time` passed to update().
+  // With the interfaces present, header.stamp comes from them, not the time passed to update().
   init_broadcaster_and_set_parameters(
     kThreeJointURDF, {}, {},
     {rclcpp::Parameter("timestamp_state_interfaces.sec", "measurement_clock/measurement_time_sec"),
@@ -221,7 +221,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp)
   ASSERT_TRUE(configure_succeeds(state_broadcaster_));
   ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
-  // A distinct controller-manager time; the published stamp must NOT equal it.
+  // A distinct time value, the published stamp must not equal it.
   ASSERT_EQ(
     state_broadcaster_->update(rclcpp::Time(5, 0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
@@ -231,17 +231,65 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp)
     << "header.stamp should come from measurement_time_sec, not the CM time";
   EXPECT_EQ(stamp.nanosec, 567000000u);
 
-  // The measurement-time interfaces are the stamp source, not joint state data: they must not be
-  // treated as a joint (which would also emit "not mapped to any joint state field" warnings).
+  // The measurement time interfaces feed the stamp, so they must not appear as a joint.
   EXPECT_EQ(state_broadcaster_->name_if_value_mapping_.count("measurement_clock"), 0u)
     << "measurement-time interfaces should not appear as a joint in the state message";
 }
 
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesIntegerType)
+{
+  // The measurement time interfaces also work as int32 and uint32, not only double.
+  for (const std::string & data_type : {std::string("int32"), std::string("uint32")})
+  {
+    SCOPED_TRACE("data_type=" + data_type);
+    state_broadcaster_ = std::make_unique<FriendJointStateBroadcaster>();
+    init_broadcaster_and_set_parameters(
+      kThreeJointURDF, {}, {},
+      {rclcpp::Parameter(
+         "timestamp_state_interfaces.sec", "measurement_clock/measurement_time_sec"),
+       rclcpp::Parameter(
+         "timestamp_state_interfaces.nsec", "measurement_clock/measurement_time_nsec")});
+
+    auto make_state = [&data_type](const std::string & interface, const std::string & value)
+    {
+      hardware_interface::InterfaceInfo info;
+      info.name = interface;
+      info.data_type = data_type;
+      info.initial_value = value;
+      return std::make_shared<hardware_interface::StateInterface>(
+        hardware_interface::InterfaceDescription("measurement_clock", info));
+    };
+
+    // Keep these alive for the iteration: a LoanedStateInterface references the StateInterface,
+    // it does not own the shared_ptr.
+    auto sec_state = make_state("measurement_time_sec", "1234");
+    auto nsec_state = make_state("measurement_time_nsec", "567000000");
+
+    std::vector<LoanedStateInterface> state_ifs;
+    state_ifs.emplace_back(joint_1_pos_state_);
+    state_ifs.emplace_back(joint_1_vel_state_);
+    state_ifs.emplace_back(sec_state);
+    state_ifs.emplace_back(nsec_state);
+    state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
+
+    ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+    ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+
+    ASSERT_EQ(
+      state_broadcaster_->update(rclcpp::Time(5, 0), rclcpp::Duration::from_seconds(0.01)),
+      controller_interface::return_type::OK);
+
+    const auto & stamp = state_broadcaster_->joint_state_msg_.header.stamp;
+    EXPECT_EQ(stamp.sec, 1234) << "header.stamp should be sourced from the " << data_type
+                               << " interface";
+    EXPECT_EQ(stamp.nanosec, 567000000u);
+  }
+}
+
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesClaimedInUrdfFilterMode)
 {
-  // In URDF-filter mode (no joints/interfaces parameters, INDIVIDUAL_BEST_EFFORT) the
-  // configured measurement-time interfaces must still be requested, otherwise they are never
-  // claimed and header.stamp silently falls back to the controller-manager time.
+  // In URDF filter mode the configured measurement time interfaces must still be requested,
+  // otherwise they are never claimed and header.stamp falls back to the controller manager time.
   init_broadcaster_and_set_parameters(
     kThreeJointURDF, {}, {},
     {rclcpp::Parameter("timestamp_state_interfaces.sec", "measurement_clock/measurement_time_sec"),
@@ -259,7 +307,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesClaimedInUrdfFilterMod
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUnsetKeepsControllerManagerTime)
 {
-  // Default (param unset): header.stamp is the controller-manager `time`.
+  // Default (unset): header.stamp is the time passed to update().
   SetUpStateBroadcaster();
   ASSERT_TRUE(configure_succeeds(state_broadcaster_));
   ASSERT_TRUE(activate_succeeds(state_broadcaster_));

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -230,6 +230,11 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp)
   EXPECT_EQ(stamp.sec, 1234)
     << "header.stamp should come from measurement_time_sec, not the CM time";
   EXPECT_EQ(stamp.nanosec, 567000000u);
+
+  // The measurement-time interfaces are the stamp source, not joint state data: they must not be
+  // treated as a joint (which would also emit "not mapped to any joint state field" warnings).
+  EXPECT_EQ(state_broadcaster_->name_if_value_mapping_.count("measurement_clock"), 0u)
+    << "measurement-time interfaces should not appear as a joint in the state message";
 }
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesClaimedInUrdfFilterMode)

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -232,6 +232,26 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp)
   EXPECT_EQ(stamp.nanosec, 567000000u);
 }
 
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesClaimedInUrdfFilterMode)
+{
+  // In URDF-filter mode (no joints/interfaces parameters, INDIVIDUAL_BEST_EFFORT) the
+  // configured measurement-time interfaces must still be requested, otherwise they are never
+  // claimed and header.stamp silently falls back to the controller-manager time.
+  init_broadcaster_and_set_parameters(
+    kThreeJointURDF, {}, {},
+    {rclcpp::Parameter("timestamp_state_interfaces.sec", "measurement_clock/measurement_time_sec"),
+     rclcpp::Parameter(
+       "timestamp_state_interfaces.nsec", "measurement_clock/measurement_time_nsec")});
+
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+
+  const auto state_if_conf = state_broadcaster_->state_interface_configuration();
+  EXPECT_EQ(
+    state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL_BEST_EFFORT);
+  EXPECT_THAT(state_if_conf.names, ::testing::Contains("measurement_clock/measurement_time_sec"));
+  EXPECT_THAT(state_if_conf.names, ::testing::Contains("measurement_clock/measurement_time_nsec"));
+}
+
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUnsetKeepsControllerManagerTime)
 {
   // Default (param unset): header.stamp is the controller-manager `time`.

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <shared_mutex>
 #include <string>
@@ -44,6 +45,19 @@ using testing::Each;
 using testing::ElementsAreArray;
 using testing::IsEmpty;
 using testing::SizeIs;
+
+namespace
+{
+constexpr char kTimestampSecInterface[] = "measurement_clock/measurement_time_sec";
+constexpr char kTimestampNsecInterface[] = "measurement_clock/measurement_time_nsec";
+
+std::vector<rclcpp::Parameter> timestamp_parameters()
+{
+  return {
+    rclcpp::Parameter("timestamp_state_interfaces.sec", kTimestampSecInterface),
+    rclcpp::Parameter("timestamp_state_interfaces.nsec", kTimestampNsecInterface)};
+}
+}  // namespace
 
 void JointStateBroadcasterTest::SetUpTestCase() { rclcpp::init(0, nullptr); }
 
@@ -160,6 +174,18 @@ void JointStateBroadcasterTest::assign_state_interfaces(
   state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
 }
 
+void JointStateBroadcasterTest::assign_state_interfaces_with_timestamp(
+  const hardware_interface::StateInterface::SharedPtr & sec,
+  const hardware_interface::StateInterface::SharedPtr & nsec)
+{
+  std::vector<LoanedStateInterface> state_ifs;
+  state_ifs.emplace_back(joint_1_pos_state_);
+  state_ifs.emplace_back(joint_1_vel_state_);
+  state_ifs.emplace_back(sec);
+  state_ifs.emplace_back(nsec);
+  state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
+}
+
 TEST_F(JointStateBroadcasterTest, ActivateEmptyTest)
 {
   // publisher not initialized yet
@@ -198,11 +224,7 @@ TEST_F(JointStateBroadcasterTest, ActivateEmptyTest)
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp)
 {
   // With the interfaces present, header.stamp comes from them, not the time passed to update().
-  init_broadcaster_and_set_parameters(
-    kThreeJointURDF, {}, {},
-    {rclcpp::Parameter("timestamp_state_interfaces.sec", "measurement_clock/measurement_time_sec"),
-     rclcpp::Parameter(
-       "timestamp_state_interfaces.nsec", "measurement_clock/measurement_time_nsec")});
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
 
   std::vector<LoanedStateInterface> state_ifs;
   state_ifs.emplace_back(joint_1_pos_state_);
@@ -243,12 +265,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesIntegerType)
   {
     SCOPED_TRACE("data_type=" + data_type);
     state_broadcaster_ = std::make_unique<FriendJointStateBroadcaster>();
-    init_broadcaster_and_set_parameters(
-      kThreeJointURDF, {}, {},
-      {rclcpp::Parameter(
-         "timestamp_state_interfaces.sec", "measurement_clock/measurement_time_sec"),
-       rclcpp::Parameter(
-         "timestamp_state_interfaces.nsec", "measurement_clock/measurement_time_nsec")});
+    init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
 
     auto make_state = [&data_type](const std::string & interface, const std::string & value)
     {
@@ -290,11 +307,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesClaimedInUrdfFilterMod
 {
   // In URDF filter mode the configured measurement time interfaces must still be requested,
   // otherwise they are never claimed and header.stamp falls back to the controller manager time.
-  init_broadcaster_and_set_parameters(
-    kThreeJointURDF, {}, {},
-    {rclcpp::Parameter("timestamp_state_interfaces.sec", "measurement_clock/measurement_time_sec"),
-     rclcpp::Parameter(
-       "timestamp_state_interfaces.nsec", "measurement_clock/measurement_time_nsec")});
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
 
   ASSERT_TRUE(configure_succeeds(state_broadcaster_));
 
@@ -303,6 +316,180 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesClaimedInUrdfFilterMod
     state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL_BEST_EFFORT);
   EXPECT_THAT(state_if_conf.names, ::testing::Contains("measurement_clock/measurement_time_sec"));
   EXPECT_THAT(state_if_conf.names, ::testing::Contains("measurement_clock/measurement_time_nsec"));
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesPartialConfigurationRejected)
+{
+  for (const auto & parameter :
+       {rclcpp::Parameter("timestamp_state_interfaces.sec", kTimestampSecInterface),
+        rclcpp::Parameter("timestamp_state_interfaces.nsec", kTimestampNsecInterface)})
+  {
+    SCOPED_TRACE(parameter.get_name());
+    state_broadcaster_ = std::make_unique<FriendJointStateBroadcaster>();
+    init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, {parameter});
+    EXPECT_FALSE(configure_succeeds(state_broadcaster_));
+  }
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesClaimedInExplicitMode)
+{
+  // In explicit joints/interfaces mode the configured timestamp interfaces are requested strictly
+  // alongside the joint interfaces, so they are required when configured.
+  init_broadcaster_and_set_parameters(
+    kThreeJointURDF, {joint_names_[0]}, {HW_IF_POSITION}, timestamp_parameters());
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+
+  const auto state_if_conf = state_broadcaster_->state_interface_configuration();
+  EXPECT_EQ(state_if_conf.type, controller_interface::interface_configuration_type::INDIVIDUAL);
+  EXPECT_THAT(state_if_conf.names, ::testing::Contains(kTimestampSecInterface));
+  EXPECT_THAT(state_if_conf.names, ::testing::Contains(kTimestampNsecInterface));
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUnsupportedTypeUsesControllerTime)
+{
+  auto unsupported_sec = std::make_shared<hardware_interface::StateInterface>(
+    "measurement_clock", "measurement_time_sec", "bool", "true");
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
+  assign_state_interfaces_with_timestamp(unsupported_sec, measurement_nsec_state_);
+
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+  ASSERT_EQ(
+    state_broadcaster_->update(rclcpp::Time(9, 0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 9);
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesDoNotMaskMissingJointInterfaces)
+{
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
+
+  std::vector<LoanedStateInterface> state_ifs;
+  state_ifs.emplace_back(measurement_sec_state_);
+  state_ifs.emplace_back(measurement_nsec_state_);
+  state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
+
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  const auto state = state_broadcaster_->get_node()->activate();
+  EXPECT_EQ(state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesInvalidValuesAreSafe)
+{
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
+  assign_state_interfaces_with_timestamp(measurement_sec_state_, measurement_nsec_state_);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+
+  // Before the first valid measurement, an invalid value yields a zero stamp.
+  measurement_sec_value_ = std::numeric_limits<double>::max();
+  ASSERT_NO_THROW(
+    state_broadcaster_->update(rclcpp::Time(10, 0), rclcpp::Duration::from_seconds(0.01)));
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 0);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 0u);
+
+  // A zero seconds value counts as no measurement, so the stamp stays zero.
+  measurement_sec_value_ = 0.0;
+  measurement_nsec_value_ = 1.0;
+  ASSERT_NO_THROW(
+    state_broadcaster_->update(rclcpp::Time(11, 0), rclcpp::Duration::from_seconds(0.01)));
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 0);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 0u);
+
+  measurement_sec_value_ = 1234.0;
+  measurement_nsec_value_ = 567000000.0;
+  ASSERT_NO_THROW(
+    state_broadcaster_->update(rclcpp::Time(12, 0), rclcpp::Duration::from_seconds(0.01)));
+
+  const std::vector<std::pair<double, double>> invalid_values = {
+    {-1.0, 0.0},
+    {1234.5, 0.0},
+    {std::numeric_limits<double>::infinity(), 0.0},
+    {std::numeric_limits<double>::quiet_NaN(), 0.0},
+    {1234.0, -1.0},
+    {1234.0, 1.5},
+    {1234.0, 1000000000.0},
+  };
+  for (const auto & [sec, nsec] : invalid_values)
+  {
+    SCOPED_TRACE("sec=" + std::to_string(sec) + ", nsec=" + std::to_string(nsec));
+    measurement_sec_value_ = sec;
+    measurement_nsec_value_ = nsec;
+    ASSERT_NO_THROW(
+      state_broadcaster_->update(rclcpp::Time(13, 0), rclcpp::Duration::from_seconds(0.01)));
+    EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 1234);
+    EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 567000000u);
+  }
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUint32OverflowIsSafe)
+{
+  hardware_interface::InterfaceInfo sec_info;
+  sec_info.name = "measurement_time_sec";
+  sec_info.data_type = "uint32";
+  sec_info.initial_value = std::to_string(std::numeric_limits<uint32_t>::max());
+  auto sec_state = std::make_shared<hardware_interface::StateInterface>(
+    hardware_interface::InterfaceDescription("measurement_clock", sec_info));
+
+  hardware_interface::InterfaceInfo nsec_info;
+  nsec_info.name = "measurement_time_nsec";
+  nsec_info.data_type = "uint32";
+  nsec_info.initial_value = "1";
+  auto nsec_state = std::make_shared<hardware_interface::StateInterface>(
+    hardware_interface::InterfaceDescription("measurement_clock", nsec_info));
+
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
+  assign_state_interfaces_with_timestamp(sec_state, nsec_state);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+
+  ASSERT_NO_THROW(
+    state_broadcaster_->update(rclcpp::Time(14, 0), rclcpp::Duration::from_seconds(0.01)));
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 0);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 0u);
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesZeroUntilFirstValidMeasurement)
+{
+  // The stamp is zero until the first valid measurement, which is then used immediately even if it
+  // is earlier than the controller manager time.
+  measurement_sec_value_ = 0.0;
+  measurement_nsec_value_ = 0.0;
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
+  assign_state_interfaces_with_timestamp(measurement_sec_state_, measurement_nsec_state_);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+
+  ASSERT_EQ(
+    state_broadcaster_->update(rclcpp::Time(100, 0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 0);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 0u);
+
+  measurement_sec_value_ = 99.0;
+  measurement_nsec_value_ = 999999999.0;
+  ASSERT_EQ(
+    state_broadcaster_->update(rclcpp::Time(101, 0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 99);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 999999999u);
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesRetainLastValidStamp)
+{
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
+  assign_state_interfaces_with_timestamp(measurement_sec_state_, measurement_nsec_state_);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+  ASSERT_EQ(
+    state_broadcaster_->update(rclcpp::Time(15, 0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  std::unique_lock<std::shared_mutex> timestamp_lock(measurement_sec_state_->get_mutex());
+  ASSERT_NO_THROW(
+    state_broadcaster_->update(rclcpp::Time(16, 0), rclcpp::Duration::from_seconds(0.01)));
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 1234);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 567000000u);
 }
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUnsetKeepsControllerManagerTime)

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -194,6 +194,59 @@ TEST_F(JointStateBroadcasterTest, ActivateEmptyTest)
   ASSERT_THAT(joint_state_msg.effort, SizeIs(NUM_JOINTS));
 }
 
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp)
+{
+  // With timestamp_state_interfaces set and the interfaces present, header.stamp is taken from
+  // them, not from the controller-manager `time` passed to update().
+  init_broadcaster_and_set_parameters(
+    "", {}, {},
+    {rclcpp::Parameter("timestamp_state_interfaces.sec", "measurement_clock/measurement_time_sec"),
+     rclcpp::Parameter(
+       "timestamp_state_interfaces.nsec", "measurement_clock/measurement_time_nsec")});
+
+  std::vector<LoanedStateInterface> state_ifs;
+  state_ifs.emplace_back(joint_1_pos_state_);
+  state_ifs.emplace_back(joint_2_pos_state_);
+  state_ifs.emplace_back(joint_3_pos_state_);
+  state_ifs.emplace_back(joint_1_vel_state_);
+  state_ifs.emplace_back(joint_2_vel_state_);
+  state_ifs.emplace_back(joint_3_vel_state_);
+  state_ifs.emplace_back(joint_1_eff_state_);
+  state_ifs.emplace_back(joint_2_eff_state_);
+  state_ifs.emplace_back(joint_3_eff_state_);
+  state_ifs.emplace_back(measurement_sec_state_);
+  state_ifs.emplace_back(measurement_nsec_state_);
+  state_broadcaster_->assign_interfaces({}, std::move(state_ifs));
+
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+
+  // A distinct controller-manager time; the published stamp must NOT equal it.
+  ASSERT_EQ(
+    state_broadcaster_->update(rclcpp::Time(5, 0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  const auto & stamp = state_broadcaster_->joint_state_msg_.header.stamp;
+  EXPECT_EQ(stamp.sec, 1234) << "header.stamp should come from measurement_time_sec, not the CM time";
+  EXPECT_EQ(stamp.nanosec, 567000000u);
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUnsetKeepsControllerManagerTime)
+{
+  // Default (param unset): header.stamp is the controller-manager `time`.
+  SetUpStateBroadcaster();
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+
+  ASSERT_EQ(
+    state_broadcaster_->update(rclcpp::Time(7, 0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  const auto & stamp = state_broadcaster_->joint_state_msg_.header.stamp;
+  EXPECT_EQ(stamp.sec, 7);
+  EXPECT_EQ(stamp.nanosec, 0u);
+}
+
 TEST_F(JointStateBroadcasterTest, ReactivateTheControllerWithDifferentInterfacesTest)
 {
   // publisher not initialized yet

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.cpp
@@ -412,31 +412,36 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesDoNotMaskMissingJointI
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesInvalidValuesAreSafe)
 {
-  // Invalid values are rejected without throwing, keeping the last valid stamp or zero.
+  // Invalid values are rejected without throwing, and their cycles are not published.
   init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
   assign_state_interfaces_with_timestamp(measurement_sec_state_, measurement_nsec_state_);
   ASSERT_TRUE(configure_succeeds(state_broadcaster_));
   ASSERT_TRUE(activate_succeeds(state_broadcaster_));
 
-  // Before the first valid measurement, an invalid value yields a zero stamp.
-  measurement_sec_value_ = std::numeric_limits<double>::max();
-  ASSERT_NO_THROW(
-    state_broadcaster_->update(rclcpp::Time(10, 0), rclcpp::Duration::from_seconds(0.01)));
-  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 0);
-  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 0u);
-
-  // A zero seconds value counts as no measurement, so the stamp stays zero.
-  measurement_sec_value_ = 0.0;
-  measurement_nsec_value_ = 1.0;
-  ASSERT_NO_THROW(
-    state_broadcaster_->update(rclcpp::Time(11, 0), rclcpp::Duration::from_seconds(0.01)));
-  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 0);
-  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 0u);
+  // Before the first valid measurement nothing is published, so the message stays untouched.
+  // The all-zero sentinel, an out-of-range value, and a stray negative all yield no measurement.
+  for (const double sec : {0.0, std::numeric_limits<double>::max(), -1.0})
+  {
+    SCOPED_TRACE("sec=" + std::to_string(sec));
+    measurement_sec_value_ = sec;
+    measurement_nsec_value_ = 0.0;
+    ASSERT_NO_THROW(
+      state_broadcaster_->update(rclcpp::Time(10, 0), rclcpp::Duration::from_seconds(0.01)));
+    EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 0);
+    EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 0u);
+  }
 
   measurement_sec_value_ = 1234.0;
   measurement_nsec_value_ = 567000000.0;
   ASSERT_NO_THROW(
     state_broadcaster_->update(rclcpp::Time(12, 0), rclcpp::Duration::from_seconds(0.01)));
+  const auto published_positions = state_broadcaster_->joint_state_msg_.position;
+
+  // Fresh joint data from here on, so an unchanged message proves each cycle was skipped.
+  for (auto & value : joint_values_)
+  {
+    value += 0.5;
+  }
 
   const std::vector<std::pair<double, double>> invalid_values = {
     {-1.0, 0.0},
@@ -454,6 +459,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesInvalidValuesAreSafe)
     measurement_nsec_value_ = nsec;
     ASSERT_NO_THROW(
       state_broadcaster_->update(rclcpp::Time(13, 0), rclcpp::Duration::from_seconds(0.01)));
+    EXPECT_EQ(state_broadcaster_->joint_state_msg_.position, published_positions);
     EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 1234);
     EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 567000000u);
   }
@@ -461,7 +467,7 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesInvalidValuesAreSafe)
 
 TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUint32OverflowIsSafe)
 {
-  // A uint32 seconds value above INT32_MAX is rejected, keeping a zero stamp.
+  // A uint32 seconds value above INT32_MAX is rejected, so nothing is published.
   hardware_interface::InterfaceInfo sec_info;
   sec_info.name = "measurement_time_sec";
   sec_info.data_type = "uint32";
@@ -487,10 +493,67 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesUint32OverflowIsSafe)
   EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 0u);
 }
 
-TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesZeroUntilFirstValidMeasurement)
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesZeroSecondsWithNanosecondsIsValid)
 {
-  // The stamp is zero until the first valid measurement, which is then used immediately even if it
-  // is earlier than the controller manager time.
+  // Only the all-zero stamp means "no measurement time", so small times near a simulated clock's
+  // origin are published as the real times they are.
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
+  assign_state_interfaces_with_timestamp(measurement_sec_state_, measurement_nsec_state_);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+
+  const std::vector<std::pair<double, double>> valid_values = {
+    {0.0, 1.0},
+    {0.0, 10000.0},
+    {0.0, 999999999.0},
+  };
+  for (const auto & [sec, nsec] : valid_values)
+  {
+    SCOPED_TRACE("sec=" + std::to_string(sec) + ", nsec=" + std::to_string(nsec));
+    measurement_sec_value_ = sec;
+    measurement_nsec_value_ = nsec;
+    ASSERT_EQ(
+      state_broadcaster_->update(rclcpp::Time(20, 0), rclcpp::Duration::from_seconds(0.01)),
+      controller_interface::return_type::OK);
+    EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 0);
+    EXPECT_EQ(
+      state_broadcaster_->joint_state_msg_.header.stamp.nanosec, static_cast<uint32_t>(nsec));
+  }
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesAbsentValueDoesNotPublish)
+{
+  // Hardware writes the all-zero sentinel to say it has no measurement time, so nothing is
+  // published, including before it has written the interfaces for the first time.
+  hardware_interface::InterfaceInfo sec_info;
+  sec_info.name = "measurement_time_sec";
+  sec_info.data_type = "int32";
+  sec_info.initial_value = "0";
+  auto sec_state = std::make_shared<hardware_interface::StateInterface>(
+    hardware_interface::InterfaceDescription("measurement_clock", sec_info));
+
+  hardware_interface::InterfaceInfo nsec_info;
+  nsec_info.name = "measurement_time_nsec";
+  nsec_info.data_type = "uint32";
+  nsec_info.initial_value = "0";
+  auto nsec_state = std::make_shared<hardware_interface::StateInterface>(
+    hardware_interface::InterfaceDescription("measurement_clock", nsec_info));
+
+  init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
+  assign_state_interfaces_with_timestamp(sec_state, nsec_state);
+  ASSERT_TRUE(configure_succeeds(state_broadcaster_));
+  ASSERT_TRUE(activate_succeeds(state_broadcaster_));
+
+  ASSERT_NO_THROW(
+    state_broadcaster_->update(rclcpp::Time(17, 0), rclcpp::Duration::from_seconds(0.01)));
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 0);
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 0u);
+}
+
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesNoPublishUntilFirstValidMeasurement)
+{
+  // Nothing is published until the first valid measurement, which is then used immediately even if
+  // it is earlier than the controller manager time.
   measurement_sec_value_ = 0.0;
   measurement_nsec_value_ = 0.0;
   init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
@@ -513,9 +576,10 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesZeroUntilFirstValidMea
   EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 999999999u);
 }
 
-TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesRetainLastValidStamp)
+TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesReadFailureSkipsCycle)
 {
-  // A transient read failure keeps the last valid stamp.
+  // A read failure leaves this cycle without a measurement time, so it is skipped rather than
+  // published with the previous stamp, which would no longer describe the data.
   init_broadcaster_and_set_parameters(kThreeJointURDF, {}, {}, timestamp_parameters());
   assign_state_interfaces_with_timestamp(measurement_sec_state_, measurement_nsec_state_);
   ASSERT_TRUE(configure_succeeds(state_broadcaster_));
@@ -523,10 +587,19 @@ TEST_F(JointStateBroadcasterTest, TimestampStateInterfacesRetainLastValidStamp)
   ASSERT_EQ(
     state_broadcaster_->update(rclcpp::Time(15, 0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
+  ASSERT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 1234);
+  const auto published_positions = state_broadcaster_->joint_state_msg_.position;
 
+  // Fresh joint data, but the seconds interface cannot be read. An unchanged message then proves
+  // nothing was published, since the publish path is the only writer of joint_state_msg_.
+  for (auto & value : joint_values_)
+  {
+    value += 0.5;
+  }
   std::unique_lock<std::shared_mutex> timestamp_lock(measurement_sec_state_->get_mutex());
   ASSERT_NO_THROW(
     state_broadcaster_->update(rclcpp::Time(16, 0), rclcpp::Duration::from_seconds(0.01)));
+  EXPECT_EQ(state_broadcaster_->joint_state_msg_.position, published_positions);
   EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.sec, 1234);
   EXPECT_EQ(state_broadcaster_->joint_state_msg_.header.stamp.nanosec, 567000000u);
 }

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -60,6 +60,8 @@ class FriendJointStateBroadcaster : public joint_state_broadcaster::JointStateBr
   FRIEND_TEST(JointStateBroadcasterTest, NoThrowWithBooleanInterfaceTest);
   FRIEND_TEST(JointStateBroadcasterTest, NoThrowWithBooleanAndDoubleInterfaceTest);
   FRIEND_TEST(JointStateBroadcasterTest, CorrectMappingWhenInterfaceReadFailsTest);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesUnsetKeepsControllerManagerTime);
 };
 
 // Minimal 3-joint URDF covering the joint_names_ used in tests
@@ -167,6 +169,16 @@ protected:
   hardware_interface::StateInterface::SharedPtr joint_1_moving_state_ =
     std::make_shared<hardware_interface::StateInterface>(
       joint_names_[0], "is_moving", "bool", "false");
+
+  // Measurement-time interfaces for the timestamp_state_interfaces feature.
+  double measurement_sec_value_ = 1234.0;
+  double measurement_nsec_value_ = 567000000.0;
+  hardware_interface::StateInterface::SharedPtr measurement_sec_state_ =
+    std::make_shared<hardware_interface::StateInterface>(
+      "measurement_clock", "measurement_time_sec", &measurement_sec_value_);
+  hardware_interface::StateInterface::SharedPtr measurement_nsec_state_ =
+    std::make_shared<hardware_interface::StateInterface>(
+      "measurement_clock", "measurement_time_nsec", &measurement_nsec_value_);
 
   std::vector<hardware_interface::StateInterface::SharedPtr> test_interfaces_;
 

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -66,8 +66,12 @@ class FriendJointStateBroadcaster : public joint_state_broadcaster::JointStateBr
   FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesUnsupportedTypeUsesControllerTime);
   FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesInvalidValuesAreSafe);
   FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesUint32OverflowIsSafe);
-  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesRetainLastValidStamp);
-  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesZeroUntilFirstValidMeasurement);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesReadFailureSkipsCycle);
+  FRIEND_TEST(
+    JointStateBroadcasterTest, TimestampStateInterfacesNoPublishUntilFirstValidMeasurement);
+  FRIEND_TEST(
+    JointStateBroadcasterTest, TimestampStateInterfacesZeroSecondsWithNanosecondsIsValid);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesAbsentValueDoesNotPublish);
 };
 
 // Minimal 3-joint URDF covering the joint_names_ used in tests

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -63,6 +63,11 @@ class FriendJointStateBroadcaster : public joint_state_broadcaster::JointStateBr
   FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp);
   FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesUnsetKeepsControllerManagerTime);
   FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesIntegerType);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesUnsupportedTypeUsesControllerTime);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesInvalidValuesAreSafe);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesUint32OverflowIsSafe);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesRetainLastValidStamp);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesZeroUntilFirstValidMeasurement);
 };
 
 // Minimal 3-joint URDF covering the joint_names_ used in tests
@@ -121,6 +126,10 @@ public:
   void assign_state_interfaces(
     const std::vector<std::string> & joint_names = {},
     const std::vector<std::string> & interfaces = {});
+
+  void assign_state_interfaces_with_timestamp(
+    const hardware_interface::StateInterface::SharedPtr & sec,
+    const hardware_interface::StateInterface::SharedPtr & nsec);
 
   void test_published_joint_state_message(const std::string & topic);
 

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -62,6 +62,7 @@ class FriendJointStateBroadcaster : public joint_state_broadcaster::JointStateBr
   FRIEND_TEST(JointStateBroadcasterTest, CorrectMappingWhenInterfaceReadFailsTest);
   FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesSourceHeaderStamp);
   FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesUnsetKeepsControllerManagerTime);
+  FRIEND_TEST(JointStateBroadcasterTest, TimestampStateInterfacesIntegerType);
 };
 
 // Minimal 3-joint URDF covering the joint_names_ used in tests
@@ -170,7 +171,7 @@ protected:
     std::make_shared<hardware_interface::StateInterface>(
       joint_names_[0], "is_moving", "bool", "false");
 
-  // Measurement-time interfaces for the timestamp_state_interfaces feature.
+  // Measurement time interfaces for the timestamp_state_interfaces feature.
   double measurement_sec_value_ = 1234.0;
   double measurement_nsec_value_ = 567000000.0;
   hardware_interface::StateInterface::SharedPtr measurement_sec_state_ =


### PR DESCRIPTION
## Description

The current state of the joint_state_broadcaster uses `now()` to stamp the joint states. Some hardware however provides encoder measurement timestamps which the user may want to use instead, to get the true measurement time. This PR adds an option to reach such measurement time from the state interfaces *optionally*: if the hardware interface doesn't declare and write it, it falls back to the current behavior, so this wouldn't break any existing use of the joint state broadcaster. 

> [!NOTE]
> Adding the measurement state interface to the hardware is a statement of the user that they want measurement time _and nothing else_. The fallback to controller time is at configuration time, by not adding the state interfaces. Once it's declared, it's expected - if no timestamp is set (reads an all-zero value), then no joint state is published. This is to avoid pitfalls of expecting measurement time and not noticing that the fallback became active.


### Is this user-facing behavior change?

It's an optional feature, while it's user facing (the user being the one writing the hardware interfaces), it's fully backwards compatible.

### Did you use Generative AI?

Claude Opus 4.8 was used to execute an implementation plan that was done by the human (myself) and then questioned **a lot** and iterated on. Finally it was edited, verified and tested by the human (also myself).

### Test plan

#### 1. Unit tests

New cases cover the feature (should pass in CI). Please see inline comments.

#### 2. Interactive test with mock hardware [optional]

If the unit tests are considered insufficient, here is a suggestion on how this can be tested interactively with `mock_components/GenericSystem` to expose the two measurement-time state interfaces with fixed values.

`jsb_timestamp_test.urdf`

```xml
<?xml version="1.0"?>                                                                               
<robot name="TimestampTestRobot">                                                                   
  <link name="base_link"/>                                                                          
  <joint name="joint1" type="revolute">                                                             
    <parent link="base_link"/><child link="link1"/>                                                 
    <axis xyz="0 0 1"/>                                                                             
    <limit effort="1" velocity="1" lower="-3.14" upper="3.14"/>                                     
  </joint>                                                                                          
  <link name="link1"/>                                                                              
                                                                                                    
  <ros2_control name="TimestampTestSystem" type="system">                                           
    <hardware>                                                                                      
      <plugin>mock_components/GenericSystem</plugin>                                                
    </hardware>                                                                                     
    <joint name="joint1">                                                                           
      <command_interface name="position"/>                                                          
      <state_interface name="position"><param name="initial_value">0.5</param></state_interface>    
      <state_interface name="velocity"/>                                                            
    </joint>                                                                                        
    <!-- Two constant state interfaces standing in for a hardware measurement clock -->             
    <sensor name="measurement_clock">                                                               
      <state_interface name="measurement_time_sec" data_type="uint32"><param name="initial_value">1234</param></state_interface>
      <state_interface name="measurement_time_nsec" data_type="uint32"><param name="initial_value">567000000</param></state_interface>
    </sensor>                                                                                       
  </ros2_control>                                                                                   
</robot>        
```

`jsb_timestamp_test.yaml`

```yaml
controller_manager:
  ros__parameters:
    update_rate: 100
    joint_state_broadcaster:
      type: joint_state_broadcaster/JointStateBroadcaster

joint_state_broadcaster:
  ros__parameters:
    timestamp_state_interfaces:
      sec: measurement_clock/measurement_time_sec
      nsec: measurement_clock/measurement_time_nsec
```

Run it (three terminals with the workspace sourced):

1) publish the URDF for robot_description
```bash
ros2 run robot_state_publisher robot_state_publisher \
    --ros-args -p robot_description:="$(cat src/ros2_controllers/joint_state_broadcaster/jsb_timestamp_test.urdf)"
```

2) start the controller manager with the mock hardware

```bash
ros2 run controller_manager ros2_control_node \
    --ros-args --params-file src/ros2_controllers/joint_state_broadcaster/jsb_timestamp_test.yaml
```

3) load + activate the broadcaster, then inspect the stamp
```bash
ros2 run controller_manager spawner joint_state_broadcaster \
    --param-file src/ros2_controllers/joint_state_broadcaster/jsb_timestamp_test.yaml
```
```bash
ros2 topic echo /joint_states --once
```

Expected: the message header shows the hardware-provided stamp:
```yaml
  header:
    stamp:
      sec: 1234
      nanosec: 567000000
```

Negative check (default behaviour preserved):
Remove the entire top-level `joint_state_broadcaster:` block, leaving only the `controller_manager:` section from the yaml:
```yaml
  controller_manager:
    ros__parameters:
      update_rate: 100
      joint_state_broadcaster:
        type: joint_state_broadcaster/JointStateBroadcaster
```
`header.stamp` now shows the controller-manager clock (a current time)

Absent check (no measurement time means nothing is published):
An all-zero stamp on the interfaces means the hardware has no measurement time.
In that case the joint state is not published at all, since no stamp would describe its data correctly: 
there is no fallback to the controller time and no reuse of an older measurement time.
It would not be a correct state and could slip through unnoticed or create bugs hard to find.
An absent joint state instead will be clearly noticed.

Keep the yaml as-is and set both `initial_value` entries in the URDF's
sensor block to zero (or skp the entire `initial-value` param):

```xml
    <sensor name="measurement_clock">
      <state_interface name="measurement_time_sec" data_type="uint32"><param name="initial_value">0</param></state_interface>
      <state_interface name="measurement_time_nsec" data_type="uint32"><param name="initial_value">0</param></state_interface>
    </sensor>
```

`ros2 topic echo /joint_states --once` now produces no output (interrupt it),
and the controller manager repeats about once a second:

```
State interfaces 'measurement_clock/measurement_time_sec' and 'measurement_clock/measurement_time_nsec' carry no valid measurement time. Not publishing joint states until they do.
```