### PR TITLE
Refactor JTC command assignment for Kilted

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -429,14 +429,9 @@ controller_interface::return_type JointTrajectoryController::update(
         }
         if (has_velocity_command_interface_)
         {
-          if (use_closed_loop_pid_adapter_)
-          {
-            assign_interface_from_point(joint_command_interface_[1], tmp_command_);
-          }
-          else
-          {
-            assign_interface_from_point(joint_command_interface_[1], command_next_.velocities);
-          }
+          assign_interface_from_point(
+            joint_command_interface_[1],
+            use_closed_loop_pid_adapter_ ? tmp_command_ : command_next_.velocities);
         }
         if (has_acceleration_command_interface_)
         {
@@ -444,15 +439,9 @@ controller_interface::return_type JointTrajectoryController::update(
         }
         if (has_effort_command_interface_)
         {
-          if (use_closed_loop_pid_adapter_)
-          {
-            assign_interface_from_point(joint_command_interface_[3], tmp_command_);
-          }
-          else
-          {
-            // If position and effort command interfaces, only pass desired effort
-            assign_interface_from_point(joint_command_interface_[3], state_desired_.effort);
-          }
+          assign_interface_from_point(
+            joint_command_interface_[3],
+            use_closed_loop_pid_adapter_ ? tmp_command_ : state_desired_.effort);
         }
 
         // store the previous command and time used in open-loop control mode


### PR DESCRIPTION
## Summary

Backport the JointTrajectoryController command-interface assignment refactor to the `kilted` branch while preserving the existing public API.

This is the Kilted-compatible counterpart of #2489. Unlike the `master` PR, this change retains the existing `tmp_command_` member name to avoid breaking downstream code that may access the protected member.

## Changes

- Simplify velocity command-source selection with a ternary expression.
- Simplify effort command-source selection with a ternary expression.
- Preserve the existing `tmp_command_` member name.
- Preserve all command-interface indexes and runtime behavior.
- Make no header or public API changes.

## Testing

Validated in a clean ROS 2 Kilted Docker environment:

- `colcon build --packages-select joint_trajectory_controller --cmake-args -DBUILD_TESTING=ON`
- `colcon test --packages-select joint_trajectory_controller --event-handlers console_cohesion+`
- `colcon test-result --test-result-base /ws/build/joint_trajectory_controller --verbose`
- `pre-commit run --files joint_trajectory_controller/src/joint_trajectory_controller.cpp`
- `git diff --check`

Results:

- 844 tests
- 0 errors
- 0 failures
- 0 skipped
- All applicable pre-commit checks passed

Related to #2489.

## AI assistance

Claude Code assisted with preparing the narrowly scoped backport. I manually reviewed the complete diff and verified the Kilted build, tests, formatting, lint, and whitespace-check results.
