### PR TITLE
feat: warn when ForwardCommandController receives commands while inactive

### DIFF
--- a/forward_command_controller/src/forward_controllers_base.cpp
+++ b/forward_command_controller/src/forward_controllers_base.cpp
@@ -22,6 +22,7 @@
 
 #include "controller_interface/helpers.hpp"
 #include "hardware_interface/loaned_command_interface.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/qos.hpp"
 
@@ -74,6 +75,14 @@ controller_interface::CallbackReturn ForwardControllersBase::on_configure(
     "~/commands", rclcpp::SystemDefaultsQoS(),
     [this](const CmdType::SharedPtr msg)
     {
+      if (get_node()->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+      {
+        RCLCPP_WARN_THROTTLE(
+          get_node()->get_logger(), *(get_node()->get_clock()), 1000,
+          "Can't accept new commands. Controller is not active.");
+        return;
+      }
+
       const auto cmd = *msg;
 
       if (!std::all_of(


### PR DESCRIPTION

<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description


This PR fixes #1760 where `ForwardCommandController` silently ignores commands when it is in an inactive lifecycle state. 
**Changes made:**
- Added a lifecycle state guard (`get_node()->get_current_state()`) to the subscription callback in `ForwardControllersBase`.
- It now logs a throttled warning (`RCLCPP_WARN_THROTTLE`) and drops the message if the controller is not in `PRIMARY_STATE_ACTIVE`.
- Since it's implemented in the base class, it fixes this behavior for both `ForwardCommandController` and `MultiInterfaceForwardCommandController`.

Fixes #1760 

### Is this user-facing behavior change?

Yes, controllers will now log a warning when commands are received while inactive, instead of silently ignoring them.

### Did you use Generative AI?

Yes, Claude Sonnet 4.6

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
