### PR TITLE
feat: migrate diff_drive_controller and joint_trajectory_controller to new RealtimePublisher constructor

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp
@@ -118,13 +118,10 @@ protected:
   // Timeout to consider cmd_vel commands old
   rclcpp::Duration cmd_vel_timeout_ = rclcpp::Duration::from_seconds(0.5);
 
-  std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::Odometry>> odometry_publisher_ = nullptr;
   std::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::msg::Odometry>>
     realtime_odometry_publisher_ = nullptr;
   nav_msgs::msg::Odometry odometry_message_;
 
-  std::shared_ptr<rclcpp::Publisher<tf2_msgs::msg::TFMessage>> odometry_transform_publisher_ =
-    nullptr;
   std::shared_ptr<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>>
     realtime_odometry_transform_publisher_ = nullptr;
   tf2_msgs::msg::TFMessage odometry_transform_message_;
@@ -142,7 +139,6 @@ protected:
   std::unique_ptr<SpeedLimiter> limiter_linear_;
   std::unique_ptr<SpeedLimiter> limiter_angular_;
 
-  std::shared_ptr<rclcpp::Publisher<TwistStamped>> limited_velocity_publisher_ = nullptr;
   std::shared_ptr<realtime_tools::RealtimePublisher<TwistStamped>>
     realtime_limited_velocity_publisher_ = nullptr;
   TwistStamped limited_velocity_message_;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -417,11 +417,9 @@ controller_interface::CallbackReturn DiffDriveController::on_configure(
 
   if (params_.publish_limited_velocity)
   {
-    limited_velocity_publisher_ = get_node()->create_publisher<TwistStamped>(
-      DEFAULT_COMMAND_OUT_TOPIC, rclcpp::SystemDefaultsQoS());
     realtime_limited_velocity_publisher_ =
       std::make_shared<realtime_tools::RealtimePublisher<TwistStamped>>(
-        limited_velocity_publisher_);
+        get_node(), DEFAULT_COMMAND_OUT_TOPIC, rclcpp::SystemDefaultsQoS());
   }
 
   // initialize command subscriber
@@ -474,11 +472,9 @@ controller_interface::CallbackReturn DiffDriveController::on_configure(
   }
 
   // initialize odometry publisher and message
-  odometry_publisher_ = get_node()->create_publisher<nav_msgs::msg::Odometry>(
-    DEFAULT_ODOMETRY_TOPIC, rclcpp::SystemDefaultsQoS());
   realtime_odometry_publisher_ =
     std::make_shared<realtime_tools::RealtimePublisher<nav_msgs::msg::Odometry>>(
-      odometry_publisher_);
+      get_node(), DEFAULT_ODOMETRY_TOPIC, rclcpp::SystemDefaultsQoS());
 
   // resolve prefix: substitute tilde (~) with the namespace if contains and normalize slashes (/)
   std::string tf_prefix = "";
@@ -528,11 +524,9 @@ controller_interface::CallbackReturn DiffDriveController::on_configure(
   }
 
   // initialize transform publisher and message
-  odometry_transform_publisher_ = get_node()->create_publisher<tf2_msgs::msg::TFMessage>(
-    DEFAULT_TRANSFORM_TOPIC, rclcpp::SystemDefaultsQoS());
   realtime_odometry_transform_publisher_ =
     std::make_shared<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>>(
-      odometry_transform_publisher_);
+      get_node(), DEFAULT_TRANSFORM_TOPIC, rclcpp::SystemDefaultsQoS());
 
   // keeping track of odom and base_link transforms only
   odometry_transform_message_.transforms.resize(1);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -196,7 +196,6 @@ protected:
   using ControllerStateMsg = control_msgs::msg::JointTrajectoryControllerState;
   using StatePublisher = realtime_tools::RealtimePublisher<ControllerStateMsg>;
   using StatePublisherPtr = std::unique_ptr<StatePublisher>;
-  rclcpp::Publisher<ControllerStateMsg>::SharedPtr publisher_;
   StatePublisherPtr state_publisher_;
   ControllerStateMsg state_msg_;
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1028,9 +1028,8 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
       "~/joint_trajectory", rclcpp::SystemDefaultsQoS(),
       std::bind(&JointTrajectoryController::topic_callback, this, std::placeholders::_1));
 
-  publisher_ = get_node()->create_publisher<ControllerStateMsg>(
-    "~/controller_state", rclcpp::SystemDefaultsQoS());
-  state_publisher_ = std::make_unique<StatePublisher>(publisher_);
+  state_publisher_ =
+    std::make_unique<StatePublisher>(get_node(), "~/controller_state", rclcpp::SystemDefaultsQoS());
 
   state_msg_.joint_names = params_.joints;
   state_msg_.reference.positions.resize(dof_);


### PR DESCRIPTION
## Description

This PR migrates `diff_drive_controller` and `joint_trajectory_controller` to use the new `RealtimePublisher` constructor that creates publishers internally.

This simplifies using `RealtimePublisher` in the controllers by removing the need to manually instantiate and pass in `rclcpp::Publisher` objects, and removes redundant publisher member variables from the classes.

Note: This is the initial subset of controllers migrated.
Depends on https://github.com/ros-controls/realtime_tools/pull/573

## Is this user-facing behavior change?

No.

## Did you use Generative AI?

No.

## Additional Information

Verified locally that the pre-commit checks run and pass successfully.