### PR TITLE
Fix/jtc cancel anchor scoped

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -272,14 +272,31 @@ protected:
 
   void preempt_active_goal();
 
-  /** @brief set the current position with zero velocity and acceleration as new command
+  /** @brief pick the point a stop or hold should be anchored to
+   *
+   * Returns last_commanded_state_ when @p from_last_command is set and it holds a usable
+   * position, otherwise the measured state.
    */
-  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> set_hold_position();
+  const trajectory_msgs::msg::JointTrajectoryPoint & select_hold_anchor(
+    bool from_last_command) const;
+
+  /** @brief set the current position with zero velocity and acceleration as new command
+   *
+   * @param from_last_command anchor the hold to the last commanded position instead of the
+   * measured one, keeping the command stream continuous across the transition. Only meaningful
+   * where the robot is still tracking; a fault path wants the measured state.
+   */
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> set_hold_position(
+    bool from_last_command = false);
 
   /** @brief decelerate at constant rate to a holding position with
    * zero velocity and acceleration as new command
+   *
+   * @param from_last_command anchor the ramp to the last commanded point instead of the measured
+   * one. See set_hold_position().
    */
-  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> decelerate_to_hold_position();
+  std::shared_ptr<trajectory_msgs::msg::JointTrajectory> decelerate_to_hold_position(
+    bool from_last_command = false);
 
   /** @brief set last trajectory point to be repeated at success
    *

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1543,15 +1543,17 @@ rclcpp_action::CancelResponse JointTrajectoryController::goal_cancelled_callback
     active_goal->setCanceled(action_res);
     rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
 
+    // The robot was tracking when the cancel arrived, so anchor the stop to the last commanded
+    // point to keep the command stream continuous. Fault paths deliberately do not do this.
     if (should_decelerate_on_cancel_)
     {
       // calculate stopping position based on max deceleration
-      add_new_trajectory_msg(decelerate_to_hold_position());
+      add_new_trajectory_msg(decelerate_to_hold_position(true));
     }
     else
     {
-      // hold current position
-      add_new_trajectory_msg(set_hold_position());
+      // hold last commanded position
+      add_new_trajectory_msg(set_hold_position(true));
     }
   }
   return rclcpp_action::CancelResponse::ACCEPT;
@@ -2133,12 +2135,30 @@ void JointTrajectoryController::preempt_active_goal()
   }
 }
 
+const trajectory_msgs::msg::JointTrajectoryPoint & JointTrajectoryController::select_hold_anchor(
+  const bool from_last_command) const
+{
+  // state_current_ is feedback and lags the command by the following error. Anchoring a stop to it
+  // steps the command stream back by that error in one cycle, which downstream reads as a huge
+  // acceleration. last_commanded_state_ is what was last written, so it keeps the stream continuous.
+  if (
+    from_last_command && last_commanded_state_.positions.size() >= num_cmd_joints_ &&
+    std::all_of(
+      last_commanded_state_.positions.cbegin(),
+      last_commanded_state_.positions.cbegin() + static_cast<std::ptrdiff_t>(num_cmd_joints_),
+      [](double x) { return std::isfinite(x); }))
+  {
+    return last_commanded_state_;
+  }
+  return state_current_;
+}
+
 std::shared_ptr<trajectory_msgs::msg::JointTrajectory>
-JointTrajectoryController::set_hold_position()
+JointTrajectoryController::set_hold_position(const bool from_last_command)
 {
   // Command to stay at current position. Never latch a non-finite position -- it would be written
   // straight to the command interfaces; keep the previous target for those joints instead.
-  const auto & source = state_current_.positions;
+  const auto & source = select_hold_anchor(from_last_command).positions;
   auto & hold = hold_position_msg_ptr_->points[0].positions;
   if (hold.size() != source.size())
   {
@@ -2170,11 +2190,14 @@ JointTrajectoryController::set_hold_position()
 }
 
 std::shared_ptr<trajectory_msgs::msg::JointTrajectory>
-JointTrajectoryController::decelerate_to_hold_position()
+JointTrajectoryController::decelerate_to_hold_position(const bool from_last_command)
 {
   double max_t_stop = 0.0;
-  const auto & p0 = state_current_.positions;
-  const auto & v0 = state_current_.velocities;
+  // Take p0 and v0 from the same point: a commanded p0 with a measured v0 leaves a slope
+  // discontinuity at the join, which is the same defect one derivative up.
+  const auto & anchor = select_hold_anchor(from_last_command);
+  const auto & p0 = anchor.positions;
+  const auto & v0 = anchor.velocities;
 
   // A hardware component can export a state interface and never write it, leaving NaN in the
   // handle. NaN would propagate silently: std::max(0.0, NaN) is 0.0, so max_t_stop stays finite,
@@ -2190,9 +2213,9 @@ JointTrajectoryController::decelerate_to_hold_position()
   {
     RCLCPP_ERROR_THROTTLE(
       get_node()->get_logger(), *get_node()->get_clock(), 1000,
-      "Cannot compute a deceleration ramp: the measured state contains non-finite values. Does "
-      "the hardware write to every state interface it exports? Holding position instead.");
-    return set_hold_position();
+      "Cannot compute a deceleration ramp: the state it would start from contains non-finite "
+      "values. Does the hardware write to every state interface it exports? Holding instead.");
+    return set_hold_position(from_last_command);
   }
 
   for (size_t i = 0; i < num_cmd_joints_; ++i)

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -14,7 +14,9 @@
 
 #include "joint_trajectory_controller/joint_trajectory_controller.hpp"
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <numeric>
@@ -2134,8 +2136,32 @@ void JointTrajectoryController::preempt_active_goal()
 std::shared_ptr<trajectory_msgs::msg::JointTrajectory>
 JointTrajectoryController::set_hold_position()
 {
-  // Command to stay at current position
-  hold_position_msg_ptr_->points[0].positions = state_current_.positions;
+  // Command to stay at current position. Never latch a non-finite position -- it would be written
+  // straight to the command interfaces; keep the previous target for those joints instead.
+  const auto & source = state_current_.positions;
+  auto & hold = hold_position_msg_ptr_->points[0].positions;
+  if (hold.size() != source.size())
+  {
+    hold.assign(source.size(), std::numeric_limits<double>::quiet_NaN());
+  }
+  bool all_finite = true;
+  for (size_t i = 0; i < source.size(); ++i)
+  {
+    if (std::isfinite(source[i]))
+    {
+      hold[i] = source[i];
+    }
+    else
+    {
+      all_finite = false;
+    }
+  }
+  if (!all_finite)
+  {
+    RCLCPP_ERROR_THROTTLE(
+      get_node()->get_logger(), *get_node()->get_clock(), 1000,
+      "Measured position contains non-finite values; holding the last valid target instead.");
+  }
 
   // set flag, otherwise tolerances will be checked with holding position too
   rt_is_holding_ = true;
@@ -2149,6 +2175,26 @@ JointTrajectoryController::decelerate_to_hold_position()
   double max_t_stop = 0.0;
   const auto & p0 = state_current_.positions;
   const auto & v0 = state_current_.velocities;
+
+  // A hardware component can export a state interface and never write it, leaving NaN in the
+  // handle. NaN would propagate silently: std::max(0.0, NaN) is 0.0, so max_t_stop stays finite,
+  // every `t < stop_time_[i]` is false, and the whole ramp fills with a NaN hold position.
+  const auto finite_prefix = [this](const std::vector<double> & v)
+  {
+    return v.size() >= num_cmd_joints_ &&
+           std::all_of(
+             v.cbegin(), v.cbegin() + static_cast<std::ptrdiff_t>(num_cmd_joints_),
+             [](double x) { return std::isfinite(x); });
+  };
+  if (!finite_prefix(p0) || !finite_prefix(v0))
+  {
+    RCLCPP_ERROR_THROTTLE(
+      get_node()->get_logger(), *get_node()->get_clock(), 1000,
+      "Cannot compute a deceleration ramp: the measured state contains non-finite values. Does "
+      "the hardware write to every state interface it exports? Holding position instead.");
+    return set_hold_position();
+  }
+
   for (size_t i = 0; i < num_cmd_joints_; ++i)
   {
     stop_direction_[i] = (v0[i] >= 0.0) ? 1.0 : -1.0;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdio>
 #include <functional>
 #include <memory>
 #include <numeric>
@@ -2164,23 +2165,36 @@ JointTrajectoryController::set_hold_position(const bool from_last_command)
   {
     hold.assign(source.size(), std::numeric_limits<double>::quiet_NaN());
   }
-  bool all_finite = true;
+  // Name the offending joints in the single throttled message below rather than logging per joint:
+  // the throttle state is a function-local static, so a throttled log inside this loop would be
+  // shared across iterations and report only one joint per interval.
+  char offenders[256];
+  size_t offenders_len = 0;
   for (size_t i = 0; i < source.size(); ++i)
   {
     if (std::isfinite(source[i]))
     {
       hold[i] = source[i];
+      continue;
     }
-    else
+    if (offenders_len < sizeof(offenders) - 1)
     {
-      all_finite = false;
+      const int written = snprintf(
+        offenders + offenders_len, sizeof(offenders) - offenders_len, "%s%s",
+        (offenders_len > 0) ? ", " : "", params_.joints[i].c_str());
+      offenders_len = (written > 0) ? std::min(
+                                        offenders_len + static_cast<size_t>(written),
+                                        sizeof(offenders) - 1)
+                                    : sizeof(offenders) - 1;
     }
   }
-  if (!all_finite)
+  if (offenders_len > 0)
   {
     RCLCPP_ERROR_THROTTLE(
       get_node()->get_logger(), *get_node()->get_clock(), 1000,
-      "Measured position contains non-finite values; holding the last valid target instead.");
+      "Non-finite position reported for joint(s) [%s]; holding the last valid target for them "
+      "instead. Does the hardware write to every state interface it exports?",
+      offenders);
   }
 
   // set flag, otherwise tolerances will be checked with holding position too
@@ -2209,12 +2223,16 @@ JointTrajectoryController::decelerate_to_hold_position(const bool from_last_comm
              v.cbegin(), v.cbegin() + static_cast<std::ptrdiff_t>(num_cmd_joints_),
              [](double x) { return std::isfinite(x); });
   };
-  if (!finite_prefix(p0) || !finite_prefix(v0))
+  const bool positions_ok = finite_prefix(p0);
+  const bool velocities_ok = finite_prefix(v0);
+  if (!positions_ok || !velocities_ok)
   {
     RCLCPP_ERROR_THROTTLE(
       get_node()->get_logger(), *get_node()->get_clock(), 1000,
-      "Cannot compute a deceleration ramp: the state it would start from contains non-finite "
-      "values. Does the hardware write to every state interface it exports? Holding instead.");
+      "Cannot compute a deceleration ramp: %s non-finite or wrongly sized. Does the hardware "
+      "write to every state interface it exports? Holding position instead.",
+      (!positions_ok && !velocities_ok) ? "positions and velocities are"
+                                        : (!positions_ok ? "positions are" : "velocities are"));
     return set_hold_position(from_last_command);
   }
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -2141,7 +2141,8 @@ const trajectory_msgs::msg::JointTrajectoryPoint & JointTrajectoryController::se
 {
   // state_current_ is feedback and lags the command by the following error. Anchoring a stop to it
   // steps the command stream back by that error in one cycle, which downstream reads as a huge
-  // acceleration. last_commanded_state_ is what was last written, so it keeps the stream continuous.
+  // acceleration. last_commanded_state_ is what was last written, so it keeps the stream
+  // continuous.
   if (
     from_last_command && last_commanded_state_.positions.size() >= num_cmd_joints_ &&
     std::all_of(
@@ -2154,8 +2155,8 @@ const trajectory_msgs::msg::JointTrajectoryPoint & JointTrajectoryController::se
   return state_current_;
 }
 
-std::shared_ptr<trajectory_msgs::msg::JointTrajectory>
-JointTrajectoryController::set_hold_position(const bool from_last_command)
+std::shared_ptr<trajectory_msgs::msg::JointTrajectory> JointTrajectoryController::set_hold_position(
+  const bool from_last_command)
 {
   // Command to stay at current position. Never latch a non-finite position -- it would be written
   // straight to the command interfaces; keep the previous target for those joints instead.
@@ -2182,10 +2183,10 @@ JointTrajectoryController::set_hold_position(const bool from_last_command)
       const int written = snprintf(
         offenders + offenders_len, sizeof(offenders) - offenders_len, "%s%s",
         (offenders_len > 0) ? ", " : "", params_.joints[i].c_str());
-      offenders_len = (written > 0) ? std::min(
-                                        offenders_len + static_cast<size_t>(written),
-                                        sizeof(offenders) - 1)
-                                    : sizeof(offenders) - 1;
+      offenders_len =
+        (written > 0)
+          ? std::min(offenders_len + static_cast<size_t>(written), sizeof(offenders) - 1)
+          : sizeof(offenders) - 1;
     }
   }
   if (offenders_len > 0)

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -1157,6 +1157,65 @@ TEST_P(TestTrajectoryActionsTestParameterized, test_cancel_decelerate_fallback)
   expectCommandPoint(cancelled_position);
 }
 
+/**
+ * @brief Cancelling must not step the command stream back onto the measured state.
+ *
+ * With separate command and state values the state stays frozen at INITIAL_POS_JOINTS while the
+ * command advances, i.e. a permanent following error. Anchoring the hold to the measured state
+ * would snap the commanded position back by that error in a single control period, which
+ * downstream reads as a very large acceleration. The hold must stay where the command was.
+ */
+TEST_P(TestTrajectoryActionsTestParameterized, test_cancel_holds_last_command_not_measured_state)
+{
+  // the defect and the fix are both about the position command stream. Skip before any setup:
+  // tearing down an executor for a test we never run is slow and flaky.
+  if (
+    std::find(command_interface_types_.begin(), command_interface_types_.end(), "position") ==
+    command_interface_types_.end())
+  {
+    GTEST_SKIP() << "no position command interface in this parameterization";
+  }
+
+  SetUpExecutor({}, true);
+  SetUpControllerHardware();
+
+  std::shared_future<typename GoalHandle::SharedPtr> gh_future;
+  {
+    std::vector<JointTrajectoryPoint> points;
+    JointTrajectoryPoint point;
+    point.time_from_start = rclcpp::Duration::from_seconds(1.0);
+    point.positions.resize(joint_names_.size());
+
+    point.positions[0] = 4.0;
+    point.positions[1] = 5.0;
+    point.positions[2] = 6.0;
+    points.push_back(point);
+
+    control_msgs::action::FollowJointTrajectory_Goal goal_msg;
+    goal_msg.goal_time_tolerance = rclcpp::Duration::from_seconds(2.0);
+    goal_msg.trajectory.joint_names = joint_names_;
+    goal_msg.trajectory.points = points;
+
+    // let the command move away from the frozen state, then cancel mid-trajectory
+    gh_future = action_client_->async_send_goal(goal_msg, goal_options_);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    const auto goal_handle = gh_future.get();
+    action_client_->async_cancel_goal(goal_handle);
+  }
+  controller_hw_thread_.join();
+
+  EXPECT_EQ(rclcpp_action::ResultCode::CANCELED, common_resultcode_);
+
+  for (size_t i = 0; i < 3; ++i)
+  {
+    const double commanded = pos_cmd_interfaces_[i]->get_optional().value();
+    // the measured state never moved, so a measured-anchored hold would land exactly here
+    EXPECT_GT(commanded, INITIAL_POS_JOINTS[i] + 0.1)
+      << "joint " << i << " snapped back toward the measured state on cancel";
+  }
+}
+
 TEST_P(TestTrajectoryActionsTestParameterized, test_allow_nonzero_velocity_at_trajectory_end_true)
 {
   std::vector<rclcpp::Parameter> params = {

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -3328,6 +3328,55 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_fallback_no_velocit
 }
 
 /**
+ * @brief A hardware component may export a velocity state interface and never write to it,
+ * leaving NaN in the handle. The deceleration ramp must not propagate that to the command
+ * interfaces: NaN is invisible to the ramp arithmetic (std::max(0.0, NaN) == 0.0, and every
+ * `t < stop_time` comparison is false), so without a guard every point of the stop trajectory
+ * is filled with a NaN hold position and written to the hardware.
+ */
+TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_nan_velocity_state_commands_no_nan)
+{
+  rclcpp::executors::MultiThreadedExecutor executor;
+  constexpr double cmd_timeout = 0.1;
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const std::vector<double> nan_vel = {nan, nan, nan};
+
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("cmd_timeout", cmd_timeout),
+    rclcpp::Parameter("constraints.joint1.max_deceleration_on_cancel", 10.0),
+    rclcpp::Parameter("constraints.joint2.max_deceleration_on_cancel", 10.0),
+    rclcpp::Parameter("constraints.joint3.max_deceleration_on_cancel", 10.0),
+    rclcpp::Parameter("constraints.decelerate_on_cancel", true)};
+
+  // velocity state interface exists but reads back NaN, as if the hardware never wrote it
+  SetUpAndActivateTrajectoryController(
+    executor, params, false, 0.0, 1.0, INITIAL_POS_JOINTS, nan_vel);
+
+  ASSERT_TRUE(traj_controller_->has_velocity_state_interface());
+
+  constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(250);
+  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(FIRST_POINT_TIME)};
+  std::vector<std::vector<double>> points{{INITIAL_POS_JOINTS}};
+  publish(time_from_start, points, rclcpp::Time(0, 0, RCL_STEADY_TIME));
+  traj_controller_->wait_for_trajectory(executor);
+
+  updateController(rclcpp::Duration(FIRST_POINT_TIME));
+  updateController(rclcpp::Duration::from_seconds(cmd_timeout + 0.05));
+  updateController(rclcpp::Duration::from_seconds(0.1));
+
+  // Whatever path was taken, no NaN may reach the position command interfaces
+  for (size_t i = 0; i < 3; ++i)
+  {
+    const auto commanded = pos_cmd_interfaces_[i]->get_optional();
+    ASSERT_TRUE(commanded.has_value());
+    EXPECT_TRUE(std::isfinite(commanded.value()))
+      << "joint " << i << " was commanded a non-finite position: " << commanded.value();
+  }
+
+  executor.cancel();
+}
+
+/**
  * @brief When max_deceleration_on_cancel is 0.0 (the default) for any joint, the
  * controller disables should_decelerate_on_cancel_ internally during configure and falls back
  * to set_hold_position on timeout.


### PR DESCRIPTION
On cancel, JTC anchors its stop to `state_current_` (feedback), but the command stream is at `command_next_`. On any robot with a following error the commanded position steps backwards by exactly that error in one control period. Measured on a KUKA LBR iisy 15 R930 over RSI at 250 Hz: a −0.005568 rad step on j2 against a −0.005597 tracking error — −397 rad/s² over one 4 ms cycle, ~300× the joint's 1.32 limit. The KRC rejects the setpoint and drops the drives. Not tunable: `max_deceleration_on_cancel` and scaling shape the ramp after the join, not the step at it. `decelerate_on_cancel: false` fails identically.

## Changes
1. Don't command NaN when a state interface is exported but never written — NaN propagates silently (`std::max(0.0, NaN)` is 0.0) and fills the whole stop trajectory. Pre-existing, independent.
2. Anchor the stop to the last command **on the cancel path only**. The five fault paths and `on_activate` keep the measured state: after a tolerance violation the robot has demonstrably failed to track, so latching an unreachable command would sustain the error.
3. Name the offending joints in the diagnostics.
## Testing
A regression test per fix, each verified to fail without the change. Full JTC suite passes.