### PR TITLE
[JTC] Add thread-safe snapshot of last commanded state

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -41,6 +41,7 @@
 #include "realtime_tools/realtime_buffer.hpp"
 #include "realtime_tools/realtime_publisher.hpp"
 #include "realtime_tools/realtime_server_goal_handle.hpp"
+#include "realtime_tools/realtime_thread_safe_box.hpp"
 #include "trajectory_msgs/msg/joint_trajectory.hpp"
 #include "trajectory_msgs/msg/joint_trajectory_point.hpp"
 
@@ -113,6 +114,9 @@ protected:
   // variables for storing internal data for open-loop control
   trajectory_msgs::msg::JointTrajectoryPoint last_commanded_state_;
   rclcpp::Time last_commanded_time_;
+  // Thread-safe snapshot of last_commanded_state_ for non-RT readers.
+  realtime_tools::RealtimeThreadSafeBox<trajectory_msgs::msg::JointTrajectoryPoint>
+    rt_last_commanded_state_;
   /// Specify interpolation method. Default to splines.
   interpolation_methods::InterpolationMethod interpolation_method_{
     interpolation_methods::DEFAULT_INTERPOLATION};

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -114,7 +114,6 @@ protected:
   // variables for storing internal data for open-loop control
   trajectory_msgs::msg::JointTrajectoryPoint last_commanded_state_;
   rclcpp::Time last_commanded_time_;
-  // Thread-safe snapshot of last_commanded_state_ for non-RT readers.
   realtime_tools::RealtimeThreadSafeBox<trajectory_msgs::msg::JointTrajectoryPoint>
     rt_last_commanded_state_;
   /// Specify interpolation method. Default to splines.

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -502,6 +502,8 @@ controller_interface::return_type JointTrajectoryController::update(
 
         // store the previous command and time used in open-loop control mode
         last_commanded_state_ = command_next_;
+        rt_last_commanded_state_.try_set([this](trajectory_msgs::msg::JointTrajectoryPoint & state)
+                                         { state = last_commanded_state_; });
         last_commanded_time_ = time;
       }
 
@@ -1262,6 +1264,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
     update_state_from_command_interfaces(state_current_);
     update_state_from_command_interfaces(last_commanded_state_);
   }
+  rt_last_commanded_state_.set(last_commanded_state_);
 
   // reset/zero out all of the PID's (The integral term is not retained and reset to zero)
   for (auto & pid : pids_)


### PR DESCRIPTION
## Description

Adds `rt_last_commanded_state_`, a `RealtimeThreadSafeBox` copy of `last_commanded_state_` that can be read safely from outside the update loop. `update()` publishes to it with `try_set`, so the control loop never blocks. `last_commanded_state_` itself is unchanged and stays the update loop's working copy, so no existing line is modified. This mirrors how other controllers pair a plain member with a box (`diff_drive`, `admittance`, `pid`), only in the opposite direction: here the update loop writes and other threads read.

Needed by controllers that build a trajectory outside the update loop and want to continue from the last commanded state instead of restarting from the measured one.

### Is this user-facing behavior change?

No. Nothing reads the new member yet, and no existing behaviour changes.