### PR TITLE
Add closed-form steering integration tests

### DIFF
--- a/steering_controllers_library/test/test_steering_odometry.cpp
+++ b/steering_controllers_library/test/test_steering_odometry.cpp
@@ -57,11 +57,13 @@ Pose integrate_twist(
     final_heading};
 }
 
-void expect_pose(const steering_kinematics::SteeringKinematics & odom, const Pose & expected)
+auto PoseNear(const Pose & expected)
 {
-  EXPECT_NEAR(odom.get_x(), expected.x, TOLERANCE);
-  EXPECT_NEAR(odom.get_y(), expected.y, TOLERANCE);
-  EXPECT_NEAR(odom.get_heading(), expected.heading, TOLERANCE);
+  return ::testing::AllOf(
+    ::testing::Field("x", &Pose::x, ::testing::DoubleNear(expected.x, TOLERANCE)),
+    ::testing::Field("y", &Pose::y, ::testing::DoubleNear(expected.y, TOLERANCE)),
+    ::testing::Field(
+      "heading", &Pose::heading, ::testing::DoubleNear(expected.heading, TOLERANCE)));
 }
 
 class SteeringOdometryIntegratorTest : public ::testing::TestWithParam<SteeringConfiguration>
@@ -78,7 +80,9 @@ protected:
     odom.set_odometry(initial.x, initial.y, initial.heading);
     odom.update_open_loop(linear, angular, dt);
 
-    expect_pose(odom, integrate_twist(initial, linear, angular, dt));
+    EXPECT_THAT(
+      (Pose{odom.get_x(), odom.get_y(), odom.get_heading()}),
+      PoseNear(integrate_twist(initial, linear, angular, dt)));
     EXPECT_DOUBLE_EQ(odom.get_linear(), linear);
     EXPECT_DOUBLE_EQ(odom.get_angular(), angular);
   }

--- a/steering_controllers_library/test/test_steering_odometry.cpp
+++ b/steering_controllers_library/test/test_steering_odometry.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2023, Virtual Vehicle Research GmbH
+// Copyright (c) 2026, Dylan Gallagher
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +17,110 @@
 
 #include <gmock/gmock.h>
 #include <cmath>
+#include <string>
 
 #include "steering_controllers_library/steering_kinematics.hpp"
+
+namespace
+{
+constexpr double TOLERANCE = 1e-10;
+
+struct SteeringConfiguration
+{
+  unsigned int type;
+  const char * name;
+};
+
+struct Pose
+{
+  double x;
+  double y;
+  double heading;
+};
+
+Pose integrate_twist(
+  const Pose & initial, const double linear, const double angular, const double dt)
+{
+  if (std::abs(angular * dt) < 1e-6)
+  {
+    const double middle_heading = initial.heading + angular * dt * 0.5;
+    return {
+      initial.x + linear * std::cos(middle_heading) * dt,
+      initial.y + linear * std::sin(middle_heading) * dt, initial.heading + angular * dt};
+  }
+
+  const double final_heading = initial.heading + angular * dt;
+  const double turning_radius = linear / angular;
+  return {
+    initial.x + turning_radius * (std::sin(final_heading) - std::sin(initial.heading)),
+    initial.y - turning_radius * (std::cos(final_heading) - std::cos(initial.heading)),
+    final_heading};
+}
+
+void expect_pose(const steering_kinematics::SteeringKinematics & odom, const Pose & expected)
+{
+  EXPECT_NEAR(odom.get_x(), expected.x, TOLERANCE);
+  EXPECT_NEAR(odom.get_y(), expected.y, TOLERANCE);
+  EXPECT_NEAR(odom.get_heading(), expected.heading, TOLERANCE);
+}
+
+class SteeringOdometryIntegratorTest : public ::testing::TestWithParam<SteeringConfiguration>
+{
+protected:
+  void configure(steering_kinematics::SteeringKinematics & odom) const
+  {
+    odom.set_odometry_type(GetParam().type);
+  }
+};
+
+std::string configuration_name(const ::testing::TestParamInfo<SteeringConfiguration> & information)
+{
+  return information.param.name;
+}
+
+// cppcheck-suppress syntaxError
+// Cppcheck does not expand the GoogleTest parameterized-test macro.
+TEST_P(SteeringOdometryIntegratorTest, integrates_straight_from_nonzero_pose)
+{
+  steering_kinematics::SteeringKinematics odom(1);
+  configure(odom);
+  const Pose initial{-1.2, 0.7, 0.4};
+  odom.set_odometry(initial.x, initial.y, initial.heading);
+
+  constexpr double linear = 1.1;
+  constexpr double dt = 0.35;
+  odom.update_open_loop(linear, 0.0, dt);
+
+  expect_pose(odom, integrate_twist(initial, linear, 0.0, dt));
+  EXPECT_DOUBLE_EQ(odom.get_linear(), linear);
+  EXPECT_DOUBLE_EQ(odom.get_angular(), 0.0);
+}
+
+TEST_P(SteeringOdometryIntegratorTest, integrates_exact_arc_from_nonzero_pose)
+{
+  steering_kinematics::SteeringKinematics odom(1);
+  configure(odom);
+  const Pose initial{0.8, -0.45, -0.3};
+  odom.set_odometry(initial.x, initial.y, initial.heading);
+
+  constexpr double linear = 1.3;
+  constexpr double angular = -0.45;
+  constexpr double dt = 0.6;
+  odom.update_open_loop(linear, angular, dt);
+
+  expect_pose(odom, integrate_twist(initial, linear, angular, dt));
+  EXPECT_DOUBLE_EQ(odom.get_linear(), linear);
+  EXPECT_DOUBLE_EQ(odom.get_angular(), angular);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  SteeringConfigurations, SteeringOdometryIntegratorTest,
+  ::testing::Values(
+    SteeringConfiguration{steering_kinematics::BICYCLE_CONFIG, "Bicycle"},
+    SteeringConfiguration{steering_kinematics::TRICYCLE_CONFIG, "Tricycle"},
+    SteeringConfiguration{steering_kinematics::ACKERMANN_CONFIG, "Ackermann"}),
+  configuration_name);
+}  // namespace
 
 TEST(TestSteeringOdometry, initialize)
 {

--- a/steering_controllers_library/test/test_steering_odometry.cpp
+++ b/steering_controllers_library/test/test_steering_odometry.cpp
@@ -67,9 +67,20 @@ void expect_pose(const steering_kinematics::SteeringKinematics & odom, const Pos
 class SteeringOdometryIntegratorTest : public ::testing::TestWithParam<SteeringConfiguration>
 {
 protected:
-  void configure(steering_kinematics::SteeringKinematics & odom) const
+  void expect_open_loop(
+    const Pose & initial, const double linear, const double angular, const double dt) const
   {
+    SCOPED_TRACE(
+      ::testing::Message() << "initial=" << initial.x << "," << initial.y << "," << initial.heading
+                           << " twist=" << linear << "," << angular << " dt=" << dt);
+    steering_kinematics::SteeringKinematics odom(1);
     odom.set_odometry_type(GetParam().type);
+    odom.set_odometry(initial.x, initial.y, initial.heading);
+    odom.update_open_loop(linear, angular, dt);
+
+    expect_pose(odom, integrate_twist(initial, linear, angular, dt));
+    EXPECT_DOUBLE_EQ(odom.get_linear(), linear);
+    EXPECT_DOUBLE_EQ(odom.get_angular(), angular);
   }
 };
 
@@ -80,37 +91,21 @@ std::string configuration_name(const ::testing::TestParamInfo<SteeringConfigurat
 
 // cppcheck-suppress syntaxError
 // Cppcheck does not expand the GoogleTest parameterized-test macro.
-TEST_P(SteeringOdometryIntegratorTest, integrates_straight_from_nonzero_pose)
+TEST_P(SteeringOdometryIntegratorTest, integrates_open_loop_straight)
 {
-  steering_kinematics::SteeringKinematics odom(1);
-  configure(odom);
-  const Pose initial{-1.2, 0.7, 0.4};
-  odom.set_odometry(initial.x, initial.y, initial.heading);
-
-  constexpr double linear = 1.1;
-  constexpr double dt = 0.35;
-  odom.update_open_loop(linear, 0.0, dt);
-
-  expect_pose(odom, integrate_twist(initial, linear, 0.0, dt));
-  EXPECT_DOUBLE_EQ(odom.get_linear(), linear);
-  EXPECT_DOUBLE_EQ(odom.get_angular(), 0.0);
+  // Retain the former Ackermann-only zero-pose case and extend it to every configuration.
+  expect_open_loop(Pose{0.0, 0.0, 0.0}, 2.0, 0.0, 0.5);
+  expect_open_loop(Pose{-1.2, 0.7, 0.4}, 1.1, 0.0, 0.35);
 }
 
-TEST_P(SteeringOdometryIntegratorTest, integrates_exact_arc_from_nonzero_pose)
+TEST_P(SteeringOdometryIntegratorTest, integrates_open_loop_arcs)
 {
-  steering_kinematics::SteeringKinematics odom(1);
-  configure(odom);
-  const Pose initial{0.8, -0.45, -0.3};
-  odom.set_odometry(initial.x, initial.y, initial.heading);
-
-  constexpr double linear = 1.3;
-  constexpr double angular = -0.45;
-  constexpr double dt = 0.6;
-  odom.update_open_loop(linear, angular, dt);
-
-  expect_pose(odom, integrate_twist(initial, linear, angular, dt));
-  EXPECT_DOUBLE_EQ(odom.get_linear(), linear);
-  EXPECT_DOUBLE_EQ(odom.get_angular(), angular);
+  for (const double direction : {-1.0, 1.0})
+  {
+    // Retain both former Ackermann-only turn directions with a stronger exact-pose oracle.
+    expect_open_loop(Pose{0.0, 0.0, 0.0}, 1.0, direction, 1.0);
+    expect_open_loop(Pose{0.8, -0.45, -0.3}, 1.3, direction * 0.45, 0.6);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -146,42 +141,6 @@ TEST(TestSteeringOdometry, ackermann_odometry)
   EXPECT_NEAR(odom.get_angular(), .1, 1e-3);
   EXPECT_NEAR(odom.get_x(), .1, 1e-3);
   EXPECT_NEAR(odom.get_heading(), .01, 1e-3);
-}
-
-TEST(TestSteeringOdometry, ackermann_odometry_openloop_linear)
-{
-  steering_kinematics::SteeringKinematics odom(1);
-  odom.set_wheel_params(1., 2., 1.);
-  odom.set_odometry_type(steering_kinematics::ACKERMANN_CONFIG);
-  odom.update_open_loop(2., 0., 0.5);
-  EXPECT_DOUBLE_EQ(odom.get_linear(), 2.);
-  EXPECT_DOUBLE_EQ(odom.get_x(), 1.);
-  EXPECT_DOUBLE_EQ(odom.get_y(), 0.);
-}
-
-TEST(TestSteeringOdometry, ackermann_odometry_openloop_angular_left)
-{
-  steering_kinematics::SteeringKinematics odom(1);
-  odom.set_wheel_params(1., 2., 1.);
-  odom.set_odometry_type(steering_kinematics::ACKERMANN_CONFIG);
-  odom.update_open_loop(1., 1., 1.);
-  EXPECT_DOUBLE_EQ(odom.get_linear(), 1.);
-  EXPECT_DOUBLE_EQ(odom.get_angular(), 1.);
-
-  EXPECT_GT(odom.get_x(), 0);  // pos x
-  EXPECT_GT(odom.get_y(), 0);  // pos y, ie. left
-}
-
-TEST(TestSteeringOdometry, ackermann_odometry_openloop_angular_right)
-{
-  steering_kinematics::SteeringKinematics odom(1);
-  odom.set_wheel_params(1., 2., 1.);
-  odom.set_odometry_type(steering_kinematics::ACKERMANN_CONFIG);
-  odom.update_open_loop(1., -1., 1.);
-  EXPECT_DOUBLE_EQ(odom.get_linear(), 1.);
-  EXPECT_DOUBLE_EQ(odom.get_angular(), -1.);
-  EXPECT_GT(odom.get_x(), 0);  // pos x
-  EXPECT_LT(odom.get_y(), 0);  // neg y ie. right
 }
 
 TEST(TestSteeringOdometry, ackermann_IK_linear)

--- a/steering_controllers_library/test/test_steering_odometry.cpp
+++ b/steering_controllers_library/test/test_steering_odometry.cpp
@@ -41,7 +41,7 @@ struct Pose
 Pose integrate_twist(
   const Pose & initial, const double linear, const double angular, const double dt)
 {
-  if (std::abs(angular * dt) < 1e-6)
+  if (steering_kinematics::is_close_to_zero(angular * dt))
   {
     const double middle_heading = initial.heading + angular * dt * 0.5;
     return {


### PR DESCRIPTION
## Summary

- add closed-form pose expectations for the straight Runge-Kutta path
- add closed-form pose expectations for the nonzero-curvature exact path
- run the same assertions for bicycle, tricycle, and Ackermann configurations
- move the former Ackermann-only open-loop straight/left/right cases into the
  fixture, retaining their inputs while strengthening their pose assertions
- add nonzero-pose cases so heading-frame mistakes are observable

This is the first small piece of #930, split from the broader test proposal as
requested in the issue. Feedback-overload and state/error-path tests are left
for separate follow-up PRs.

## Validation

- full `steering_controllers_library` suite: 32/32 tests pass on ROS Rolling
- repository pre-commit suite passes for the changed file, including
  clang-format, cppcheck, cpplint, copyright, and codespell
- a temporary mutation halving the exact-turn radius made all three curved
  parameter rows fail; production source was then restored byte-for-byte
- test-only diff; no production or public API change

Part of #930.

Generated-by: OpenAI Codex (GPT-5; accessed 2026-08-17)
