### PR TITLE
Fix wrench transformer namespace test flake

### DIFF
--- a/force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp
+++ b/force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp
@@ -143,6 +143,21 @@ protected:
     }
   }
 
+  bool wait_for_publisher_topic(
+    rclcpp::Node::SharedPtr node, const std::string & topic_name, int max_attempts = 20)
+  {
+    for (int attempts = 0; attempts < max_attempts; ++attempts)
+    {
+      if (check_publisher_exists_via_graph(node, topic_name))
+      {
+        return true;
+      }
+      executor_->spin_some(std::chrono::milliseconds(100));
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    return false;
+  }
+
   void wait_for_publisher(
     rclcpp::Subscription<geometry_msgs::msg::WrenchStamped>::SharedPtr subscriber,
     int max_attempts = 20)
@@ -606,39 +621,20 @@ TEST_F(TestWrenchTransformer, NamespaceNormalizationRootNamespace)
 {
   // Test with root namespace ("/") - should use node name
   auto node = create_transformer_node({"base_link"}, 0.1, "test_broadcaster/wrench", "/");
-  executor_->spin_some(std::chrono::milliseconds(100));
 
-  // Get the publisher and check its topic name directly
-  auto topic_names_and_types = node->get_topic_names_and_types();
-  bool found = false;
-  for (const auto & [topic_name, topic_types] : topic_names_and_types)
-  {
-    if (topic_name == "/fts_wrench_transformer/base_link/wrench")
-    {
-      found = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(found) << "Publisher topic should be /fts_wrench_transformer/base_link/wrench";
+  // Poll the graph until discovery reflects the publisher; a single snapshot is racy
+  EXPECT_TRUE(wait_for_publisher_topic(node, "/fts_wrench_transformer/base_link/wrench"))
+    << "Publisher topic should be /fts_wrench_transformer/base_link/wrench";
 }
 
 TEST_F(TestWrenchTransformer, NamespaceNormalizationCustomNamespace)
 {
   // Test with custom namespace - should use the namespace
   auto node = create_transformer_node({"base_link"}, 0.1, "test_broadcaster/wrench", "/my_robot");
-  executor_->spin_some(std::chrono::milliseconds(100));
 
-  auto topic_names_and_types = node->get_topic_names_and_types();
-  bool found = false;
-  for (const auto & [topic_name, topic_types] : topic_names_and_types)
-  {
-    if (topic_name == "/my_robot/base_link/wrench")
-    {
-      found = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(found) << "Publisher topic should be /my_robot/base_link/wrench";
+  // Poll the graph until discovery reflects the publisher; a single snapshot is racy
+  EXPECT_TRUE(wait_for_publisher_topic(node, "/my_robot/base_link/wrench"))
+    << "Publisher topic should be /my_robot/base_link/wrench";
 }
 
 TEST_F(TestWrenchTransformer, RunWrenchTransformerFunction)


### PR DESCRIPTION
## Summary

Fix the flaky wrench transformer namespace tests by replacing timing-sensitive, one-shot ROS graph checks with bounded polling.

## Changes

* Add a test helper that waits for a publisher on an exact topic using the ROS graph API.
* Update the root-namespace and custom-namespace tests to use bounded polling.
* Preserve the existing topic-name assertions.
* Keep the change limited to test code; no production behavior is modified.

## Testing

* `colcon build --symlink-install --packages-up-to force_torque_sensor_broadcaster --cmake-args -DBUILD_TESTING=ON`
* `colcon test --packages-select force_torque_sensor_broadcaster --event-handlers console_cohesion+`
* `colcon test-result --verbose`
* Repeated both namespace tests 100 times:

  * `TestWrenchTransformer.NamespaceNormalizationRootNamespace`
  * `TestWrenchTransformer.NamespaceNormalizationCustomNamespace`
* `pre-commit run --files force_torque_sensor_broadcaster/test/test_wrench_transformer.cpp`
* `git diff --check`

Results:

* 35 package tests
* 0 errors
* 0 failures
* 0 skipped
* 100 repeated namespace-test iterations passed
* All applicable pre-commit checks passed

Closes #2487

## AI assistance

Claude Code assisted with analyzing and preparing the narrowly scoped test change. I manually reviewed the complete diff and verified the build, package tests, repeated stress tests, formatting, lint, and whitespace-check results.
