### PR TITLE
rqt-jtc: reuse shared rqt node

### DIFF
--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_limits_urdf.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_limits_urdf.py
@@ -18,6 +18,7 @@
 # https://github.com/ros/robot_model/blob/indigo-devel/
 # joint_state_publisher/joint_state_publisher/joint_state_publisher
 
+import threading
 import xml.etree.ElementTree as ET
 from math import pi
 
@@ -26,6 +27,7 @@ from std_msgs.msg import String
 from urdf_parser_py.urdf import Robot
 
 description = ""
+_description_received = threading.Event()
 
 
 # Tags defined as direct children of <robot> in the URDF specification.
@@ -38,14 +40,16 @@ _URDF_STANDARD_TAGS = frozenset({"link", "joint", "transmission", "material"})
 def callback(msg):
     global description
     description = msg.data
+    _description_received.set()
 
 
 def subscribe_to_robot_description(node, key="robot_description"):
+    """Create and return the robot_description subscription; caller owns its lifetime."""
     qos_profile = rclpy.qos.QoSProfile(depth=1)
     qos_profile.durability = rclpy.qos.DurabilityPolicy.TRANSIENT_LOCAL
     qos_profile.reliability = rclpy.qos.ReliabilityPolicy.RELIABLE
 
-    node.create_subscription(String, key, callback, qos_profile)
+    return node.create_subscription(String, key, callback, qos_profile)
 
 
 def _strip_non_urdf_tags(urdf_string):
@@ -216,19 +220,25 @@ def parse_joint_limits(
     return free_joints
 
 
-def get_joint_limits(node, joints_names, use_smallest_joint_limits=True):
+def get_joint_limits(node, joints_names, use_smallest_joint_limits=True, timeout_sec=10.0):
     """
     ROS-aware wrapper around parse_joint_limits.
 
     Waits for the robot_description topic to publish, then delegates all
     real parsing work to parse_joint_limits(). This separation means
     parse_joint_limits() can be tested without any ROS infrastructure.
+
+    node's own spin/executor is never touched here: node may be context.node,
+    which rqt_gui_py already spins continuously on another thread, so the
+    robot_description subscription callback (set up by
+    subscribe_to_robot_description()) is relied on to deliver the message and
+    signal _description_received instead.
     """
-    count = 0
-    while description == "" and count < 10:
+    if description == "":
         print("Waiting for the robot_description!")
-        count += 1
-        rclpy.spin_once(node, timeout_sec=1.0)
+        _description_received.clear()
+        if description == "":
+            _description_received.wait(timeout=timeout_sec)
 
     if description == "":
         return {}

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -102,7 +102,10 @@ class JointTrajectoryController(Plugin):
     def __init__(self, context):
         super().__init__(context)
         self.setObjectName("JointTrajectoryController")
-        self._node = rclpy.node.Node("rqt_joint_trajectory_controller")
+        self._node = rclpy.node.Node(
+            "rqt_joint_trajectory_controller",
+            cli_args=["--ros-args", "-r", "__node:=rqt_joint_trajectory_controller"],
+        )
         self._executor = None
         self._executor_thread = None
 

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -166,7 +166,7 @@ class JointTrajectoryController(Plugin):
         self._update_act_pos_timer.timeout.connect(self._update_joint_widgets)
 
         # Timer for controller manager updates
-        self._list_cm = ControllerManagerLister()
+        self._list_cm = ControllerManagerLister(self._node)
         self._update_cm_list_timer = QTimer(self)
         self._update_cm_list_timer.setInterval(int(1000.0 / self._ctrlrs_update_freq))
         self._update_cm_list_timer.timeout.connect(self._update_cm_list)
@@ -200,6 +200,7 @@ class JointTrajectoryController(Plugin):
         self._unregister_state_sub()
         self._unregister_cmd_pub()
         self._unregister_robot_description_sub()
+        self._unregister_list_controllers()
         # self._node is context.node, owned and spun by rqt_gui_py. It must not
         # be destroyed here; the framework destroys it after all plugins have
         # shut down.
@@ -304,14 +305,18 @@ class JointTrajectoryController(Plugin):
 
     def _on_cm_change(self, cm_ns):
         self._cm_ns = cm_ns
+        self._unregister_list_controllers()
         if cm_ns:
-            self._list_controllers = ControllerLister(cm_ns)
+            self._list_controllers = ControllerLister(self._node, cm_ns)
             # NOTE: Clear below is important, as different controller managers
             # might have controllers with the same name but different
             # configurations. Clearing forces controller re-discovery
             self._widget.jtc_combo.clear()
             self._update_jtc_list()
-        else:
+
+    def _unregister_list_controllers(self):
+        if self._list_controllers is not None:
+            self._list_controllers.close()
             self._list_controllers = None
 
     def _on_jtc_change(self, jtc_name):

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -16,7 +16,6 @@
 
 import os
 import rclpy
-import threading
 from ament_index_python.packages import get_package_share_directory
 
 from qt_gui.plugin import Plugin
@@ -102,12 +101,7 @@ class JointTrajectoryController(Plugin):
     def __init__(self, context):
         super().__init__(context)
         self.setObjectName("JointTrajectoryController")
-        self._node = rclpy.node.Node(
-            "rqt_joint_trajectory_controller",
-            cli_args=["--ros-args", "-r", "__node:=rqt_joint_trajectory_controller"],
-        )
-        self._executor = None
-        self._executor_thread = None
+        self._node = context.node
 
         # Create QWidget and extend it with all the attributes and children
         # from the UI file
@@ -185,7 +179,7 @@ class JointTrajectoryController(Plugin):
         self._update_jtc_list_timer.start()
 
         # subscriptions
-        subscribe_to_robot_description(self._node)
+        self._robot_description_sub = subscribe_to_robot_description(self._node)
 
         # Signal connections
         w = self._widget
@@ -205,18 +199,11 @@ class JointTrajectoryController(Plugin):
         self._update_jtc_list_timer.stop()
         self._unregister_state_sub()
         self._unregister_cmd_pub()
-        self._unregister_executor()
-        self._destroy_node()
-
-    def _destroy_node(self):
-        if self._node is not None:
-            try:
-                self._node.destroy_node()
-            except Exception as e:
-                if not is_shutdown_context_error(e):
-                    raise
-            finally:
-                self._node = None
+        self._unregister_robot_description_sub()
+        # self._node is context.node, owned and spun by rqt_gui_py. It must not
+        # be destroyed here; the framework destroys it after all plugins have
+        # shut down.
+        self._node = None
 
     def save_settings(self, plugin_settings, instance_settings):
         instance_settings.set_value("cm_ns", self._cm_ns)
@@ -426,21 +413,6 @@ class JointTrajectoryController(Plugin):
 
         self.jointStateChanged.connect(self._on_joint_state_change)
 
-        self._executor = rclpy.executors.SingleThreadedExecutor()
-        self._executor.add_node(self._node)
-        self._executor_thread = threading.Thread(target=self._spin_executor, daemon=True)
-        self._executor_thread.start()
-
-    def _spin_executor(self):
-        try:
-            self._executor.spin()
-        except (KeyboardInterrupt, rclpy.executors.ExternalShutdownException):
-            pass
-        except Exception as e:
-            # During SIGINT shutdown, the ROS context can become invalid before spin exits.
-            if not is_shutdown_context_error(e):
-                print(f"Executor thread failed: {e}")
-
     def _unload_jtc(self):
         # Stop updating the joint positions
         try:
@@ -451,7 +423,6 @@ class JointTrajectoryController(Plugin):
         # Reset ROS interfaces
         self._unregister_state_sub()
         self._unregister_cmd_pub()
-        self._unregister_executor()
 
         # Clear joint widgets
         # NOTE: Implementation is a workaround for:
@@ -492,12 +463,10 @@ class JointTrajectoryController(Plugin):
             self._node.destroy_subscription(self._state_sub)
             self._state_sub = None
 
-    def _unregister_executor(self):
-        if self._executor is not None:
-            self._executor.shutdown()
-            self._executor_thread.join()
-            self._executor = None
-            self._executor_thread = None
+    def _unregister_robot_description_sub(self):
+        if self._robot_description_sub is not None:
+            self._node.destroy_subscription(self._robot_description_sub)
+            self._robot_description_sub = None
 
     def _state_cb(self, msg):
         current_pos = {}

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
@@ -262,34 +262,11 @@ class ControllerLister:
     def __call__(self):
         try:
             future = self._srv_client.call_async(ListControllers.Request())
-            # Wait via a plain threading.Event rather than spinning self._node:
-            # self._node may be context.node, which rqt_gui_py's RclpySpinner
-            # already spins continuously on another thread. Its executor already
-            # processes this future's response and completes it; we only need to
-            # be woken up when that happens. Poll self._node's own context between
-            # short waits so shutdown doesn't block here indefinitely, mirroring
-            # the exit condition spin_until_future_complete used to provide.
-            # self._node.context.ok() (not rclpy.ok(), which always checks the
-            # process-wide default context) is the correct check here: self._node
-            # may not be tied to the default context, and it is that node's
-            # context -- not the default one -- whose executor is what would ever
-            # complete this future.
-            #
-            # We deliberately do not use Client.call(): in Humble it blocks with
-            # no timeout at all and no way to observe context shutdown, and even
-            # in Jazzy/Rolling (where it gained a timeout_sec) a fixed wall-clock
-            # timeout can't express "keep waiting while healthy, stop promptly on
-            # shutdown" -- polling it in a loop would just resend a fresh request
-            # each iteration, since it calls call_async() internally every time.
+            # Wait without spinning the shared rqt node.
             done_event = threading.Event()
             future.add_done_callback(lambda _future: done_event.set())
             while self._node.context.ok() and not done_event.is_set():
                 done_event.wait(timeout=0.1)
-            # No-op if the future is already done. Otherwise (we gave up waiting
-            # because the context is shutting down) this marks it CANCELLED,
-            # which runs Client.remove_pending_request() via the future's own
-            # done-callback, so the request is not left registered in the
-            # client's pending-requests table after we stop waiting on it.
             future.cancel()
             result = future.result()
             return result.controller if result else []

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
@@ -79,7 +79,10 @@ def get_controller_managers(namespace="/", initial_guess=None):
         ns_list = initial_guess[:]  # force copy
 
     # Get list of (potential) currently running controller managers
-    node = rclpy.node.Node("get_controller_managers_node")
+    node = rclpy.node.Node(
+        "get_controller_managers_node",
+        cli_args=["--ros-args", "-r", "__node:=get_controller_managers_node"],
+    )
     try:
         ns_list_curr = _sloppy_get_controller_managers(node, namespace)
 
@@ -232,7 +235,10 @@ class ControllerLister:
 
         @type namespace str
         """
-        self._node = rclpy.node.Node("controller_lister")
+        self._node = rclpy.node.Node(
+            "controller_lister",
+            cli_args=["--ros-args", "-r", "__node:=controller_lister"],
+        )
         self._srv_name = namespace + "/" + _LIST_CONTROLLERS_STR
         self._srv_client = self._create_client()
 

--- a/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
+++ b/rqt_joint_trajectory_controller/rqt_joint_trajectory_controller/utils.py
@@ -19,6 +19,8 @@
 # No backwards compatibility guarantees are provided at this moment.
 
 
+import threading
+
 import rclpy
 from controller_manager_msgs.srv import ListControllers
 
@@ -56,10 +58,15 @@ def is_shutdown_context_error(exc):
     )
 
 
-def get_controller_managers(namespace="/", initial_guess=None):
+def get_controller_managers(node, namespace="/", initial_guess=None):
     """
     Get list of active controller manager namespaces.
 
+    @param node: Node used to query the ROS graph for controller_manager services.
+    Only synchronous graph introspection calls are made on it (get_service_names_and_types);
+    it is never spun, so it is safe to pass a node whose spinning is owned elsewhere
+    (e.g. rqt's shared context.node).
+    @type node: rclpy.node.Node
     @param namespace: Namespace where to look for controller managers.
     @type namespace: str
     @param initial_guess: Initial guess of the active controller managers.
@@ -79,24 +86,15 @@ def get_controller_managers(namespace="/", initial_guess=None):
         ns_list = initial_guess[:]  # force copy
 
     # Get list of (potential) currently running controller managers
-    node = rclpy.node.Node(
-        "get_controller_managers_node",
-        cli_args=["--ros-args", "-r", "__node:=get_controller_managers_node"],
-    )
-    try:
-        ns_list_curr = _sloppy_get_controller_managers(node, namespace)
+    ns_list_curr = _sloppy_get_controller_managers(node, namespace)
 
-        # Update initial guess:
-        # 1. Remove entries not found in current list
-        # 2. Add new untracked controller managers
-        ns_list[:] = [ns for ns in ns_list if ns in ns_list_curr]
-        ns_list += [
-            ns for ns in ns_list_curr if ns not in ns_list and is_controller_manager(node, ns)
-        ]
+    # Update initial guess:
+    # 1. Remove entries not found in current list
+    # 2. Add new untracked controller managers
+    ns_list[:] = [ns for ns in ns_list if ns in ns_list_curr]
+    ns_list += [ns for ns in ns_list_curr if ns not in ns_list and is_controller_manager(node, ns)]
 
-        return sorted(ns_list)
-    finally:
-        node.destroy_node()
+    return sorted(ns_list)
 
 
 def is_controller_manager(node, namespace):
@@ -191,11 +189,20 @@ class ControllerManagerLister:
     ROS master.
 
     Example usage:
-        >>> list_cm = ControllerManagerLister()
+        >>> list_cm = ControllerManagerLister(node)
         >>> print(list_cm())
     """
 
-    def __init__(self, namespace="/"):
+    def __init__(self, node, namespace="/"):
+        """
+        Store the injected node and namespace used to look up controller managers.
+
+        @param node Node used to query the ROS graph. Never spun by this class.
+        @type node rclpy.node.Node
+        @param namespace Namespace where to look for controller managers.
+        @type namespace str
+        """
+        self._node = node
         self._ns = namespace
         self._cm_list = []
 
@@ -205,7 +212,7 @@ class ControllerManagerLister:
             return self._cm_list
 
         try:
-            self._cm_list = get_controller_managers(self._ns, self._cm_list)
+            self._cm_list = get_controller_managers(self._node, self._ns, self._cm_list)
         except rclpy.executors.ExternalShutdownException:
             return self._cm_list
         except Exception as e:
@@ -223,22 +230,27 @@ class ControllerLister:
     controller filtering functions available in this module.
 
     Example usage. Get I{running} controllers of type C{bar_base/bar}:
-        >>> list_controllers = ControllerLister('foo_robot/controller_manager')
+        >>> list_controllers = ControllerLister(node, 'foo_robot/controller_manager')
         >>> all_ctrl = list_controllers()
         >>> running_ctrl = filter_by_state(all_ctrl, 'running')
         >>> running_bar_ctrl = filter_by_type(running_ctrl, 'bar_base/bar')
     """
 
-    def __init__(self, namespace="/controller_manager"):
+    def __init__(self, node, namespace="/controller_manager"):
         """
-        @param namespace Namespace of controller manager to monitor.
+        Store the injected node and namespace, and create the list_controllers client.
 
+        @param node Node used to call the controller manager's list_controllers
+        service. This class never spins node itself (see __call__): node may be
+        a shared node (e.g. rqt's context.node) that some other executor already
+        spins continuously elsewhere, and calling rclpy.spin_until_future_complete()
+        or spin_once() on it here would race against that executor.
+        @type node rclpy.node.Node
+
+        @param namespace Namespace of controller manager to monitor.
         @type namespace str
         """
-        self._node = rclpy.node.Node(
-            "controller_lister",
-            cli_args=["--ros-args", "-r", "__node:=controller_lister"],
-        )
+        self._node = node
         self._srv_name = namespace + "/" + _LIST_CONTROLLERS_STR
         self._srv_client = self._create_client()
 
@@ -249,9 +261,37 @@ class ControllerLister:
 
     def __call__(self):
         try:
-            controller_list = self._srv_client.call_async(ListControllers.Request())
-            rclpy.spin_until_future_complete(self._node, controller_list)
-            result = controller_list.result()
+            future = self._srv_client.call_async(ListControllers.Request())
+            # Wait via a plain threading.Event rather than spinning self._node:
+            # self._node may be context.node, which rqt_gui_py's RclpySpinner
+            # already spins continuously on another thread. Its executor already
+            # processes this future's response and completes it; we only need to
+            # be woken up when that happens. Poll self._node's own context between
+            # short waits so shutdown doesn't block here indefinitely, mirroring
+            # the exit condition spin_until_future_complete used to provide.
+            # self._node.context.ok() (not rclpy.ok(), which always checks the
+            # process-wide default context) is the correct check here: self._node
+            # may not be tied to the default context, and it is that node's
+            # context -- not the default one -- whose executor is what would ever
+            # complete this future.
+            #
+            # We deliberately do not use Client.call(): in Humble it blocks with
+            # no timeout at all and no way to observe context shutdown, and even
+            # in Jazzy/Rolling (where it gained a timeout_sec) a fixed wall-clock
+            # timeout can't express "keep waiting while healthy, stop promptly on
+            # shutdown" -- polling it in a loop would just resend a fresh request
+            # each iteration, since it calls call_async() internally every time.
+            done_event = threading.Event()
+            future.add_done_callback(lambda _future: done_event.set())
+            while self._node.context.ok() and not done_event.is_set():
+                done_event.wait(timeout=0.1)
+            # No-op if the future is already done. Otherwise (we gave up waiting
+            # because the context is shutting down) this marks it CANCELLED,
+            # which runs Client.remove_pending_request() via the future's own
+            # done-callback, so the request is not left registered in the
+            # client's pending-requests table after we stop waiting on it.
+            future.cancel()
+            result = future.result()
             return result.controller if result else []
         except rclpy.executors.ExternalShutdownException:
             return []
@@ -262,6 +302,24 @@ class ControllerLister:
 
     def _create_client(self):
         return self._node.create_client(ListControllers, self._srv_name)
+
+    def close(self):
+        """
+        Destroy the list_controllers client this instance owns on self._node.
+
+        Node.create_client() registers the client on self._node and never garbage-
+        collects it on its own; the client only stops being registered once
+        self._node.destroy_client() is called on it, or self._node itself is
+        destroyed. Since self._node may be long-lived and shared (e.g. rqt's
+        context.node), callers must call close() once this ControllerLister is no
+        longer used -- e.g. before replacing it with a new one, when
+        controller-manager selection is cleared, or during plugin shutdown --
+        otherwise every replacement leaks one more client onto self._node forever.
+        Does not touch self._node itself.
+        """
+        if self._srv_client is not None:
+            self._node.destroy_client(self._srv_client)
+            self._srv_client = None
 
 
 ###############################################################################

--- a/rqt_joint_trajectory_controller/test/test_joint_limits_urdf.py
+++ b/rqt_joint_trajectory_controller/test/test_joint_limits_urdf.py
@@ -12,20 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for parse_joint_limits() in joint_limits_urdf.py.
+"""Unit tests for joint_limits_urdf.py.
 
-All tests are ROS-free. They call parse_joint_limits() directly with
-URDF strings and assert on the returned dict. No node, no topic, no
+Most tests are ROS-free: they call parse_joint_limits() directly with URDF
+strings and assert on the returned dict. No node, no topic, no
 robot_description publisher is needed.
+
+The last group tests the callback/threading.Event/get_joint_limits waiting
+behavior using a minimal fake node stub, still without any live ROS node,
+context, or executor.
 
 Run with:
     pytest rqt_joint_trajectory_controller/test/test_joint_limits_urdf.py -v
 """
 
 import math
+import threading
+import time
+from unittest.mock import Mock
+
 import pytest
 
-from rqt_joint_trajectory_controller.joint_limits_urdf import parse_joint_limits
+from rqt_joint_trajectory_controller import joint_limits_urdf
+from rqt_joint_trajectory_controller.joint_limits_urdf import (
+    callback as robot_description_callback,
+    get_joint_limits,
+    parse_joint_limits,
+)
 
 # ---------------------------------------------------------------------------
 # Small URDF builder helpers
@@ -437,3 +450,154 @@ def test_missing_velocity_raises():
     )
     with pytest.raises(Exception, match="Required attribute not set in XML: velocity"):
         parse_joint_limits(urdf, ["j"])
+
+
+# ---------------------------------------------------------------------------
+# Group 8: robot_description wait mechanism.
+#
+# get_joint_limits() used to call rclpy.spin_once(node, ...) directly on the
+# node passed to it. That node can now be context.node, which rqt_gui_py
+# already spins continuously on its own thread — calling spin_once on it
+# here too would be a concurrent-access hazard on the same node. These
+# tests exercise the threading.Event-based replacement: the
+# robot_description subscription callback stores the message and signals
+# an Event, and get_joint_limits() waits on that Event instead of spinning.
+# A minimal fake node/message is used, so no real rclpy node, context, or
+# executor is involved.
+# ---------------------------------------------------------------------------
+
+
+class _FakeMsg:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeSubscribingNode(_TestNode):
+    """Minimal node stub that records create_subscription() calls and returns a handle."""
+
+    def __init__(self, logger):
+        super().__init__(logger)
+        self.subscriptions = []
+
+    def create_subscription(self, msg_type, topic, cb, qos_profile):
+        handle = (msg_type, topic, cb, qos_profile)
+        self.subscriptions.append(handle)
+        return handle
+
+
+@pytest.fixture
+def _clean_description_state():
+    """Reset the module-level description cache and event around each test."""
+    joint_limits_urdf.description = ""
+    joint_limits_urdf._description_received.clear()
+    yield
+    joint_limits_urdf.description = ""
+    joint_limits_urdf._description_received.clear()
+
+
+@pytest.fixture
+def _node(_clean_description_state):
+    return _TestNode(_TestLogger())
+
+
+@pytest.fixture
+def _no_spin_once(monkeypatch):
+    """
+    Fail loudly if get_joint_limits() ever calls rclpy.spin_once().
+
+    It must not: node may be context.node, which rqt_gui_py already spins
+    on another thread, so spinning it again here would race.
+    """
+    spin_once = Mock(side_effect=AssertionError("spin_once must not be called"))
+    monkeypatch.setattr(joint_limits_urdf.rclpy, "spin_once", spin_once)
+    return spin_once
+
+
+def _minimal_urdf():
+    return _robot(_revolute("j1", -1.0, 1.0, 1.0))
+
+
+def test_callback_sets_description_and_signals_event(_clean_description_state):
+    assert joint_limits_urdf.description == ""
+    assert not joint_limits_urdf._description_received.is_set()
+
+    robot_description_callback(_FakeMsg(_minimal_urdf()))
+
+    assert joint_limits_urdf.description == _minimal_urdf()
+    assert joint_limits_urdf._description_received.is_set()
+
+
+def test_subscribe_to_robot_description_returns_owned_subscription(_clean_description_state):
+    """subscribe_to_robot_description() must return the handle so the caller can destroy it later.
+
+    The plugin needs this to destroy its own subscription in shutdown_plugin() without
+    relying on context.node's destruction, since it doesn't own that node.
+    """
+    node = _FakeSubscribingNode(_TestLogger())
+    sub = joint_limits_urdf.subscribe_to_robot_description(node)
+
+    assert node.subscriptions == [sub]
+    _msg_type, topic, cb, _qos = sub
+    assert topic == "robot_description"
+    assert cb is robot_description_callback
+
+
+def test_get_joint_limits_does_not_call_spin_once(_node, _no_spin_once):
+    joint_limits_urdf.description = _minimal_urdf()
+    joint_limits_urdf._description_received.set()
+
+    result = get_joint_limits(_node, ["j1"])
+
+    assert "j1" in result
+    _no_spin_once.assert_not_called()
+
+
+def test_get_joint_limits_waits_for_event_set_by_callback(_node, _no_spin_once):
+    def deliver_after_delay():
+        time.sleep(0.05)
+        robot_description_callback(_FakeMsg(_minimal_urdf()))
+
+    thread = threading.Thread(target=deliver_after_delay, daemon=True)
+    thread.start()
+
+    result = get_joint_limits(_node, ["j1"], timeout_sec=2.0)
+    thread.join(timeout=1.0)
+
+    assert "j1" in result
+    _no_spin_once.assert_not_called()
+
+
+def test_get_joint_limits_timeout_returns_empty_dict_without_description(_node):
+    result = get_joint_limits(_node, ["j1"], timeout_sec=0.05)
+
+    assert result == {}
+
+
+def test_get_joint_limits_robust_to_stale_set_event_waits_for_new_description(
+    _node, _no_spin_once
+):
+    """
+    The event may be stale-set while description is empty (e.g. a caller
+    reset description="" directly without also clearing the event, or
+    leftover state from a previous run/test). get_joint_limits() must not
+    misread that stale set as "description available"; it must clear the
+    event and keep waiting for an actual new description to arrive.
+    """
+    joint_limits_urdf.description = _minimal_urdf()
+    joint_limits_urdf._description_received.set()
+
+    # Simulate a reset that forgets to clear the event.
+    joint_limits_urdf.description = ""
+
+    def deliver_after_delay():
+        time.sleep(0.05)
+        robot_description_callback(_FakeMsg(_minimal_urdf()))
+
+    thread = threading.Thread(target=deliver_after_delay, daemon=True)
+    thread.start()
+
+    result = get_joint_limits(_node, ["j1"], timeout_sec=2.0)
+    thread.join(timeout=1.0)
+
+    assert "j1" in result
+    _no_spin_once.assert_not_called()

--- a/rqt_joint_trajectory_controller/test/test_run_launch.py
+++ b/rqt_joint_trajectory_controller/test/test_run_launch.py
@@ -75,3 +75,14 @@ class TestShutdown(unittest.TestCase):
         launch_testing.asserts.assertExitCodes(
             proc_info, allowable_exit_codes=allowable_exit_codes
         )
+
+    def test_no_duplicate_node_name_registration(self, proc_output):
+        """
+        Internal ROS nodes must not inherit the executable-wide '__node' remap.
+
+        If they did, they would register under the same name as the framework's
+        shared node, and rcl's rosout logging would report a duplicate publisher
+        registration for that name.
+        """
+        combined_output = "".join(output.text.decode() for output in proc_output)
+        self.assertNotIn("Publisher already registered for node name", combined_output)

--- a/rqt_joint_trajectory_controller/test/test_utils.py
+++ b/rqt_joint_trajectory_controller/test/test_utils.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python
+
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for utils.py's node dependency-injection behavior.
+
+get_controller_managers(), ControllerManagerLister and ControllerLister used
+to each create their own private rclpy node. They now take a node supplied by
+the caller (e.g. rqt's shared context.node) and never spin it themselves.
+These tests exercise that contract -- including ControllerLister's owned
+service client lifetime (close()) and its context-shutdown-aware wait -- with
+minimal fake node/client/future stubs, so no live ROS node, context, or
+executor is involved. In particular, none of these tests call rclpy.init(),
+so any regression that reintroduces private node creation would fail here
+immediately.
+
+Run with:
+    pytest rqt_joint_trajectory_controller/test/test_utils.py -v
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from rqt_joint_trajectory_controller import utils
+
+# ---------------------------------------------------------------------------
+# Fake node/client/future stubs
+# ---------------------------------------------------------------------------
+
+
+class _FakeGraphNode:
+    """Minimal node stub for get_controller_managers()/ControllerManagerLister.
+
+    Only get_service_names_and_types() is needed -- these never spin or call
+    services, they only do synchronous ROS graph introspection.
+    """
+
+    def __init__(self, services):
+        self._services = services
+
+    def get_service_names_and_types(self):
+        return self._services
+
+
+def _cm_services_under(ns):
+    """Build a get_service_names_and_types()-style list exposing all controller
+    manager services under namespace ns, so is_controller_manager(node, ns) is True.
+    """
+    prefix = "" if ns in ("", "/") else ns
+    return [(f"{prefix}/{name}", [srv_type]) for name, srv_type in utils.cm_services.items()]
+
+
+class _FakeContext:
+    """Minimal stand-in for rclpy.context.Context: only ok() is needed."""
+
+    def __init__(self, ok=True):
+        self._ok = ok
+
+    def ok(self):
+        return self._ok
+
+
+class _FakeFuture:
+    """
+    Minimal stand-in for rclpy.task.Future, driven manually by tests.
+
+    Mirrors the two behaviors ControllerLister.__call__() relies on: done
+    callbacks fire immediately if added after completion/cancellation
+    (real rclpy Future does this too, to avoid missing an already-done
+    future), and cancel() is a no-op once the future is already done.
+    """
+
+    def __init__(self):
+        self._callbacks = []
+        self._result = None
+        self._done = False
+        self._cancelled = False
+
+    def add_done_callback(self, callback):
+        self._callbacks.append(callback)
+        if self._done or self._cancelled:
+            callback(self)
+
+    def result(self):
+        return self._result
+
+    def cancelled(self):
+        return self._cancelled
+
+    def cancel(self):
+        if self._done or self._cancelled:
+            return
+        self._cancelled = True
+        for callback in self._callbacks:
+            callback(self)
+
+    def complete(self, result):
+        self._result = result
+        self._done = True
+        for callback in self._callbacks:
+            callback(self)
+
+
+class _FakeListControllersClient:
+    """
+    Mirrors rclpy.client.Client's pending-request bookkeeping closely enough
+    to assert on it: call_async() tracks the future in pending_requests until
+    it is done or cancelled, exactly like Client.remove_pending_request()
+    being wired up as the future's own done-callback in real rclpy.
+    """
+
+    def __init__(self):
+        self.requests = []
+        self.last_future = None
+        self.pending_requests = {}
+
+    def call_async(self, request):
+        self.requests.append(request)
+        future = _FakeFuture()
+        self.last_future = future
+        seq = len(self.requests)
+        self.pending_requests[seq] = future
+        future.add_done_callback(lambda _future, seq=seq: self.pending_requests.pop(seq, None))
+        return future
+
+
+class _FakeControllerListerNode:
+    """Minimal node stub for ControllerLister: create_client()/destroy_client()/context."""
+
+    def __init__(self, context=None):
+        self.context = context if context is not None else _FakeContext()
+        self.created_clients = []  # [(srv_type, srv_name), ...] requested via create_client()
+        self.client_instances = []  # [_FakeListControllersClient, ...] returned, in order
+        self.destroyed_clients = []  # [_FakeListControllersClient, ...] passed to destroy_client()
+
+    @property
+    def client(self):
+        """The most recently created client, for tests using a single ControllerLister."""
+        return self.client_instances[-1]
+
+    def create_client(self, srv_type, srv_name):
+        self.created_clients.append((srv_type, srv_name))
+        client = _FakeListControllersClient()
+        self.client_instances.append(client)
+        return client
+
+    def destroy_client(self, client):
+        self.destroyed_clients.append(client)
+        return True
+
+
+class _RaisingClient:
+    def __init__(self, exc):
+        self._exc = exc
+
+    def call_async(self, request):
+        raise self._exc
+
+
+class _RaisingClientNode:
+    def __init__(self, exc):
+        self._exc = exc
+
+    def create_client(self, srv_type, srv_name):
+        return _RaisingClient(self._exc)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _no_spin(monkeypatch):
+    """
+    Fail loudly if ControllerLister.__call__() ever calls rclpy.spin_once()
+    or rclpy.spin_until_future_complete().
+
+    It must not: node may be context.node, which rqt_gui_py's RclpySpinner
+    already spins continuously on another thread. spin_once() there would
+    race it, and spin_until_future_complete(node, future) -- with no executor
+    argument -- silently detaches node from that other executor's node set
+    (verified experimentally: node.executor gets reassigned to the global
+    executor, permanently removing it from RclpySpinner's).
+    """
+    spin_once = Mock(side_effect=AssertionError("spin_once must not be called"))
+    spin_until_future_complete = Mock(
+        side_effect=AssertionError("spin_until_future_complete must not be called")
+    )
+    monkeypatch.setattr(utils.rclpy, "spin_once", spin_once)
+    monkeypatch.setattr(utils.rclpy, "spin_until_future_complete", spin_until_future_complete)
+    return spin_once, spin_until_future_complete
+
+
+@pytest.fixture
+def _rclpy_ok(monkeypatch):
+    """Make utils.rclpy.ok() report True without requiring a real rclpy.init()."""
+    monkeypatch.setattr(utils.rclpy, "ok", lambda: True)
+
+
+# ---------------------------------------------------------------------------
+# get_controller_managers() / ControllerManagerLister: node injection
+# ---------------------------------------------------------------------------
+
+
+def test_get_controller_managers_uses_injected_node():
+    node = _FakeGraphNode(_cm_services_under("/foo"))
+
+    result = utils.get_controller_managers(node)
+
+    assert result == ["/foo"]
+
+
+def test_controller_manager_lister_requires_node_argument():
+    with pytest.raises(TypeError):
+        utils.ControllerManagerLister()
+
+
+def test_controller_manager_lister_uses_injected_node(_rclpy_ok):
+    node = _FakeGraphNode(_cm_services_under("/foo"))
+    list_cm = utils.ControllerManagerLister(node)
+
+    assert list_cm() == ["/foo"]
+
+
+# ---------------------------------------------------------------------------
+# ControllerLister: node injection, and Event-based (non-spinning) wait
+# ---------------------------------------------------------------------------
+
+
+def test_controller_lister_requires_node_argument():
+    with pytest.raises(TypeError):
+        utils.ControllerLister()
+
+
+def test_controller_lister_creates_client_on_injected_node():
+    node = _FakeControllerListerNode()
+
+    utils.ControllerLister(node, "/controller_manager")
+
+    assert node.created_clients == [
+        (utils.ListControllers, "/controller_manager/list_controllers")
+    ]
+
+
+def test_controller_lister_call_waits_for_future_without_spinning(_no_spin):
+    node = _FakeControllerListerNode()
+    list_controllers = utils.ControllerLister(node)
+    fake_result = SimpleNamespace(controller=["ctrl_a", "ctrl_b"])
+
+    def deliver_after_delay():
+        while node.client.last_future is None:
+            time.sleep(0.01)
+        time.sleep(0.05)
+        node.client.last_future.complete(fake_result)
+
+    thread = threading.Thread(target=deliver_after_delay, daemon=True)
+    thread.start()
+
+    result = list_controllers()
+    thread.join(timeout=1.0)
+
+    assert result == ["ctrl_a", "ctrl_b"]
+    spin_once, spin_until_future_complete = _no_spin
+    spin_once.assert_not_called()
+    spin_until_future_complete.assert_not_called()
+
+
+def test_controller_lister_call_returns_empty_list_on_shutdown_context_error():
+    node = _RaisingClientNode(RuntimeError("context is not valid"))
+    list_controllers = utils.ControllerLister(node)
+
+    assert list_controllers() == []
+
+
+def test_controller_lister_call_reraises_unexpected_errors():
+    node = _RaisingClientNode(ValueError("boom"))
+    list_controllers = utils.ControllerLister(node)
+
+    with pytest.raises(ValueError, match="boom"):
+        list_controllers()
+
+
+# ---------------------------------------------------------------------------
+# ControllerLister: service client lifetime (close()) and context-shutdown wait
+# ---------------------------------------------------------------------------
+
+
+def test_controller_lister_close_destroys_client_and_is_idempotent():
+    node = _FakeControllerListerNode()
+    list_controllers = utils.ControllerLister(node)
+    client = node.client_instances[-1]
+
+    list_controllers.close()
+    list_controllers.close()  # must not double-destroy, or error, on repeat calls
+
+    assert node.destroyed_clients == [client]
+
+
+def test_repeated_controller_lister_replacement_does_not_accumulate_clients():
+    """
+    Mirrors what _on_cm_change() now does each time the user picks a different
+    controller manager: close() the old ControllerLister before constructing
+    a new one on the same (long-lived, shared) node. Node.create_client()
+    never garbage-collects on its own, so without this, every replacement
+    would leak one more client onto the shared node forever.
+    """
+    node = _FakeControllerListerNode()
+
+    current = None
+    for _ in range(5):
+        if current is not None:
+            current.close()
+        current = utils.ControllerLister(node, "/controller_manager")
+
+    assert len(node.client_instances) == 5
+    assert len(node.destroyed_clients) == 4
+    assert node.client_instances[-1] not in node.destroyed_clients
+
+
+def test_controller_lister_call_stops_waiting_and_cleans_up_pending_request_on_context_shutdown(
+    _no_spin,
+):
+    """
+    While node.context.ok(), __call__() must keep waiting for a response
+    indefinitely, same as the spin_until_future_complete() call it replaces.
+    Once the node's own context goes not-ok (shutdown), it must stop waiting
+    promptly rather than block forever on a future that will now never
+    complete, fall back to an empty list like a call with no result, and --
+    unlike a bare timeout -- must not leave the request sitting in the
+    client's pending-requests table afterwards.
+    """
+    remaining_ok_checks = {"count": 2}
+
+    class _ShuttingDownContext:
+        def ok(self):
+            remaining_ok_checks["count"] -= 1
+            return remaining_ok_checks["count"] >= 0
+
+    node = _FakeControllerListerNode(context=_ShuttingDownContext())
+    list_controllers = utils.ControllerLister(node)
+
+    result = list_controllers()
+
+    assert result == []
+    assert node.client.pending_requests == {}
+    assert node.client.last_future.cancelled()


### PR DESCRIPTION
## Description

Fixes #2555.

`rqt_joint_trajectory_controller` is launched with an executable-wide
`__node` remap. Previously, the plugin created additional ROS nodes that also
consumed that remap, causing multiple nodes to register with the same name.

This produced duplicate rosout publisher registrations during startup.

The plugin now reuses the `context.node` provided and spun by `rqt_gui_py`
instead of creating its own ROS nodes. Controller-manager discovery and
controller queries also use this shared node.

Because the shared node is already spun by rqt, the plugin must not call
`rclpy.spin_once()` or `rclpy.spin_until_future_complete()` on it.
`robot_description` and controller service waits instead use callbacks and
`threading.Event` synchronization while rqt's executor continues processing
the shared node.

ROS entities created by the plugin on the shared node are explicitly owned
and cleaned up by the plugin, including the `robot_description` subscription
and controller-query service client.

The launch regression test verifies that startup does not emit duplicate
node-name registration warnings.

### Is this user-facing behavior change?

No. The change aligns the plugin with rqt's shared-node lifecycle while
preserving normal namespace and topic remapping behavior.

### Did you use Generative AI?

Yes. Claude was used to assist with investigation and implementation. The
resulting changes were manually reviewed and tested.

### Testing

- full `rqt_joint_trajectory_controller` package suite: 46 passed
- focused `utils.py` tests: 11 passed
- `test_joint_limits_urdf.py`: 34 passed
- focused launch test passed
- focused launch test repeated 20 times with no duplicate-registration warnings
- topic remapping verified with the shared context node
- controller service-client cleanup verified across repeated replacement cycles
- pending controller request cleanup verified during context shutdown
- `git diff --check`
