### PR TITLE
mecanum_drive_controller: fix short-circuit skipping wheels in comman…

### DIFF
--- a/mecanum_drive_controller/src/mecanum_drive_controller.cpp
+++ b/mecanum_drive_controller/src/mecanum_drive_controller.cpp
@@ -660,25 +660,39 @@ controller_interface::return_type MecanumDriveController::update_and_write_comma
 
     // Set wheels velocities - The joint names are sorted according to the order documented in the
     // header file!
+    // NOTE: each set_value() call is evaluated into its own local first, then combined --
+    // combining them directly with && short-circuits on the first failure and would skip
+    // commanding the remaining wheels entirely.
+    const bool front_left_set = command_interfaces_[FRONT_LEFT].set_value(wheel_front_left_vel);
+    const bool front_right_set = command_interfaces_[FRONT_RIGHT].set_value(wheel_front_right_vel);
+    const bool rear_right_set = command_interfaces_[REAR_RIGHT].set_value(wheel_rear_right_vel);
+    const bool rear_left_set = command_interfaces_[REAR_LEFT].set_value(wheel_rear_left_vel);
     const bool value_set_error =
-      command_interfaces_[FRONT_LEFT].set_value(wheel_front_left_vel) &&
-      command_interfaces_[FRONT_RIGHT].set_value(wheel_front_right_vel) &&
-      command_interfaces_[REAR_RIGHT].set_value(wheel_rear_right_vel) &&
-      command_interfaces_[REAR_LEFT].set_value(wheel_rear_left_vel);
+      !(front_left_set && front_right_set && rear_right_set && rear_left_set);
     RCLCPP_ERROR_EXPRESSION(
-      get_node()->get_logger(), !value_set_error,
+      get_node()->get_logger(), value_set_error,
       "Setting values to command interfaces has failed! "
       "This means that you are maybe blocking the interface in your hardware for too long.");
   }
   else
   {
-    const bool value_set_error =
-      command_interfaces_[FRONT_LEFT].set_value(0.0, std::numeric_limits<unsigned int>::max()) ||
-      command_interfaces_[FRONT_RIGHT].set_value(0.0, std::numeric_limits<unsigned int>::max()) ||
-      command_interfaces_[REAR_RIGHT].set_value(0.0, std::numeric_limits<unsigned int>::max()) ||
+    // Halt path: every wheel must be commanded to zero regardless of whether an earlier
+    // one failed. The previous implementation combined the four set_value() calls with ||,
+    // which both short-circuits (skipping the remaining wheels as soon as one succeeds) and
+    // only reports an error if ALL FOUR failed -- far too lenient for a safety-relevant halt,
+    // where a single wheel failing to stop should be surfaced.
+    const bool front_left_set =
+      command_interfaces_[FRONT_LEFT].set_value(0.0, std::numeric_limits<unsigned int>::max());
+    const bool front_right_set =
+      command_interfaces_[FRONT_RIGHT].set_value(0.0, std::numeric_limits<unsigned int>::max());
+    const bool rear_right_set =
+      command_interfaces_[REAR_RIGHT].set_value(0.0, std::numeric_limits<unsigned int>::max());
+    const bool rear_left_set =
       command_interfaces_[REAR_LEFT].set_value(0.0, std::numeric_limits<unsigned int>::max());
+    const bool value_set_error =
+      !(front_left_set && front_right_set && rear_right_set && rear_left_set);
     RCLCPP_ERROR_EXPRESSION(
-      get_node()->get_logger(), !value_set_error,
+      get_node()->get_logger(), value_set_error,
       "Setting values to command interfaces has failed! "
       "This means that you are maybe blocking the interface in your hardware for too long.");
   }


### PR DESCRIPTION
Closes #2325.

The normal-command and halt branches of `update_and_write_commands()` combined four `set_value()` calls directly with `&&` / `||` respectively. Both operators short-circuit in C++, so as soon as one call determined the result, the remaining `set_value()` calls were never even executed — meaning some wheels could silently go uncommanded, most critically during a halt (e.g. on deactivate or an internal error), where the `||` combination meant only the first wheel's zero-velocity command was guaranteed to be sent.

Each `set_value()` result is now captured into its own local before being combined, so all four command interfaces are always written to. The halt branch's error-reporting condition was also changed from "error only if all four failed" (`||`) to "error if any failed" (`&&`), matching the normal-command branch and matching what you'd want from a safety-relevant stop.

**Tested locally against ROS2 Jazzy (RoboStack/conda):**
- Full `mecanum_drive_controller` test suite: 28/29 pass.
- The one failure (`when_reference_timeout_is_zero_expect_reference_msg_being_used_only_once`) is a pre-existing clock-resolution flake — confirmed by running it repeatedly against both the patched and unpatched code, where it fails intermittently on both. Unrelated to this change.

Note: `steering_controllers_library` and `omni_wheel_drive_controller` have related-but-different bugs in their own halt-command error handling (early-return mid-loop, and a `|=` accumulator that can never detect failure, respectively) — flagging in case a maintainer wants a tracking issue, but left out of scope for this PR to keep it focused.