### PR TITLE
Add controller interface dependencies

### DIFF
--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -6,6 +6,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  controller_interface
   forward_command_controller
   pluginlib
   rclcpp

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -20,6 +20,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>backward_ros</depend>
+  <depend>controller_interface</depend>
   <depend>forward_command_controller</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/position_controllers/CMakeLists.txt
+++ b/position_controllers/CMakeLists.txt
@@ -6,6 +6,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  controller_interface
   forward_command_controller
   pluginlib
   rclcpp

--- a/position_controllers/package.xml
+++ b/position_controllers/package.xml
@@ -20,6 +20,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>backward_ros</depend>
+  <depend>controller_interface</depend>
   <depend>forward_command_controller</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/velocity_controllers/CMakeLists.txt
+++ b/velocity_controllers/CMakeLists.txt
@@ -6,6 +6,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  controller_interface
   forward_command_controller
   pluginlib
   rclcpp

--- a/velocity_controllers/package.xml
+++ b/velocity_controllers/package.xml
@@ -20,6 +20,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>backward_ros</depend>
+  <depend>controller_interface</depend>
   <depend>forward_command_controller</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
This PR adds the missing direct `controller_interface` dependency to `effort_controllers`, `position_controllers`, and `velocity_controllers`.

All three packages use `controller_interface` in production source code for `CallbackReturn` and `ControllerInterface` plugin registration, but the dependency was not declared in their package manifests or CMake dependency lists. It was available transitively through existing controller dependencies.

Changes:

- Add `<depend>controller_interface</depend>` to the three `package.xml` files.
- Add `controller_interface` to `THIS_PACKAGE_INCLUDE_DEPENDS` in the three `CMakeLists.txt` files.
