### PR TITLE
test: cleanup controller fixture member variables

### DIFF
--- a/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
+++ b/ackermann_steering_controller/test/test_ackermann_steering_controller.hpp
@@ -147,15 +147,6 @@ protected:
     params.node_options = controller_->define_custom_node_options();
     ASSERT_EQ(controller_->init(params), controller_interface::return_type::OK);
 
-    if (position_feedback_ == true)
-    {
-      traction_interface_name_ = "position";
-    }
-    else
-    {
-      traction_interface_name_ = "velocity";
-    }
-
     std::vector<hardware_interface::LoanedCommandInterface> loaned_command_ifs;
     command_itfs_.reserve(joint_command_values_.size());
     loaned_command_ifs.reserve(joint_command_values_.size());
@@ -286,34 +277,28 @@ protected:
 
 protected:
   // Controller-related parameters
-  double reference_timeout_ = 2.0;
-  bool open_loop_ = false;
-  unsigned int velocity_rolling_window_size_ = 10;
-  bool position_feedback_ = false;
-  std::vector<std::string> traction_joints_names_ = {
+  const bool open_loop_ = false;
+  const unsigned int velocity_rolling_window_size_ = 10;
+  const bool position_feedback_ = false;
+  const std::vector<std::string> traction_joints_names_ = {
     "rear_right_wheel_joint", "rear_left_wheel_joint"};
-  std::vector<std::string> steering_joints_names_ = {
+  const std::vector<std::string> steering_joints_names_ = {
     "front_right_steering_joint", "front_left_steering_joint"};
-  std::vector<std::string> joint_names_ = {
-    traction_joints_names_[0], traction_joints_names_[1], steering_joints_names_[0],
-    steering_joints_names_[1]};
-
-  std::vector<std::string> traction_joints_preceding_names_ = {
+  const std::vector<std::string> traction_joints_preceding_names_ = {
     "pid_controller/rear_right_wheel_joint", "pid_controller/rear_left_wheel_joint"};
-  std::vector<std::string> steering_joints_preceding_names_ = {
+  const std::vector<std::string> steering_joints_preceding_names_ = {
     "pid_controller/front_right_steering_joint", "pid_controller/front_left_steering_joint"};
 
-  double wheelbase_ = 3.24644;
-  double traction_track_width_ = 1.76868;
-  double traction_wheels_radius_ = 0.45;
+  const double wheelbase_ = 3.24644;
+  const double traction_track_width_ = 1.76868;
+  const double traction_wheels_radius_ = 0.45;
 
-  std::array<double, 4> joint_state_values_ = {{0.5, 0.5, 0.0, 0.0}};
-  std::array<double, 4> joint_command_values_ = {{1.1, 3.3, 2.2, 4.4}};
-  std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
-  std::string steering_interface_name_ = "position";
-  // defined in setup
-  std::string traction_interface_name_ = "";
-  std::string preceding_prefix_ = "pid_controller";
+  const std::array<double, 4> joint_state_values_ = {{0.5, 0.5, 0.0, 0.0}};
+  const std::array<double, 4> joint_command_values_ = {{1.1, 3.3, 2.2, 4.4}};
+  const std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
+  const std::string steering_interface_name_ = "position";
+  const std::string traction_interface_name_ = position_feedback_ ? "position" : "velocity";
+  const std::string preceding_prefix_ = "pid_controller";
 
   std::vector<hardware_interface::StateInterface::SharedPtr> state_itfs_;
   std::vector<hardware_interface::CommandInterface::SharedPtr> command_itfs_;

--- a/admittance_controller/test/test_admittance_controller.hpp
+++ b/admittance_controller/test/test_admittance_controller.hpp
@@ -199,10 +199,10 @@ protected:
     }
 
     auto sc_fts = semantic_components::ForceTorqueSensor(ft_sensor_name_);
-    fts_state_names_ = sc_fts.get_state_interface_names();
+    const auto fts_state_names = sc_fts.get_state_interface_names();
     std::vector<hardware_interface::LoanedStateInterface> loaned_state_ifs;
 
-    const size_t num_state_ifs = joint_state_values_.size() + fts_state_names_.size();
+    const size_t num_state_ifs = joint_state_values_.size() + fts_state_names.size();
     state_itfs_.reserve(num_state_ifs);
     loaned_state_ifs.reserve(num_state_ifs);
 
@@ -215,10 +215,10 @@ protected:
       loaned_state_ifs.emplace_back(state_itfs_.back(), nullptr);
     }
 
-    std::vector<std::string> fts_itf_names = {"force.x",  "force.y",  "force.z",
-                                              "torque.x", "torque.y", "torque.z"};
+    const std::vector<std::string> fts_itf_names = {"force.x",  "force.y",  "force.z",
+                                                    "torque.x", "torque.y", "torque.z"};
 
-    for (auto i = 0u; i < fts_state_names_.size(); ++i)
+    for (auto i = 0u; i < fts_state_names.size(); ++i)
     {
       auto fts_state_itf =
         std::make_shared<hardware_interface::StateInterface>(ft_sensor_name_, fts_itf_names[i]);
@@ -388,28 +388,22 @@ protected:
   const std::vector<std::string> state_interface_types_ = {"position"};
   const std::string ft_sensor_name_ = "ft_sensor_name";
 
-  bool hardware_state_has_offset_ = false;
-
   const std::string ik_base_frame_ = "base_link";
   const std::string ik_tip_frame_ = "tool0";
-  const std::string ik_group_name_ = "arm";
-
   const std::string control_frame_ = "tool0";
   const std::string endeffector_frame_ = "endeffector_frame";
   const std::string fixed_world_frame_ = "fixed_world_frame";
   const std::string sensor_frame_ = "link_6";
 
-  std::array<bool, 6> admittance_selected_axes_ = {{true, true, true, true, true, true}};
-  std::array<double, 6> admittance_mass_ = {{5.5, 6.6, 7.7, 8.8, 9.9, 10.10}};
-  std::array<double, 6> admittance_damping_ratio_ = {
+  const std::array<bool, 6> admittance_selected_axes_ = {{true, true, true, true, true, true}};
+  const std::array<double, 6> admittance_mass_ = {{5.5, 6.6, 7.7, 8.8, 9.9, 10.10}};
+  const std::array<double, 6> admittance_damping_ratio_ = {
     {2.828427, 2.828427, 2.828427, 2.828427, 2.828427, 2.828427}};
-  std::array<double, 6> admittance_stiffness_ = {{214.1, 214.2, 214.3, 214.4, 214.5, 214.6}};
+  const std::array<double, 6> admittance_stiffness_ = {{214.1, 214.2, 214.3, 214.4, 214.5, 214.6}};
 
-  std::array<double, 6> joint_command_values_ = {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
-  std::array<double, 6> joint_state_values_ = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6}};
-  std::array<double, 6> fts_state_values_ = {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
-  std::vector<std::string> fts_state_names_;
-
+  const std::array<double, 6> joint_command_values_ = {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
+  const std::array<double, 6> joint_state_values_ = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6}};
+  const std::array<double, 6> fts_state_values_ = {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
   std::vector<hardware_interface::StateInterface::SharedPtr> state_itfs_;
   std::vector<hardware_interface::CommandInterface::SharedPtr> command_itfs_;
 

--- a/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
+++ b/bicycle_steering_controller/test/test_bicycle_steering_controller.hpp
@@ -144,15 +144,6 @@ protected:
     params.node_options = controller_->define_custom_node_options();
     ASSERT_EQ(controller_->init(params), controller_interface::return_type::OK);
 
-    if (position_feedback_ == true)
-    {
-      traction_interface_name_ = "position";
-    }
-    else
-    {
-      traction_interface_name_ = "velocity";
-    }
-
     std::vector<hardware_interface::LoanedCommandInterface> loaned_command_ifs;
     command_itfs_.reserve(joint_command_values_.size());
     loaned_command_ifs.reserve(joint_command_values_.size());
@@ -259,30 +250,26 @@ protected:
 
 protected:
   // Controller-related parameters
-  double reference_timeout_ = 2.0;
-  bool front_steering_ = true;
-  bool open_loop_ = false;
-  unsigned int velocity_rolling_window_size_ = 10;
-  bool position_feedback_ = false;
-  std::vector<std::string> traction_joints_names_ = {{"rear_wheel_joint"}};
-  std::vector<std::string> steering_joints_names_ = {{"steering_axis_joint"}};
-  std::vector<std::string> joint_names_ = {{traction_joints_names_[0], steering_joints_names_[0]}};
-
-  std::vector<std::string> traction_joints_preceding_names_ = {{"pid_controller/rear_wheel_joint"}};
-  std::vector<std::string> steering_joints_preceding_names_ = {
+  const bool open_loop_ = false;
+  const unsigned int velocity_rolling_window_size_ = 10;
+  const bool position_feedback_ = false;
+  const std::vector<std::string> traction_joints_names_ = {{"rear_wheel_joint"}};
+  const std::vector<std::string> steering_joints_names_ = {{"steering_axis_joint"}};
+  const std::vector<std::string> traction_joints_preceding_names_ = {
+    {"pid_controller/rear_wheel_joint"}};
+  const std::vector<std::string> steering_joints_preceding_names_ = {
     {"pid_controller/steering_axis_joint"}};
 
-  double wheelbase_ = 3.24644;
-  double traction_wheel_radius_ = 0.45;
+  const double wheelbase_ = 3.24644;
+  const double traction_wheel_radius_ = 0.45;
 
-  std::array<double, 2> joint_state_values_ = {{3.3, 0.5}};
-  std::array<double, 2> joint_command_values_ = {{1.1, 2.2}};
-  std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
-  std::string steering_interface_name_ = "position";
+  const std::array<double, 2> joint_state_values_ = {{3.3, 0.5}};
+  const std::array<double, 2> joint_command_values_ = {{1.1, 2.2}};
+  const std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
+  const std::string steering_interface_name_ = "position";
 
-  // defined in setup
-  std::string traction_interface_name_ = "";
-  std::string preceding_prefix_ = "pid_controller";
+  const std::string traction_interface_name_ = position_feedback_ ? "position" : "velocity";
+  const std::string preceding_prefix_ = "pid_controller";
 
   std::vector<hardware_interface::StateInterface::SharedPtr> state_itfs_;
   std::vector<hardware_interface::CommandInterface::SharedPtr> command_itfs_;

--- a/chained_filter_controller/test/test_chained_filter.hpp
+++ b/chained_filter_controller/test/test_chained_filter.hpp
@@ -54,7 +54,7 @@ protected:
 
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"wheel_left"};
-  std::vector<double> joint_states_ = {1.1};
+  const std::vector<double> joint_states_ = {1.1};
 
   StateInterface::SharedPtr joint_1_pos_;
   rclcpp::executors::SingleThreadedExecutor executor;

--- a/chained_filter_controller/test/test_multiple_chained_filter.hpp
+++ b/chained_filter_controller/test/test_multiple_chained_filter.hpp
@@ -51,7 +51,7 @@ protected:
 
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"wheel_left", "wheel_right"};
-  std::vector<double> joint_states_ = {1.1, 2.2};
+  const std::vector<double> joint_states_ = {1.1, 2.2};
 
   StateInterface::SharedPtr joint_1_pos_;
   StateInterface::SharedPtr joint_2_pos_;

--- a/diff_drive_controller/test/test_diff_drive_controller.cpp
+++ b/diff_drive_controller/test/test_diff_drive_controller.cpp
@@ -253,7 +253,7 @@ protected:
   std::unique_ptr<TestableDiffDriveController> controller_;
 
   std::vector<double> position_values_ = {0.1, 0.2};
-  std::vector<double> velocity_values_ = {0.01, 0.02};
+  const std::vector<double> velocity_values_ = {0.01, 0.02};
 
   hardware_interface::StateInterface::SharedPtr left_wheel_pos_state_;
   hardware_interface::StateInterface::SharedPtr right_wheel_pos_state_;

--- a/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.hpp
+++ b/force_torque_sensor_broadcaster/test/test_force_torque_sensor_broadcaster.hpp
@@ -66,7 +66,7 @@ public:
 protected:
   const std::string sensor_name_ = "fts_sensor";
   const std::string frame_id_ = "fts_sensor_frame";
-  std::array<double, 6> sensor_values_ = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6}};
+  const std::array<double, 6> sensor_values_ = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6}};
 
   hardware_interface::StateInterface::SharedPtr fts_force_x_;
   hardware_interface::StateInterface::SharedPtr fts_force_y_;

--- a/forward_command_controller/test/test_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_forward_command_controller.hpp
@@ -69,7 +69,7 @@ protected:
 
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
-  std::vector<double> joint_commands_ = {1.1, 2.1, 3.1};
+  const std::vector<double> joint_commands_ = {1.1, 2.1, 3.1};
 
   CommandInterface::SharedPtr joint_1_pos_cmd_;
   CommandInterface::SharedPtr joint_2_pos_cmd_;

--- a/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
+++ b/forward_command_controller/test/test_multi_interface_forward_command_controller.hpp
@@ -76,9 +76,9 @@ protected:
   // dummy joint state value used for tests
   const std::string joint_name_ = "joint1";
 
-  double pos_cmd_ = 1.1;
-  double vel_cmd_ = 2.1;
-  double eff_cmd_ = 3.1;
+  const double pos_cmd_ = 1.1;
+  const double vel_cmd_ = 2.1;
+  const double eff_cmd_ = 3.1;
 
   CommandInterface::SharedPtr joint_1_pos_cmd_;
   CommandInterface::SharedPtr joint_1_vel_cmd_;

--- a/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
+++ b/gps_sensor_broadcaster/test/test_gps_sensor_broadcaster.cpp
@@ -151,7 +151,7 @@ protected:
   const rclcpp::Parameter sensor_name_param_ = rclcpp::Parameter("sensor_name", "gps_sensor");
   const std::string sensor_name_ = sensor_name_param_.get_value<std::string>();
   const rclcpp::Parameter frame_id_ = rclcpp::Parameter("frame_id", "gps_sensor_frame");
-  std::array<double, 8> sensor_values_ = {{1.0, 1.0, 1.1, 2.2, 3.3, 0.5, 0.7, 0.9}};
+  const std::array<double, 8> sensor_values_ = {{1.0, 1.0, 1.1, 2.2, 3.3, 0.5, 0.7, 0.9}};
   hardware_interface::StateInterface::SharedPtr gps_status_;
   hardware_interface::StateInterface::SharedPtr gps_service_;
   hardware_interface::StateInterface::SharedPtr gps_latitude_;

--- a/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.hpp
+++ b/imu_sensor_broadcaster/test/test_imu_sensor_broadcaster.hpp
@@ -61,7 +61,7 @@ public:
 protected:
   const std::string sensor_name_ = "imu_sensor";
   const std::string frame_id_ = "imu_sensor_frame";
-  std::array<double, 10> sensor_values_ = {
+  const std::array<double, 10> sensor_values_ = {
     {0.1826, 0.3651, 0.5477, 0.7303, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10}};
   hardware_interface::StateInterface::SharedPtr imu_orientation_x_;
   hardware_interface::StateInterface::SharedPtr imu_orientation_y_;

--- a/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/test/test_joint_state_broadcaster.hpp
@@ -128,8 +128,8 @@ protected:
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
   const std::vector<std::string> interface_names_ = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
-  std::string custom_interface_name_ = "measured_position";
-  std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
+  const std::string custom_interface_name_ = "measured_position";
+  const std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
   double custom_joint_value_ = 3.5;
 
   hardware_interface::StateInterface::SharedPtr joint_1_pos_state_;
@@ -151,7 +151,7 @@ protected:
   std::vector<hardware_interface::StateInterface::SharedPtr> test_interfaces_;
 
   std::unique_ptr<FriendJointStateBroadcaster> state_broadcaster_;
-  std::string frame_id_ = "base_link";
+  const std::string frame_id_ = "base_link";
 };
 
 #endif  // TEST_JOINT_STATE_BROADCASTER_HPP_

--- a/magnetometer_broadcaster/test/test_magnetometer_broadcaster.cpp
+++ b/magnetometer_broadcaster/test/test_magnetometer_broadcaster.cpp
@@ -119,7 +119,7 @@ protected:
   const std::string frame_id_ = "magnetometer_frame";
   const rclcpp::Parameter frame_id_param_ = rclcpp::Parameter("frame_id", frame_id_);
 
-  std::array<double, 3> sensor_values_ = {{20e-6, 30e-6, 40e-6}};
+  const std::array<double, 3> sensor_values_ = {{20e-6, 30e-6, 40e-6}};
   hardware_interface::StateInterface::SharedPtr magnetic_field_x;
   hardware_interface::StateInterface::SharedPtr magnetic_field_y;
   hardware_interface::StateInterface::SharedPtr magnetic_field_z;

--- a/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
+++ b/mecanum_drive_controller/test/test_mecanum_drive_controller.hpp
@@ -302,7 +302,7 @@ protected:
   static constexpr char TEST_FRONT_RIGHT_CMD_JOINT_NAME[] = "front_right_wheel_joint";
   static constexpr char TEST_REAR_RIGHT_CMD_JOINT_NAME[] = "back_right_wheel_joint";
   static constexpr char TEST_REAR_LEFT_CMD_JOINT_NAME[] = "back_left_wheel_joint";
-  std::vector<std::string> command_joint_names_ = {
+  const std::vector<std::string> command_joint_names_ = {
     TEST_FRONT_LEFT_CMD_JOINT_NAME, TEST_FRONT_RIGHT_CMD_JOINT_NAME, TEST_REAR_RIGHT_CMD_JOINT_NAME,
     TEST_REAR_LEFT_CMD_JOINT_NAME};
 
@@ -310,10 +310,10 @@ protected:
   static constexpr char TEST_FRONT_RIGHT_STATE_JOINT_NAME[] = "state_front_right_wheel_joint";
   static constexpr char TEST_REAR_RIGHT_STATE_JOINT_NAME[] = "state_back_right_wheel_joint";
   static constexpr char TEST_REAR_LEFT_STATE_JOINT_NAME[] = "state_back_left_wheel_joint";
-  std::vector<std::string> state_joint_names_ = {
+  const std::vector<std::string> state_joint_names_ = {
     TEST_FRONT_LEFT_STATE_JOINT_NAME, TEST_FRONT_RIGHT_STATE_JOINT_NAME,
     TEST_REAR_RIGHT_STATE_JOINT_NAME, TEST_REAR_LEFT_STATE_JOINT_NAME};
-  std::string interface_name_ = hardware_interface::HW_IF_VELOCITY;
+  const std::string interface_name_ = hardware_interface::HW_IF_VELOCITY;
 
   // Controller-related parameters
 
@@ -323,12 +323,10 @@ protected:
   static constexpr double TEST_LINEAR_VELOCITY_X = 1.5;
   static constexpr double TEST_LINEAR_VELOCITY_y = 0.0;
   static constexpr double TEST_ANGULAR_VELOCITY_Z = 0.0;
-  double command_lin_x = 111;
+  const double command_lin_x = 111;
 
   std::vector<hardware_interface::StateInterface::SharedPtr> state_itfs_;
   std::vector<hardware_interface::CommandInterface::SharedPtr> command_itfs_;
-
-  double ref_timeout_ = 0.1;
 
   // Test related parameters
   std::unique_ptr<CtrlType> controller_;

--- a/motion_primitives_controllers/test/test_motion_primitives_forward_controller.hpp
+++ b/motion_primitives_controllers/test/test_motion_primitives_forward_controller.hpp
@@ -190,20 +190,21 @@ protected:
     std::cout << "Goal accepted by the action server." << std::endl;
   }
 
-  std::vector<std::string> command_interface_names_ = {
+  const std::vector<std::string> command_interface_names_ = {
     "motion_type", "q1",           "q2",         "q3",           "q4",
     "q5",          "q6",           "pos_x",      "pos_y",        "pos_z",
     "pos_qx",      "pos_qy",       "pos_qz",     "pos_qw",       "pos_via_x",
     "pos_via_y",   "pos_via_z",    "pos_via_qx", "pos_via_qy",   "pos_via_qz",
     "pos_via_qw",  "blend_radius", "velocity",   "acceleration", "move_time"};
 
-  std::vector<std::string> state_interface_names_ = {"execution_status", "ready_for_new_primitive"};
+  const std::vector<std::string> state_interface_names_ = {
+    "execution_status", "ready_for_new_primitive"};
 
-  std::string interface_namespace_ = "motion_primitive";
-  std::array<double, 2> state_values_ = {
+  const std::string interface_namespace_ = "motion_primitive";
+  const std::array<double, 2> state_values_ = {
     {static_cast<uint8_t>(motion_primitives_controllers::ExecutionState::IDLE),
      static_cast<uint8_t>(motion_primitives_controllers::ReadyForNewPrimitive::READY)}};
-  std::array<double, 25> command_values_ = {
+  const std::array<double, 25> command_values_ = {
     {101.101, 101.101, 101.101, 101.101, 101.101, 101.101, 101.101, 101.101, 101.101,
      101.101, 101.101, 101.101, 101.101, 101.101, 101.101, 101.101, 101.101, 101.101,
      101.101, 101.101, 101.101, 101.101, 101.101, 101.101, 101.101}};

--- a/parallel_gripper_controller/test/test_parallel_gripper_controller.hpp
+++ b/parallel_gripper_controller/test/test_parallel_gripper_controller.hpp
@@ -46,10 +46,10 @@ protected:
   std::unique_ptr<FriendGripperController> controller_;
   // dummy joint state values used for tests
   const std::string joint_name_ = "joint1";
-  std::vector<double> joint_states_ = {1.1, 2.1};
-  std::vector<double> joint_commands_ = {3.1};
-  std::vector<double> joint_effort_commands_ = {0.0};
-  std::vector<double> joint_speed_commands_ = {0.0};
+  const std::vector<double> joint_states_ = {1.1, 2.1};
+  const std::vector<double> joint_commands_ = {3.1};
+  const std::vector<double> joint_effort_commands_ = {0.0};
+  const std::vector<double> joint_speed_commands_ = {0.0};
   hardware_interface::StateInterface::SharedPtr joint_1_pos_state_;
   hardware_interface::StateInterface::SharedPtr joint_1_vel_state_;
   hardware_interface::CommandInterface::SharedPtr joint_1_cmd_;

--- a/pose_broadcaster/test/test_pose_broadcaster.hpp
+++ b/pose_broadcaster/test/test_pose_broadcaster.hpp
@@ -45,7 +45,7 @@ protected:
   const std::string frame_id_ = "pose_base_frame";
   const std::string tf_child_frame_id_ = "pose_frame";
 
-  std::array<double, 7> pose_values_ = {
+  const std::array<double, 7> pose_values_ = {
     {1.1, 2.2, 3.3, 0.39190382, 0.20056212, 0.53197575, 0.72331744}};
 
   hardware_interface::StateInterface::SharedPtr pose_position_x_;

--- a/range_sensor_broadcaster/test/test_range_sensor_broadcaster.hpp
+++ b/range_sensor_broadcaster/test/test_range_sensor_broadcaster.hpp
@@ -43,8 +43,6 @@ protected:
   // defining the parameter names same as in test/range_sensor_broadcaster_params.yaml
   const std::string sensor_name_ = "range_sensor";
   const std::string frame_id_ = "range_sensor_frame";
-  const std::string interface_name_ = "range";
-
   const double field_of_view_ = 0.1;
   const int radiation_type_ = 1;
   const double min_range_ = 0.1;

--- a/state_interfaces_broadcaster/test/test_state_interfaces_broadcaster.hpp
+++ b/state_interfaces_broadcaster/test/test_state_interfaces_broadcaster.hpp
@@ -72,9 +72,9 @@ protected:
   // dummy joint state values used for tests
   const std::vector<std::string> joint_names_ = {"joint1", "joint2", "joint3"};
   const std::vector<std::string> interface_names_ = {HW_IF_POSITION, HW_IF_VELOCITY, HW_IF_EFFORT};
-  std::string custom_interface_name_ = "measured_position";
-  std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
-  double custom_joint_value_ = 3.5;
+  const std::string custom_interface_name_ = "measured_position";
+  const std::vector<double> joint_values_ = {1.1, 2.1, 3.1};
+  const double custom_joint_value_ = 3.5;
 
   hardware_interface::StateInterface::SharedPtr joint_1_pos_state_;
   hardware_interface::StateInterface::SharedPtr joint_2_pos_state_;
@@ -88,10 +88,7 @@ protected:
 
   hardware_interface::StateInterface::SharedPtr joint_X_custom_state;
 
-  std::vector<hardware_interface::StateInterface::SharedPtr> test_interfaces_;
-
   std::unique_ptr<FriendStateInterfacesBroadcaster> state_broadcaster_;
-  std::string frame_id_ = "base_link";
 };
 
 #endif  // TEST_STATE_INTERFACES_BROADCASTER_HPP_

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -178,15 +178,6 @@ protected:
     params.node_options = node_options;
     ASSERT_EQ(controller_->init(params), controller_interface::return_type::OK);
 
-    if (position_feedback_ == true)
-    {
-      traction_interface_name_ = "position";
-    }
-    else
-    {
-      traction_interface_name_ = "velocity";
-    }
-
     std::vector<hardware_interface::LoanedCommandInterface> loaned_command_ifs;
     command_itfs_.reserve(joint_command_values_.size());
     loaned_command_ifs.reserve(joint_command_values_.size());
@@ -317,31 +308,16 @@ protected:
 
 protected:
   // Controller-related parameters
-  double reference_timeout_ = 2.0;
-  bool open_loop_ = false;
-  unsigned int velocity_rolling_window_size_ = 10;
-  bool position_feedback_ = false;
-  std::vector<std::string> traction_joints_names_ = {
+  const std::vector<std::string> traction_joints_names_ = {
     "rear_right_wheel_joint", "rear_left_wheel_joint"};
-  std::vector<std::string> steering_joints_names_ = {
+  const std::vector<std::string> steering_joints_names_ = {
     "front_right_steering_joint", "front_left_steering_joint"};
-  std::vector<std::string> joint_names_ = {
-    traction_joints_names_[0], traction_joints_names_[1], steering_joints_names_[0],
-    steering_joints_names_[1]};
-
-  std::vector<std::string> traction_joints_preceding_names_ = {
-    "pid_controller/rear_right_wheel_joint", "pid_controller/rear_left_wheel_joint"};
-  std::vector<std::string> steering_joints_preceding_names_ = {
-    "pid_controller/front_right_steering_joint", "pid_controller/front_left_steering_joint"};
-
   std::array<double, 4> joint_state_values_ = {{0.5, 0.5, 0.0, 0.0}};
-  std::array<double, 4> joint_command_values_ = {{1.1, 3.3, 2.2, 4.4}};
+  const std::array<double, 4> joint_command_values_ = {{1.1, 3.3, 2.2, 4.4}};
 
-  std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
-  std::string steering_interface_name_ = "position";
-  // defined in setup
-  std::string traction_interface_name_ = "";
-  std::string preceding_prefix_ = "pid_controller";
+  const std::array<std::string, 2> reference_interface_names_ = {{"linear", "angular"}};
+  const std::string steering_interface_name_ = "position";
+  const std::string traction_interface_name_ = "velocity";
 
   std::vector<hardware_interface::StateInterface::SharedPtr> state_itfs_;
   std::vector<hardware_interface::CommandInterface::SharedPtr> command_itfs_;

--- a/tricycle_controller/test/test_tricycle_controller.cpp
+++ b/tricycle_controller/test/test_tricycle_controller.cpp
@@ -198,8 +198,8 @@ protected:
   const std::string controller_name = "test_tricycle_controller";
   std::unique_ptr<TestableTricycleController> controller_;
 
-  double position_ = 0.1;
-  double velocity_ = 0.2;
+  const double position_ = 0.1;
+  const double velocity_ = 0.2;
 
   hardware_interface::StateInterface::SharedPtr steering_joint_pos_state_;
   hardware_interface::StateInterface::SharedPtr traction_joint_vel_state_;

--- a/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
+++ b/tricycle_steering_controller/test/test_tricycle_steering_controller.hpp
@@ -146,15 +146,6 @@ protected:
     params.node_options = controller_->define_custom_node_options();
     ASSERT_EQ(controller_->init(params), controller_interface::return_type::OK);
 
-    if (position_feedback_ == true)
-    {
-      traction_interface_name_ = "position";
-    }
-    else
-    {
-      traction_interface_name_ = "velocity";
-    }
-
     std::vector<hardware_interface::LoanedCommandInterface> loaned_command_ifs;
     command_itfs_.reserve(joint_command_values_.size());
     loaned_command_ifs.reserve(joint_command_values_.size());
@@ -273,32 +264,27 @@ protected:
 
 protected:
   // Controller-related parameters
-  double reference_timeout_ = 2.0;
-  bool open_loop_ = false;
-  unsigned int velocity_rolling_window_size_ = 10;
-  bool position_feedback_ = false;
-  std::vector<std::string> traction_joints_names_ = {
+  const bool open_loop_ = false;
+  const unsigned int velocity_rolling_window_size_ = 10;
+  const bool position_feedback_ = false;
+  const std::vector<std::string> traction_joints_names_ = {
     "rear_right_wheel_joint", "rear_left_wheel_joint"};
-  std::vector<std::string> steering_joints_names_ = {"steering_axis_joint"};
-  std::vector<std::string> joint_names_ = {
-    traction_joints_names_[0], traction_joints_names_[1], steering_joints_names_[0]};
-
-  std::vector<std::string> traction_joints_preceding_names_ = {
+  const std::vector<std::string> steering_joints_names_ = {"steering_axis_joint"};
+  const std::vector<std::string> traction_joints_preceding_names_ = {
     "pid_controller/rear_right_wheel_joint", "pid_controller/rear_left_wheel_joint"};
-  std::vector<std::string> steering_joints_preceding_names_ = {
+  const std::vector<std::string> steering_joints_preceding_names_ = {
     "pid_controller/steering_axis_joint"};
 
-  double wheelbase_ = 3.24644;
-  double traction_track_width_ = 1.212121;
-  double traction_wheels_radius_ = 0.45;
+  const double wheelbase_ = 3.24644;
+  const double traction_track_width_ = 1.212121;
+  const double traction_wheels_radius_ = 0.45;
 
-  std::array<double, 3> joint_state_values_{{0.5, 0.5, 0.0}};
-  std::array<double, 3> joint_command_values_{{1.1, 3.3, 2.2}};
-  std::array<std::string, 2> reference_interface_names_{{"linear", "angular"}};
-  std::string steering_interface_name_ = "position";
-  // defined in setup
-  std::string traction_interface_name_ = "";
-  std::string preceding_prefix_ = "pid_controller";
+  const std::array<double, 3> joint_state_values_{{0.5, 0.5, 0.0}};
+  const std::array<double, 3> joint_command_values_{{1.1, 3.3, 2.2}};
+  const std::array<std::string, 2> reference_interface_names_{{"linear", "angular"}};
+  const std::string steering_interface_name_ = "position";
+  const std::string traction_interface_name_ = position_feedback_ ? "position" : "velocity";
+  const std::string preceding_prefix_ = "pid_controller";
 
   std::vector<hardware_interface::StateInterface::SharedPtr> state_itfs_;
   std::vector<hardware_interface::CommandInterface::SharedPtr> command_itfs_;


### PR DESCRIPTION
## Description

Cleans up test fixture member variables following the Command/State Interface API migration from #2476.

- Makes immutable fixture data `const`.
- Removes obsolete fixture members.
- Moves force/torque interface-name state to local scope.
- Preserves mutable members where tests model changing hardware state.
- No production controller behavior is changed.

Fixes #2531

### Additional Information

Validation completed:

- 20 affected packages built successfully.
- 401 tests passed with 0 failures.
- `pre-commit run --all-files` passed.
- `ament_cpplint` and `ament_cppcheck` passed.
- `git diff --check` passed.

## TODOs

- [x] Fork the repository.
- [x] Modify the source; changes are limited to test fixtures.
- [x] Ensure local tests pass.
- [ x] Commit to your fork using clear commit messages.
- [ x] Send a pull request.
- [ x] Monitor automated CI results and respond to review feedback.