### PR TITLE
Allow disabling diff drive command timeout

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -118,12 +118,19 @@ controller_interface::return_type DiffDriveController::update_reference_from_sub
     command_msg_ = current_ref_op.value();
   }
 
+  constexpr rcutils_duration_value_t warning_throttle_ms = 1000;
+
   const auto age_of_last_command = time - command_msg_.header.stamp;
-  // Brake if cmd_vel has timeout, override the stored command
-  if (age_of_last_command > cmd_vel_timeout_)
+  const bool cmd_vel_timeout_disabled = cmd_vel_timeout_ == rclcpp::Duration::from_seconds(0.0);
+  // Brake if cmd_vel has timeout, override the stored command.
+  // A cmd_vel_timeout of 0.0 disables the timeout.
+  if (!cmd_vel_timeout_disabled && age_of_last_command > cmd_vel_timeout_)
   {
     ordered_exported_reference_interfaces_[0]->set_value(0.0);
     ordered_exported_reference_interfaces_[1]->set_value(0.0);
+    RCLCPP_WARN_THROTTLE(
+      logger, *get_node()->get_clock(), warning_throttle_ms,
+      "Velocity command timed out. Braking.");
   }
   else if (
     std::isfinite(command_msg_.twist.linear.x) && std::isfinite(command_msg_.twist.angular.z))
@@ -134,8 +141,7 @@ controller_interface::return_type DiffDriveController::update_reference_from_sub
   else
   {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
-      logger, *get_node()->get_clock(),
-      static_cast<rcutils_duration_value_t>(cmd_vel_timeout_.seconds() * 1000),
+      logger, *get_node()->get_clock(), warning_throttle_ms,
       "Command message contains NaNs. Not updating reference interfaces.");
   }
 

--- a/diff_drive_controller/src/diff_drive_controller_parameter.yaml
+++ b/diff_drive_controller/src/diff_drive_controller_parameter.yaml
@@ -109,7 +109,7 @@ diff_drive_controller:
   cmd_vel_timeout: {
     type: double,
     default_value: 0.5, # seconds
-    description: "Timeout in seconds, after which input command on ``cmd_vel`` topic is considered staled.",
+    description: "Timeout in seconds after which a command received on the ``cmd_vel`` topic is considered stale. A value of 0.0 disables the timeout.",
   }
   publish_limited_velocity: {
     type: bool,

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -1303,6 +1303,61 @@ TEST_F(TestDiffDriveController, command_with_zero_timestamp_is_accepted_with_war
   executor.cancel();
 }
 
+// Regression test for https://github.com/ros-controls/ros2_controllers/issues/440
+// A cmd_vel_timeout of 0.0 disables the timeout: an arbitrarily old command must be
+// preserved instead of being overridden with zero.
+TEST_F(TestDiffDriveController, zero_cmd_vel_timeout_disables_timeout)
+{
+  ASSERT_EQ(
+    InitController(
+      left_wheel_names, right_wheel_names,
+      {rclcpp::Parameter("wheel_separation", 0.4), rclcpp::Parameter("wheel_radius", 1.0),
+       rclcpp::Parameter("cmd_vel_timeout", rclcpp::ParameterValue(0.0))}),
+    controller_interface::return_type::OK);
+  // choose radius = 1 so that the command values (rev/s) are the same as the linear velocity (m/s)
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
+
+  ASSERT_TRUE(controller_->set_chained_mode(false));
+
+  ASSERT_TRUE(configure_succeeds(controller_));
+
+  assignResourcesPosFeedback();
+
+  ASSERT_TRUE(activate_succeeds(controller_));
+
+  waitForSetup(executor);
+
+  // before any command arrives the stored command is NaN: this update exercises the
+  // NaN-warning path with its finite throttle period while the timeout is disabled
+  ASSERT_EQ(
+    controller_->update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // publish a command with an explicit old nonzero timestamp, so its age at update time is
+  // deterministic and would be far expired for any positive cmd_vel_timeout
+  const double linear = 1.0;
+  const rclcpp::Time command_stamp(1, 0, RCL_ROS_TIME);
+  publish_timestamped(linear, 0.0, command_stamp);
+  // wait for msg is be published to the system
+  controller_->wait_for_twist(executor);
+
+  ASSERT_EQ(
+    controller_->update(
+      command_stamp + rclcpp::Duration::from_seconds(10.0), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+  EXPECT_EQ(linear, left_wheel_vel_cmd_->get_optional().value())
+    << "Wheels should not halt when cmd_vel_timeout is disabled";
+  EXPECT_EQ(linear, right_wheel_vel_cmd_->get_optional().value())
+    << "Wheels should not halt when cmd_vel_timeout is disabled";
+
+  // Deactivate and cleanup
+  ASSERT_TRUE(deactivate_succeeds(controller_));
+  ASSERT_TRUE(cleanup_succeeds(controller_));
+  executor.cancel();
+}
+
 TEST_F(TestDiffDriveController, odometry_set_service)
 {
   // 0. Initialize and activate the controller


### PR DESCRIPTION
## Summary

Allow the diff drive controller command timeout to be disabled by setting `cmd_vel_timeout` to `0.0`.

Previously, every command with a positive age was considered stale when the timeout was zero, causing the controller to replace valid velocity commands with zero.

## Changes

- Skip stale-command braking when `cmd_vel_timeout` is `0.0`.
- Preserve the existing timeout behavior for all positive timeout values.
- Keep the NaN warning throttle finite when the command timeout is disabled.
- Document that `0.0` disables the timeout.
- Add a deterministic regression test using an explicitly old command timestamp.
- Preserve the existing runtime parameter-update behavior.

## Testing

- `colcon build --symlink-install --packages-select diff_drive_controller --cmake-args -DBUILD_TESTING=ON`
- `colcon test --packages-select diff_drive_controller --event-handlers console_cohesion+`
- `colcon test-result --test-result-base build/diff_drive_controller --verbose`
- `pre-commit run --files diff_drive_controller/src/diff_drive_controller.cpp diff_drive_controller/src/diff_drive_controller_parameter.yaml diff_drive_controller/test/test_diff_drive_controller.cpp`
- `git diff --check`

Results:

- 42 tests
- 0 errors
- 0 failures
- 0 skipped
- All applicable pre-commit checks passed

Closes #440

## AI assistance

Claude Code assisted with analyzing the issue and preparing the narrowly scoped implementation and regression test. I manually reviewed the complete diff and verified the build, tests, formatting, lint, and whitespace-check results.
