### PR TITLE
Setting command interfaces to 0 instead of NaN on deactivate (mecanum_drive_controller)

### DIFF
--- a/mecanum_drive_controller/src/mecanum_drive_controller.cpp
+++ b/mecanum_drive_controller/src/mecanum_drive_controller.cpp
@@ -418,8 +418,7 @@ controller_interface::CallbackReturn MecanumDriveController::on_deactivate(
   bool value_set_no_error = true;
   for (size_t i = 0; i < NR_CMD_ITFS; ++i)
   {
-    value_set_no_error &=
-      command_interfaces_[i].set_value(std::numeric_limits<double>::quiet_NaN());
+    value_set_no_error &= command_interfaces_[i].set_value(0.0);
   }
   if (!value_set_no_error)
   {

--- a/mecanum_drive_controller/test/test_mecanum_drive_controller.cpp
+++ b/mecanum_drive_controller/test/test_mecanum_drive_controller.cpp
@@ -313,9 +313,9 @@ TEST_F(
   ASSERT_TRUE(activate_succeeds(controller_));
   ASSERT_EQ(controller_->command_interfaces_[NR_CMD_ITFS - 4].get_optional().value(), 101.101);
   ASSERT_TRUE(deactivate_succeeds(controller_));
-  ASSERT_TRUE(std::isnan(controller_->command_interfaces_[NR_CMD_ITFS - 4].get_optional().value()));
+  ASSERT_EQ(controller_->command_interfaces_[NR_CMD_ITFS - 4].get_optional().value(), 0.0);
   ASSERT_TRUE(activate_succeeds(controller_));
-  ASSERT_TRUE(std::isnan(controller_->command_interfaces_[NR_CMD_ITFS - 4].get_optional().value()));
+  ASSERT_EQ(controller_->command_interfaces_[NR_CMD_ITFS - 4].get_optional().value(), 0.0);
 
   ASSERT_EQ(
     controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

On the mecanum_drive_controller, on deactivate, the controller sets the command interfaces to `std::numeric_limits<double>::quiet_NaN()`. On at least one HWI (clearpath ridgeback), this results in commands being sent to the motors that run at full speed. On a different version of this controller provided by clearpath (which seems like it might have been a fork of an earlier version of this controller), [this same change](https://github.com/clearpathrobotics/clearpath_mecanum_drive_controller/pull/4/changes) was made by [my suggestion](https://github.com/clearpathrobotics/clearpath_mecanum_drive_controller/issues/3) and it resolved this issue. 

### Is this user-facing behavior change?

Hopefully should make robots more safe, but if some HWI was relying on this value being NaN, then could change behavior.

### Did you use Generative AI?

No

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
