### PR TITLE
Throttle speed limiter parameter error logs

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -173,7 +173,9 @@ controller_interface::return_type DiffDriveController::update_and_write_commands
     }
     catch (const std::invalid_argument & e)
     {
-      RCLCPP_ERROR(logger, "Failed to update speed limiter parameters: %s", e.what());
+      RCLCPP_ERROR_THROTTLE(
+        logger, *get_node()->get_clock(), 1000,
+        "Failed to update speed limiter parameters: %s", e.what());
     }
   }
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -174,8 +174,8 @@ controller_interface::return_type DiffDriveController::update_and_write_commands
     catch (const std::invalid_argument & e)
     {
       RCLCPP_ERROR_THROTTLE(
-        logger, *get_node()->get_clock(), 1000,
-        "Failed to update speed limiter parameters: %s", e.what());
+        logger, *get_node()->get_clock(), 1000, "Failed to update speed limiter parameters: %s",
+        e.what());
     }
   }
 

--- a/mecanum_drive_controller/src/mecanum_drive_controller.cpp
+++ b/mecanum_drive_controller/src/mecanum_drive_controller.cpp
@@ -533,8 +533,9 @@ controller_interface::return_type MecanumDriveController::update_and_write_comma
     }
     catch (const std::invalid_argument & e)
     {
-      RCLCPP_ERROR(
-        get_node()->get_logger(), "Failed to update speed limiter parameters: %s", e.what());
+      RCLCPP_ERROR_THROTTLE(
+        get_node()->get_logger(), *get_node()->get_clock(), 1000,
+        "Failed to update speed limiter parameters: %s", e.what());
     }
   }
 


### PR DESCRIPTION
Fixes #2539

Invalid runtime limiter parameters could cause an ERROR log to be emitted every controller update cycle.

This throttles the affected runtime speed limiter parameter update errors to once per second.

Affected implementations:
- `diff_drive_controller`
- `mecanum_drive_controller`

Configure-time-only limiter validation errors, such as in `tricycle_controller`, were intentionally left unchanged because they do not run every control cycle.

Validation:
- `git diff --check upstream/master..HEAD`: passed
- `pre-commit run -a`: partially passed
  - clang-format and non-ROS hooks passed
  - `ament_cppcheck`, `ament_cpplint`, `ament_lint_cmake`, and `ament_copyright` could not run because the corresponding executables are not installed in this environment
- Build/tests not run locally because this machine does not have a usable ROS 2/colcon environment