### PR TITLE
[JTC] Redefine constraints.goal_time semantics and default to 10s

### DIFF
--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -19,6 +19,14 @@ effort_controllers
 *****************************
 * ``effort_controllers/JointGroupEffortController`` is deprecated. Use :ref:`forward_command_controller <forward_command_controller_userdoc>` instead by adding the ``interface_name`` parameter and set it to ``effort``. (`#1913 <https://github.com/ros-controls/ros2_controllers/pull/1913>`_).
 
+joint_trajectory_controller
+*****************************
+* The default value of the ``constraints.goal_time`` parameter changed from ``0.0`` to ``10.0`` seconds and its semantics changed.
+  Previously ``goal_time`` of ``0.0`` meant that the controller would wait a potentially infinite amount of time for the goal to be reached.
+  Now, any **negative** ``goal_time`` (e.g. ``-1.0``) means the controller will wait indefinitely, while ``0.0`` disables the grace period so the goal must be reached on time, and positive values set a finite grace period in seconds.
+  Configurations that relied on the old default or on ``goal_time: 0.0`` for an infinite timeout must set ``constraints.goal_time`` to a negative value (e.g. ``-1.0``) explicitly.
+  Note that ``cmd_timeout`` only activates when ``cmd_timeout > constraints.goal_time``; with the new default timeout feature setups relying on ``cmd_timeout`` (e.g. to hold position at the end of the trajectory) must set ``constraints.goal_time`` accordingly.
+
 position_controllers
 *****************************
 * ``position_controllers/JointGroupPositionController`` is deprecated. Use :ref:`forward_command_controller <forward_command_controller_userdoc>` instead by adding the ``interface_name`` parameter and set it to ``position``. (`#1913 <https://github.com/ros-controls/ros2_controllers/pull/1913>`_).

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -26,6 +26,7 @@ joint_trajectory_controller
   Now, any **negative** ``goal_time`` (e.g. ``-1.0``) means the controller will wait indefinitely, while ``0.0`` disables the grace period so the goal must be reached on time, and positive values set a finite grace period in seconds.
   Configurations that relied on the old default or on ``goal_time: 0.0`` for an infinite timeout must set ``constraints.goal_time`` to a negative value (e.g. ``-1.0``) explicitly.
   Note that ``cmd_timeout`` only activates when ``cmd_timeout > constraints.goal_time``; with the new default timeout feature setups relying on ``cmd_timeout`` (e.g. to hold position at the end of the trajectory) must set ``constraints.goal_time`` accordingly.
+  The ``action_execution_timeout`` parameter is removed.
 
 position_controllers
 *****************************

--- a/joint_trajectory_controller/doc/decelerate_on_cancel.rst
+++ b/joint_trajectory_controller/doc/decelerate_on_cancel.rst
@@ -66,7 +66,7 @@ Enable the feature by setting ``constraints.decelerate_on_cancel`` to ``true`` a
        constraints:
          decelerate_on_cancel: true
          stopped_velocity_tolerance: 0.01
-         goal_time: 0.0
+         goal_time: 10.0
          joint_1:
            max_deceleration_on_cancel: 10.0
          joint_2:

--- a/joint_trajectory_controller/doc/userdoc.rst
+++ b/joint_trajectory_controller/doc/userdoc.rst
@@ -105,7 +105,7 @@ A yaml file for using it could be:
           interpolate_from_desired_state: true
           constraints:
             stopped_velocity_tolerance: 0.01
-            goal_time: 0.0
+            goal_time: 10.0
             joint1:
               trajectory: 0.05
               goal: 0.03

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -79,7 +79,7 @@ struct SegmentTolerances
  *
  * \code
  * constraints:
- *  goal_time: 1.0                   # Defaults to zero
+ *  goal_time: 1.0                   # Defaults to 10.0, negative waits indefinitely
  *  stopped_velocity_tolerance: 0.02 # Defaults to 0.01
  *  foo_joint:
  *    trajectory: 0.05               # Defaults to zero (ie. the tolerance is not enforced)

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.hpp
@@ -98,7 +98,9 @@ SegmentTolerances get_segment_tolerances(rclcpp::Logger & jtc_logger, const Para
   auto const n_joints = params.joints.size();
 
   SegmentTolerances tolerances;
-  tolerances.goal_time_tolerance = constraints.goal_time;
+  // Negative goal_time means wait indefinitely for the goal to be reached
+  tolerances.goal_time_tolerance =
+    constraints.goal_time < 0.0 ? std::numeric_limits<double>::infinity() : constraints.goal_time;
   static auto logger = jtc_logger.get_child("tolerance");
   RCLCPP_DEBUG(logger, "goal_time %f", constraints.goal_time);
 

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -15,6 +15,7 @@
 #include "joint_trajectory_controller/joint_trajectory_controller.hpp"
 
 #include <chrono>
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <numeric>
@@ -409,7 +410,7 @@ controller_interface::return_type JointTrajectoryController::update(
         {
           outside_goal_tolerance = true;
 
-          if (active_tol->goal_time_tolerance != 0.0)
+          if (std::isfinite(active_tol->goal_time_tolerance))
           {
             // if we exceed goal_time_tolerance set it to aborted
             if (time_difference > active_tol->goal_time_tolerance)

--- a/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
+++ b/joint_trajectory_controller/src/joint_trajectory_controller_parameters.yaml
@@ -237,12 +237,11 @@ joint_trajectory_controller:
     }
     goal_time: {
       type: double,
-      default_value: 0.0,
+      default_value: 10.0,
       description: "Time tolerance for achieving trajectory goal before or after commanded time.
-        If set to zero, the controller will wait a potentially infinite amount of time.",
-      validation: {
-        gt_eq: [0.0],
-      }
+        Positive values set a finite grace period in seconds.
+        If set to a negative value, the controller will wait a potentially infinite amount of time.
+        If set to zero, no grace period is allowed, the goal must be reached on time.",
     }
     decelerate_on_cancel: {
       type: bool,

--- a/joint_trajectory_controller/test/test_tolerances.cpp
+++ b/joint_trajectory_controller/test/test_tolerances.cpp
@@ -80,6 +80,29 @@ protected:
   }
 };
 
+TEST_F(TestTolerancesFixture, test_goal_time_from_parameters)
+{
+  for (const auto & joint : joint_names_)
+  {
+    params.constraints.joints_map[joint] = {};
+  }
+
+  params.constraints.goal_time = 5.0;
+  auto active_tolerances = joint_trajectory_controller::get_segment_tolerances(logger, params);
+  EXPECT_DOUBLE_EQ(active_tolerances.goal_time_tolerance, 5.0);
+  EXPECT_TRUE(std::isfinite(active_tolerances.goal_time_tolerance));
+
+  params.constraints.goal_time = 0.0;
+  active_tolerances = joint_trajectory_controller::get_segment_tolerances(logger, params);
+  EXPECT_DOUBLE_EQ(active_tolerances.goal_time_tolerance, 0.0);
+  EXPECT_TRUE(std::isfinite(active_tolerances.goal_time_tolerance));
+
+  params.constraints.goal_time = -1.0;
+  active_tolerances = joint_trajectory_controller::get_segment_tolerances(logger, params);
+  EXPECT_TRUE(std::isinf(active_tolerances.goal_time_tolerance));
+  EXPECT_GT(active_tolerances.goal_time_tolerance, 0.0);
+}
+
 TEST_F(TestTolerancesFixture, test_get_segment_tolerances)
 {
   // send goal with nonzero tolerances, are they accepted?

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -547,7 +547,7 @@ TEST_P(TrajectoryControllerTestParameterized, update_dynamic_tolerances)
   // test default parameters
   {
     auto tols = traj_controller_->get_tolerances();
-    EXPECT_EQ(tols.goal_time_tolerance, 0.0);
+    EXPECT_EQ(tols.goal_time_tolerance, 10.0);
     for (size_t i = 0; i < joint_names_.size(); ++i)
     {
       EXPECT_EQ(tols.state_tolerance.at(i).position, 0.0);
@@ -1374,8 +1374,11 @@ TEST_P(TrajectoryControllerTestParameterized, timeout)
   rclcpp::executors::MultiThreadedExecutor executor;
   constexpr double cmd_timeout = 0.1;
   rclcpp::Parameter cmd_timeout_parameter("cmd_timeout", cmd_timeout);
+  // timeout only activates when cmd_timeout > constraints.goal_time
+  rclcpp::Parameter goal_time_parameter("constraints.goal_time", 0.001);
   double kp = 1.0;  // activate feedback control for testing velocity/effort PID
-  SetUpAndActivateTrajectoryController(executor, {cmd_timeout_parameter}, false, kp);
+  SetUpAndActivateTrajectoryController(
+    executor, {cmd_timeout_parameter, goal_time_parameter}, false, kp);
 
   // send msg
   constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(250);
@@ -3299,6 +3302,8 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_fallback_no_velocit
   constexpr double cmd_timeout = 0.1;
   std::vector<rclcpp::Parameter> params = {
     rclcpp::Parameter("cmd_timeout", cmd_timeout),
+    // timeout only activates when cmd_timeout > constraints.goal_time
+    rclcpp::Parameter("constraints.goal_time", 0.001),
     rclcpp::Parameter("constraints.joint1.max_deceleration_on_cancel", 10.0),
     rclcpp::Parameter("constraints.joint2.max_deceleration_on_cancel", 10.0),
     rclcpp::Parameter("constraints.joint3.max_deceleration_on_cancel", 10.0),
@@ -3340,6 +3345,8 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_fallback_zero_max_d
   // -> controller disables should_decelerate_on_cancel_ and falls back to set_hold_position
   std::vector<rclcpp::Parameter> params = {
     rclcpp::Parameter("cmd_timeout", cmd_timeout),
+    // timeout only activates when cmd_timeout > constraints.goal_time
+    rclcpp::Parameter("constraints.goal_time", 0.001),
     rclcpp::Parameter("constraints.decelerate_on_cancel", true)};
 
   SetUpAndActivateTrajectoryController(executor, params);
@@ -3383,6 +3390,8 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_positive_velocity)
 
   std::vector<rclcpp::Parameter> params = {
     rclcpp::Parameter("cmd_timeout", cmd_timeout),
+    // timeout only activates when cmd_timeout > constraints.goal_time
+    rclcpp::Parameter("constraints.goal_time", 0.001),
     rclcpp::Parameter("constraints.joint1.max_deceleration_on_cancel", max_decel),
     rclcpp::Parameter("constraints.joint2.max_deceleration_on_cancel", max_decel),
     rclcpp::Parameter("constraints.joint3.max_deceleration_on_cancel", max_decel),
@@ -3441,6 +3450,8 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_negative_velocity)
 
   std::vector<rclcpp::Parameter> params = {
     rclcpp::Parameter("cmd_timeout", cmd_timeout),
+    // timeout only activates when cmd_timeout > constraints.goal_time
+    rclcpp::Parameter("constraints.goal_time", 0.001),
     rclcpp::Parameter("constraints.joint1.max_deceleration_on_cancel", max_decel),
     rclcpp::Parameter("constraints.joint2.max_deceleration_on_cancel", max_decel),
     rclcpp::Parameter("constraints.joint3.max_deceleration_on_cancel", max_decel),
@@ -3493,6 +3504,8 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_per_joint_calculati
 
   std::vector<rclcpp::Parameter> params = {
     rclcpp::Parameter("cmd_timeout", cmd_timeout),
+    // timeout only activates when cmd_timeout > constraints.goal_time
+    rclcpp::Parameter("constraints.goal_time", 0.001),
     rclcpp::Parameter("constraints.joint1.max_deceleration_on_cancel", max_decel),
     rclcpp::Parameter("constraints.joint2.max_deceleration_on_cancel", max_decel),
     rclcpp::Parameter("constraints.joint3.max_deceleration_on_cancel", max_decel),
@@ -3555,6 +3568,8 @@ TEST_F(TrajectoryControllerTest, decelerate_to_hold_position_velocity_command_ra
 
   std::vector<rclcpp::Parameter> params = {
     rclcpp::Parameter("cmd_timeout", cmd_timeout),
+    // timeout only activates when cmd_timeout > constraints.goal_time
+    rclcpp::Parameter("constraints.goal_time", 0.001),
     rclcpp::Parameter("constraints.joint1.max_deceleration_on_cancel", max_decel),
     rclcpp::Parameter("constraints.joint2.max_deceleration_on_cancel", max_decel),
     rclcpp::Parameter("constraints.joint3.max_deceleration_on_cancel", max_decel),


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Previously, `constraints.goal_time: 0.0` (the default) meant the controller could wait indefinitely for the goal to be reached. As a result, a goal that could never be reached would cause the action to hang forever.

This PR normalizes the `goal_time` semantics and changes the default to a finite value.

## Changes

- Default changed from `0.0` to `10.0` seconds.
- New semantics:
  - `goal_time < 0` → wait indefinitely (the old `0.0` behavior, now explicit).
  - `goal_time == 0` → no grace period; the goal must be reached on time.
  - `goal_time > 0` → wait for the specified grace period after the last trajectory point.
- The runtime check now uses `std::isfinite(...)` instead of `!= 0.0`, so negative values are handled correctly.
- Updated documentation (`userdoc`, `decelerate_on_cancel`, and the migration guide).
- Updated tests accordingly.

## Migration

Configurations relying on the old wait-forever default must now explicitly set:

```yaml
constraints:
  goal_time: -1.0  # wait indefinitely
```

**Note:** `cmd_timeout` only activates when `cmd_timeout > constraints.goal_time`. Therefore, `cmd_timeout` tests now explicitly set `goal_time` to a small positive value, e.g. `0.001`.


Fixes #2582

### Is this user-facing behavior change?

YES
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
NO
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
