### PR TITLE
fix: prevent JTC segfault when continuous joint has no URDF limits (#2480)

### DIFF
--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -100,7 +100,9 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
         }
         else if (urdf_joint)
         {
-          RCLCPP_WARN(
+          // Continuous joints may omit <limit>; velocity is only needed for
+          // decelerate_on_cancel (warned later if that feature cannot run).
+          RCLCPP_DEBUG(
             get_node()->get_logger(),
             "Joint '%s' has no <limit> in the URDF; velocity limit unavailable (using 0.0).",
             params_.joints[i].c_str());

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -93,9 +93,17 @@ controller_interface::CallbackReturn JointTrajectoryController::on_init()
       for (size_t i = 0; i < params_.joints.size(); ++i)
       {
         auto urdf_joint = model.getJoint(params_.joints[i]);
-        if (urdf_joint)
+        // Continuous joints are not required to declare <limit> in URDF; limits may be null.
+        if (urdf_joint && urdf_joint->limits)
         {
           max_joint_vel[i] = urdf_joint->limits->velocity;
+        }
+        else if (urdf_joint)
+        {
+          RCLCPP_WARN(
+            get_node()->get_logger(),
+            "Joint '%s' has no <limit> in the URDF; velocity limit unavailable (using 0.0).",
+            params_.joints[i].c_str());
         }
         if (urdf_joint && urdf_joint->type == urdf::Joint::CONTINUOUS)
         {

--- a/joint_trajectory_controller/test/test_assets.hpp
+++ b/joint_trajectory_controller/test/test_assets.hpp
@@ -271,6 +271,63 @@ const auto urdf_rrrbot_continuous =
 </robot>
 )";
 
+// Continuous joints without <limit> (valid URDF; used to guard null limits access).
+const auto urdf_rrrbot_continuous_no_limits =
+  R"(
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="RRRbotContinuousNoLimits">
+  <link name="world"/>
+  <joint name="base_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="base_link"/>
+  </joint>
+  <link name="base_link">
+    <inertial>
+      <mass value="0.01"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+    </inertial>
+  </link>
+  <joint name="joint1" type="continuous">
+    <origin rpy="-1.57079632679 0 0" xyz="0 0 0.2"/>
+    <parent link="base_link"/>
+    <child link="link1"/>
+  </joint>
+  <link name="link1">
+    <inertial>
+      <mass value="0.01"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+    </inertial>
+  </link>
+  <joint name="joint2" type="continuous">
+    <origin rpy="1.57079632679 0 0" xyz="0 0 0.9"/>
+    <parent link="link1"/>
+    <child link="link2"/>
+  </joint>
+  <link name="link2">
+    <inertial>
+      <mass value="0.01"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+    </inertial>
+  </link>
+  <joint name="joint3" type="continuous">
+    <origin rpy="1.57079632679 0 0" xyz="0 0 0.9"/>
+    <parent link="link2"/>
+    <child link="link3"/>
+  </joint>
+  <link name="link3">
+    <inertial>
+      <mass value="0.01"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+    </inertial>
+  </link>
+</robot>
+)";
+
 }  // namespace test_trajectory_controllers
 
 #endif  // TEST_ASSETS_HPP_

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -54,6 +54,16 @@ TEST_P(TrajectoryControllerTestParameterized, invalid_robot_description)
     SetUpTrajectoryControllerLocal({}, "<invalid_robot_description/>"));
 }
 
+// Continuous joints need not declare <limit>; on_init must not dereference null limits.
+TEST_P(TrajectoryControllerTestParameterized, continuous_joint_without_urdf_limits)
+{
+  ASSERT_EQ(
+    controller_interface::return_type::OK,
+    SetUpTrajectoryControllerLocal(
+      {}, test_trajectory_controllers::urdf_rrrbot_continuous_no_limits));
+  ASSERT_TRUE(configure_succeeds(traj_controller_));
+}
+
 TEST_P(TrajectoryControllerTestParameterized, check_interface_names)
 {
   rclcpp::executors::MultiThreadedExecutor executor;


### PR DESCRIPTION
﻿## Summary
- Guard null `urdf_joint->limits` in `JointTrajectoryController::on_init()` so continuous joints without a URDF `<limit>` tag no longer segfault.
- Leave velocity at the existing 0.0 default and warn; do not invent limits.
- Add continuous-no-limits URDF fixture + regression test.

Fixes #2480

## Test plan
- [ ] `colcon test --packages-select joint_trajectory_controller`
- [ ] Confirm `continuous_joint_without_urdf_limits` passes
